### PR TITLE
fix: remove deprecated web_search_request from generated Codex configs

### DIFF
--- a/packages/docker-git/src/server/codex.ts
+++ b/packages/docker-git/src/server/codex.ts
@@ -79,7 +79,6 @@ web_search = "live"
 ${codexConfigLine}
 
 [features]
-web_search_request = true
 shell_snapshot = true
 collab = true
 apps = true
@@ -101,7 +100,6 @@ sandbox_mode = "danger-full-access"
 web_search = "live"
 
 [features]
-web_search_request = true
 shell_snapshot = true
 collab = true
 apps = true

--- a/packages/lib/src/core/templates-entrypoint/codex.ts
+++ b/packages/lib/src/core/templates-entrypoint/codex.ts
@@ -64,7 +64,6 @@ sandbox_mode = "danger-full-access"
 web_search = "live"
 
 [features]
-web_search_request = true
 shell_snapshot = true
 collab = true
 apps = true

--- a/packages/lib/src/usecases/auth-sync.ts
+++ b/packages/lib/src/usecases/auth-sync.ts
@@ -29,7 +29,6 @@ const defaultCodexConfig = [
   "web_search = \"live\"",
   "",
   "[features]",
-  "web_search_request = true",
   "shell_snapshot = true",
   "collab = true",
   "apps = true",


### PR DESCRIPTION
## Summary
- remove deprecated `web_search_request` from generated `config.toml` and `config.yml` content
- keep `web_search = "live"` as top-level setting
- update all docker-git-managed config templates so new/rewritten configs are warning-free

## Verification
- `pnpm -C packages/lib build`
- `pnpm -C packages/docker-git typecheck`
- `pnpm -C packages/docker-git test`
- `pnpm -C packages/lib test`

Closes #1