### PR TITLE
fix: auto-configure git credentials after gh auth

### DIFF
--- a/packages/docker-git/tests/core/templates.test.ts
+++ b/packages/docker-git/tests/core/templates.test.ts
@@ -39,11 +39,15 @@ describe("planFiles", () => {
       const dockerfileSpec = specs.find(
         (spec) => spec._tag === "File" && spec.relativePath === "Dockerfile"
       )
+      const entrypointSpec = specs.find(
+        (spec) => spec._tag === "File" && spec.relativePath === "entrypoint.sh"
+      )
 
       expect(composeSpec !== undefined && composeSpec._tag === "File").toBe(true)
       expect(ignoreSpec !== undefined && ignoreSpec._tag === "File").toBe(true)
       expect(configSpec !== undefined && configSpec._tag === "File").toBe(true)
       expect(dockerfileSpec !== undefined && dockerfileSpec._tag === "File").toBe(true)
+      expect(entrypointSpec !== undefined && entrypointSpec._tag === "File").toBe(true)
 
       if (configSpec && configSpec._tag === "File") {
         expect(configSpec.contents).toContain(config.repoUrl)
@@ -60,6 +64,11 @@ describe("planFiles", () => {
         expect(dockerfileSpec.contents).toContain("AUTO_MENU")
         expect(dockerfileSpec.contents).toContain("ncurses-term")
         expect(dockerfileSpec.contents).toContain("tag-order builtins commands")
+      }
+
+      if (entrypointSpec && entrypointSpec._tag === "File") {
+        expect(entrypointSpec.contents).toContain("gh auth setup-git --hostname github.com --force")
+        expect(entrypointSpec.contents).toContain("GIT_USER_EMAIL=\"${GH_ID}+${GH_LOGIN}@users.noreply.github.com\"")
       }
     }))
 

--- a/packages/lib/src/core/templates-entrypoint/git.ts
+++ b/packages/lib/src/core/templates-entrypoint/git.ts
@@ -12,6 +12,22 @@ if [[ -n "$GH_TOKEN" ]]; then
   fi
   chmod 600 "$SSH_ENV_PATH"
   chown 1000:1000 "$SSH_ENV_PATH" || true
+
+  SAFE_GH_TOKEN="$(printf "%q" "$GH_TOKEN")"
+  # Keep git+https auth in sync with gh auth so push/pull works without manual setup.
+  su - ${config.sshUser} -c "GH_TOKEN=$SAFE_GH_TOKEN gh auth setup-git --hostname github.com --force" || true
+
+  GH_LOGIN="$(su - ${config.sshUser} -c "GH_TOKEN=$SAFE_GH_TOKEN gh api user --jq .login" 2>/dev/null || true)"
+  GH_ID="$(su - ${config.sshUser} -c "GH_TOKEN=$SAFE_GH_TOKEN gh api user --jq .id" 2>/dev/null || true)"
+  GH_LOGIN="$(printf "%s" "$GH_LOGIN" | tr -d '\r\n')"
+  GH_ID="$(printf "%s" "$GH_ID" | tr -d '\r\n')"
+
+  if [[ -z "$GIT_USER_NAME" && -n "$GH_LOGIN" ]]; then
+    GIT_USER_NAME="$GH_LOGIN"
+  fi
+  if [[ -z "$GIT_USER_EMAIL" && -n "$GH_LOGIN" && -n "$GH_ID" ]]; then
+    GIT_USER_EMAIL="${"${"}GH_ID}+${"${"}GH_LOGIN}@users.noreply.github.com"
+  fi
 fi
 
 # 3) Configure git identity for the dev user if provided


### PR DESCRIPTION
## Summary
- run `gh auth setup-git --hostname github.com --force` in generated entrypoint when `GH_TOKEN` is present
- derive git identity fallback (`user.name`, `user.email`) from authenticated GitHub account when env identity is not set
- add regression assertions in template tests for the new gh->git wiring

## Verification
- `pnpm --filter @effect-template/docker-git test`
- `pnpm check`
- `pnpm test`

Fixes #14