### PR TITLE
fix(ci): run check workflow for app and lib

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -32,9 +32,10 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: pnpm check
-      - name: Types (lib)
-        run: pnpm --filter @effect-template/lib typecheck
+      - name: Typecheck (app)
+        run: pnpm --filter ./packages/app check
+      - name: Typecheck (lib)
+        run: pnpm --filter ./packages/lib typecheck
 
   lint:
     name: Lint
@@ -50,9 +51,10 @@ jobs:
       # See: https://github.com/ton-ai-core/vibecode-linter/issues (pending issue)
       - name: Install global linter dependencies
         run: npm install -g typescript @biomejs/biome
-      - run: pnpm lint
+      - name: Lint (app)
+        run: pnpm --filter ./packages/app lint
       - name: Lint (lib)
-        run: pnpm --filter @effect-template/lib lint
+        run: pnpm --filter ./packages/lib lint
 
   test:
     name: Test
@@ -65,9 +67,10 @@ jobs:
       # vibecode-linter uses npx internally for dependency checks (lint:tests runs first)
       - name: Install global linter dependencies
         run: npm install -g typescript @biomejs/biome
-      - run: pnpm test
+      - name: Test (app)
+        run: pnpm --filter ./packages/app test
       - name: Test (lib)
-        run: pnpm --filter @effect-template/lib test
+        run: pnpm --filter ./packages/lib test
 
   lint-effect:
     name: Lint Effect-TS
@@ -77,6 +80,7 @@ jobs:
       - uses: actions/checkout@v6
       - name: Install dependencies
         uses: ./.github/actions/setup
-      - run: pnpm lint:effect
+      - name: Lint Effect-TS (app)
+        run: pnpm --filter ./packages/app lint:effect
       - name: Lint Effect-TS (lib)
-        run: pnpm --filter @effect-template/lib lint:effect
+        run: pnpm --filter ./packages/lib lint:effect

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   ],
   "scripts": {
     "build": "pnpm --filter ./packages/app build",
-    "check": "pnpm --filter ./packages/app check",
+    "check": "pnpm --filter ./packages/app check && pnpm --filter ./packages/lib typecheck",
     "changeset": "changeset",
     "changeset-publish": "node -e \"if (!process.env.NPM_TOKEN) { console.log('Skipping publish: NPM_TOKEN is not set'); process.exit(0); }\" && changeset publish",
     "changeset-version": "changeset version",
@@ -17,11 +17,11 @@
     "docker-git": "pnpm --filter ./packages/app build:docker-git && node packages/app/dist/src/docker-git/main.js",
     "list": "pnpm --filter ./packages/app build && node packages/app/dist/main.js list",
     "dev": "pnpm --filter ./packages/app dev",
-    "lint": "pnpm --filter ./packages/app lint",
+    "lint": "pnpm --filter ./packages/app lint && pnpm --filter ./packages/lib lint",
     "lint:tests": "pnpm --filter ./packages/app lint:tests",
-    "lint:effect": "pnpm --filter ./packages/app lint:effect",
-    "test": "pnpm --filter ./packages/app test",
-    "typecheck": "pnpm --filter ./packages/app typecheck",
+    "lint:effect": "pnpm --filter ./packages/app lint:effect && pnpm --filter ./packages/lib lint:effect",
+    "test": "pnpm --filter ./packages/app test && pnpm --filter ./packages/lib test",
+    "typecheck": "pnpm --filter ./packages/app typecheck && pnpm --filter ./packages/lib typecheck",
     "start": "pnpm --filter ./packages/app start"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- make check workflow run explicit app and lib steps for typecheck/lint/lint:effect/test
- use package-path filters (`./packages/app`, `./packages/lib`) instead of implicit root scripts
- update root validation scripts so local `pnpm check|lint|lint:effect|test|typecheck` validates both packages

## Validation
- pnpm install
- pnpm check
- pnpm typecheck
- pnpm lint
- pnpm lint:effect
- pnpm test

Closes #21