### PR TITLE
fix(release): publish only @prover-coder-ai/docker-git

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -9,7 +9,7 @@
   "commit": false,
   "fixed": [],
   "linked": [],
-  "access": "restricted",
+  "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
   "ignore": []

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -47,6 +47,9 @@
   "bugs": {
     "url": "https://github.com/ProverCoderAI/docker-git/issues"
   },
+  "publishConfig": {
+    "access": "public"
+  },
   "homepage": "https://github.com/ProverCoderAI/docker-git#readme",
   "packageManager": "pnpm@10.28.0",
   "dependencies": {

--- a/packages/docker-git/package.json
+++ b/packages/docker-git/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@effect-template/docker-git",
   "version": "0.1.0",
+  "private": true,
   "description": "docker-git orchestrator (CLI + server)",
   "main": "dist/src/server/main.js",
   "type": "module",

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@effect-template/lib",
   "version": "1.0.0",
+  "private": true,
   "description": "Shared business logic (docker-git orchestrator core)",
   "main": "dist/index.js",
   "directories": {


### PR DESCRIPTION
## Problem
Release job was trying to publish additional workspace packages (`@effect-template/lib`, `@effect-template/docker-git`) instead of only the CLI package.

## Changes
- mark `packages/lib` as `private: true`
- mark `packages/docker-git` as `private: true`
- set Changesets access to `public`
- set `packages/app` publish access to `public`

## Validation
- `pnpm check`
- `pnpm -C packages/lib typecheck`
- `pnpm -C packages/docker-git typecheck`
- `pnpm changeset publish` in local no-auth env now attempts to publish only `@prover-coder-ai/docker-git` (then fails with ENEEDAUTH as expected)