### PR TITLE
feat: add optional Nix container flavor for docker-git projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ pnpm run docker-git clone https://github.com/agiens/crm/issues/123 --force-env
 
 # Same, but also enable Playwright MCP + Chromium sidecar for Codex
 pnpm run docker-git clone https://github.com/agiens/crm/tree/vova-fork --force --mcp-playwright
+
+# Experimental: generate project with Nix-based container flavor
+pnpm run docker-git clone https://github.com/agiens/crm/tree/vova-fork --force --nix
 ```
 
 ## Parallel Issues / PRs
@@ -45,6 +48,16 @@ Force modes:
 Agent context for issue workspaces:
 - Global `${CODEX_HOME}/AGENTS.md` includes workspace path + issue/PR context.
 - For `issue-*` workspaces, docker-git creates `${TARGET_DIR}/AGENTS.md` (if missing) with issue context and auto-adds it to `.git/info/exclude`.
+
+## Container Base Flavor (Ubuntu/Nix)
+
+By default, generated projects use an Ubuntu-based Dockerfile (`--base-flavor ubuntu`).
+
+For migration experiments you can switch to Nix-based container setup:
+- `--base-flavor nix`
+- or shorthand `--nix`
+
+This keeps the same docker-git workflow (SSH, compose, entrypoint logic), but installs toolchain packages via `nix profile install` instead of `apt`.
 
 ## Projects Root Layout
 

--- a/packages/app/src/docker-git/cli/parser-options.ts
+++ b/packages/app/src/docker-git/cli/parser-options.ts
@@ -22,6 +22,7 @@ interface ValueOptionSpec {
     | "codexHome"
     | "archivePath"
     | "scrapMode"
+    | "baseFlavor"
     | "label"
     | "token"
     | "scopes"
@@ -50,6 +51,7 @@ const valueOptionSpecs: ReadonlyArray<ValueOptionSpec> = [
   { flag: "--codex-home", key: "codexHome" },
   { flag: "--archive", key: "archivePath" },
   { flag: "--mode", key: "scrapMode" },
+  { flag: "--base-flavor", key: "baseFlavor" },
   { flag: "--label", key: "label" },
   { flag: "--token", key: "token" },
   { flag: "--scopes", key: "scopes" },
@@ -73,6 +75,8 @@ const booleanFlagUpdaters: Readonly<Record<string, (raw: RawOptions) => RawOptio
   "--no-ssh": (raw) => ({ ...raw, openSsh: false }),
   "--force": (raw) => ({ ...raw, force: true }),
   "--force-env": (raw) => ({ ...raw, forceEnv: true }),
+  "--nix": (raw) => ({ ...raw, baseFlavor: "nix" }),
+  "--ubuntu": (raw) => ({ ...raw, baseFlavor: "ubuntu" }),
   "--mcp-playwright": (raw) => ({ ...raw, enableMcpPlaywright: true }),
   "--no-mcp-playwright": (raw) => ({ ...raw, enableMcpPlaywright: false }),
   "--wipe": (raw) => ({ ...raw, wipe: true }),
@@ -98,6 +102,7 @@ const valueFlagUpdaters: { readonly [K in ValueKey]: (raw: RawOptions, value: st
   codexHome: (raw, value) => ({ ...raw, codexHome: value }),
   archivePath: (raw, value) => ({ ...raw, archivePath: value }),
   scrapMode: (raw, value) => ({ ...raw, scrapMode: value }),
+  baseFlavor: (raw, value) => ({ ...raw, baseFlavor: value }),
   label: (raw, value) => ({ ...raw, label: value }),
   token: (raw, value) => ({ ...raw, token: value }),
   scopes: (raw, value) => ({ ...raw, scopes: value }),

--- a/packages/app/src/docker-git/cli/usage.ts
+++ b/packages/app/src/docker-git/cli/usage.ts
@@ -46,6 +46,8 @@ Options:
   --env-project <path>      Host path to project env file (default: ./.orch/env/project.env)
   --codex-auth <path>       Host path for Codex auth cache (default: <projectsRoot>/.orch/auth/codex)
   --codex-home <path>       Container path for Codex auth (default: /home/dev/.codex)
+  --base-flavor <flavor>    Container base/toolchain flavor: ubuntu|nix (default: ubuntu)
+  --nix | --ubuntu          Shorthand for --base-flavor nix|ubuntu
   --out-dir <path>          Output directory (default: <projectsRoot>/<org>/<repo>[/issue-<id>|/pr-<id>])
   --project-dir <path>      Project directory for attach (default: .)
   --archive <path>          Scrap snapshot directory (default: .orch/scrap/session)

--- a/packages/app/src/docker-git/menu-create-helpers.ts
+++ b/packages/app/src/docker-git/menu-create-helpers.ts
@@ -1,0 +1,147 @@
+import { deriveRepoPathParts, resolveRepoInput } from "@effect-template/lib/core/domain"
+import { defaultProjectsRoot } from "@effect-template/lib/usecases/menu-helpers"
+
+import type { CreateInputs } from "./menu-types.js"
+
+export const buildCreateArgs = (input: CreateInputs): ReadonlyArray<string> => {
+  const args: Array<string> = [
+    "create",
+    "--repo-url",
+    input.repoUrl,
+    "--secrets-root",
+    input.secretsRoot,
+    "--base-flavor",
+    input.baseFlavor
+  ]
+  if (input.repoRef.length > 0) {
+    args.push("--repo-ref", input.repoRef)
+  }
+  args.push("--out-dir", input.outDir)
+  if (!input.runUp) {
+    args.push("--no-up")
+  }
+  if (input.enableMcpPlaywright) {
+    args.push("--mcp-playwright")
+  }
+  if (input.force) {
+    args.push("--force")
+  }
+  if (input.forceEnv) {
+    args.push("--force-env")
+  }
+  return args
+}
+
+const trimLeftSlash = (value: string): string => {
+  let start = 0
+  while (start < value.length && value[start] === "/") {
+    start += 1
+  }
+  return value.slice(start)
+}
+
+const trimRightSlash = (value: string): string => {
+  let end = value.length
+  while (end > 0 && value[end - 1] === "/") {
+    end -= 1
+  }
+  return value.slice(0, end)
+}
+
+const joinPath = (...parts: ReadonlyArray<string>): string => {
+  const cleaned = parts
+    .filter((part) => part.length > 0)
+    .map((part, index) => {
+      if (index === 0) {
+        return trimRightSlash(part)
+      }
+      return trimRightSlash(trimLeftSlash(part))
+    })
+  return cleaned.join("/")
+}
+
+export const resolveDefaultOutDir = (cwd: string, repoUrl: string): string => {
+  const resolvedRepo = resolveRepoInput(repoUrl)
+  const baseParts = deriveRepoPathParts(resolvedRepo.repoUrl).pathParts
+  const projectParts = resolvedRepo.workspaceSuffix ? [...baseParts, resolvedRepo.workspaceSuffix] : baseParts
+  return joinPath(defaultProjectsRoot(cwd), ...projectParts)
+}
+
+const resolveRepoRef = (
+  repoUrl: string,
+  values: Partial<CreateInputs>
+): string => {
+  if (values.repoRef !== undefined) {
+    return values.repoRef
+  }
+  if (repoUrl.length === 0) {
+    return "main"
+  }
+  return resolveRepoInput(repoUrl).repoRef ?? "main"
+}
+
+const resolveSecretsRoot = (
+  cwd: string,
+  values: Partial<CreateInputs>
+): string => values.secretsRoot ?? joinPath(defaultProjectsRoot(cwd), "secrets")
+
+const resolveOutDir = (
+  cwd: string,
+  repoUrl: string,
+  values: Partial<CreateInputs>
+): string => {
+  if (values.outDir !== undefined) {
+    return values.outDir
+  }
+  if (repoUrl.length === 0) {
+    return ""
+  }
+  return resolveDefaultOutDir(cwd, repoUrl)
+}
+
+export const resolveCreateInputs = (
+  cwd: string,
+  values: Partial<CreateInputs>
+): CreateInputs => {
+  const repoUrl = values.repoUrl ?? ""
+  const repoRef = resolveRepoRef(repoUrl, values)
+  const secretsRoot = resolveSecretsRoot(cwd, values)
+  const outDir = resolveOutDir(cwd, repoUrl, values)
+
+  return {
+    repoUrl,
+    repoRef,
+    outDir,
+    secretsRoot,
+    baseFlavor: values.baseFlavor ?? "ubuntu",
+    runUp: values.runUp !== false,
+    enableMcpPlaywright: values.enableMcpPlaywright === true,
+    force: values.force === true,
+    forceEnv: values.forceEnv === true
+  }
+}
+
+export const parseYesDefault = (input: string, fallback: boolean): boolean => {
+  const normalized = input.trim().toLowerCase()
+  if (normalized === "y" || normalized === "yes") {
+    return true
+  }
+  if (normalized === "n" || normalized === "no") {
+    return false
+  }
+  return fallback
+}
+
+export const parseBaseFlavorDefault = (
+  input: string,
+  fallback: CreateInputs["baseFlavor"]
+): CreateInputs["baseFlavor"] => {
+  const normalized = input.trim().toLowerCase()
+  if (normalized === "nix") {
+    return "nix"
+  }
+  if (normalized === "ubuntu") {
+    return "ubuntu"
+  }
+  return fallback
+}

--- a/packages/app/src/docker-git/menu-create.ts
+++ b/packages/app/src/docker-git/menu-create.ts
@@ -1,11 +1,17 @@
-import { type CreateCommand, deriveRepoPathParts, resolveRepoInput } from "@effect-template/lib/core/domain"
+import { type CreateCommand } from "@effect-template/lib/core/domain"
 import { createProject } from "@effect-template/lib/usecases/actions"
 import type { AppError } from "@effect-template/lib/usecases/errors"
-import { defaultProjectsRoot } from "@effect-template/lib/usecases/menu-helpers"
 import * as Path from "@effect/platform/Path"
 import { Effect, Either, Match, pipe } from "effect"
 import { parseArgs } from "./cli/parser.js"
 import { formatParseError, usageText } from "./cli/usage.js"
+import {
+  buildCreateArgs,
+  parseBaseFlavorDefault,
+  parseYesDefault,
+  resolveCreateInputs,
+  resolveDefaultOutDir
+} from "./menu-create-helpers.js"
 
 import { resetToMenu } from "./menu-shared.js"
 import {
@@ -42,117 +48,6 @@ type CreateContext = {
 
 type CreateReturnContext = CreateContext & {
   readonly view: Extract<ViewState, { readonly _tag: "Create" }>
-}
-
-export const buildCreateArgs = (input: CreateInputs): ReadonlyArray<string> => {
-  const args: Array<string> = [
-    "create",
-    "--repo-url",
-    input.repoUrl,
-    "--secrets-root",
-    input.secretsRoot,
-    "--base-flavor",
-    input.baseFlavor
-  ]
-  if (input.repoRef.length > 0) {
-    args.push("--repo-ref", input.repoRef)
-  }
-  args.push("--out-dir", input.outDir)
-  if (!input.runUp) {
-    args.push("--no-up")
-  }
-  if (input.enableMcpPlaywright) {
-    args.push("--mcp-playwright")
-  }
-  if (input.force) {
-    args.push("--force")
-  }
-  if (input.forceEnv) {
-    args.push("--force-env")
-  }
-  return args
-}
-
-const trimLeftSlash = (value: string): string => {
-  let start = 0
-  while (start < value.length && value[start] === "/") {
-    start += 1
-  }
-  return value.slice(start)
-}
-
-const trimRightSlash = (value: string): string => {
-  let end = value.length
-  while (end > 0 && value[end - 1] === "/") {
-    end -= 1
-  }
-  return value.slice(0, end)
-}
-
-const joinPath = (...parts: ReadonlyArray<string>): string => {
-  const cleaned = parts
-    .filter((part) => part.length > 0)
-    .map((part, index) => {
-      if (index === 0) {
-        return trimRightSlash(part)
-      }
-      return trimRightSlash(trimLeftSlash(part))
-    })
-  return cleaned.join("/")
-}
-
-const resolveDefaultOutDir = (cwd: string, repoUrl: string): string => {
-  const resolvedRepo = resolveRepoInput(repoUrl)
-  const baseParts = deriveRepoPathParts(resolvedRepo.repoUrl).pathParts
-  const projectParts = resolvedRepo.workspaceSuffix ? [...baseParts, resolvedRepo.workspaceSuffix] : baseParts
-  return joinPath(defaultProjectsRoot(cwd), ...projectParts)
-}
-
-export const resolveCreateInputs = (
-  cwd: string,
-  values: Partial<CreateInputs>
-): CreateInputs => {
-  const repoUrl = values.repoUrl ?? ""
-  const resolvedRepoRef = repoUrl.length > 0 ? resolveRepoInput(repoUrl).repoRef : undefined
-  const secretsRoot = values.secretsRoot ?? joinPath(defaultProjectsRoot(cwd), "secrets")
-  const outDir = values.outDir ?? (repoUrl.length > 0 ? resolveDefaultOutDir(cwd, repoUrl) : "")
-
-  return {
-    repoUrl,
-    repoRef: values.repoRef ?? resolvedRepoRef ?? "main",
-    outDir,
-    secretsRoot,
-    baseFlavor: values.baseFlavor ?? "ubuntu",
-    runUp: values.runUp !== false,
-    enableMcpPlaywright: values.enableMcpPlaywright === true,
-    force: values.force === true,
-    forceEnv: values.forceEnv === true
-  }
-}
-
-const parseYesDefault = (input: string, fallback: boolean): boolean => {
-  const normalized = input.trim().toLowerCase()
-  if (normalized === "y" || normalized === "yes") {
-    return true
-  }
-  if (normalized === "n" || normalized === "no") {
-    return false
-  }
-  return fallback
-}
-
-const parseBaseFlavorDefault = (
-  input: string,
-  fallback: CreateInputs["baseFlavor"]
-): CreateInputs["baseFlavor"] => {
-  const normalized = input.trim().toLowerCase()
-  if (normalized === "nix") {
-    return "nix"
-  }
-  if (normalized === "ubuntu") {
-    return "ubuntu"
-  }
-  return fallback
 }
 
 const applyCreateCommand = (
@@ -348,3 +243,5 @@ export const handleCreateInput = (
     context.setView({ ...view, buffer: view.buffer + input })
   }
 }
+
+export { buildCreateArgs, resolveCreateInputs } from "./menu-create-helpers.js"

--- a/packages/app/src/docker-git/menu-render.ts
+++ b/packages/app/src/docker-git/menu-render.ts
@@ -29,6 +29,7 @@ export const renderStepLabel = (step: CreateStep, defaults: CreateInputs): strin
     Match.when("repoUrl", () => "Repo URL"),
     Match.when("repoRef", () => `Repo ref [${defaults.repoRef}]`),
     Match.when("outDir", () => `Output dir [${defaults.outDir}]`),
+    Match.when("baseFlavor", () => `Container base flavor [${defaults.baseFlavor}]`),
     Match.when("runUp", () => `Run docker compose up now? [${defaults.runUp ? "Y" : "n"}]`),
     Match.when(
       "mcpPlaywright",

--- a/packages/app/src/docker-git/menu-types.ts
+++ b/packages/app/src/docker-git/menu-types.ts
@@ -47,6 +47,7 @@ export type CreateInputs = {
   readonly repoRef: string
   readonly outDir: string
   readonly secretsRoot: string
+  readonly baseFlavor: "ubuntu" | "nix"
   readonly runUp: boolean
   readonly enableMcpPlaywright: boolean
   readonly force: boolean
@@ -57,6 +58,7 @@ export type CreateStep =
   | "repoUrl"
   | "repoRef"
   | "outDir"
+  | "baseFlavor"
   | "runUp"
   | "mcpPlaywright"
   | "force"
@@ -65,6 +67,7 @@ export const createSteps: ReadonlyArray<CreateStep> = [
   "repoUrl",
   "repoRef",
   "outDir",
+  "baseFlavor",
   "runUp",
   "mcpPlaywright",
   "force"

--- a/packages/lib/src/core/command-builders.ts
+++ b/packages/lib/src/core/command-builders.ts
@@ -30,6 +30,20 @@ const parsePort = (value: string): Either.Either<number, ParseError> => {
   return Either.right(parsed)
 }
 
+const parseBaseFlavor = (
+  value: string | undefined
+): Either.Either<"ubuntu" | "nix", ParseError> => {
+  const candidate = value?.trim() ?? defaultTemplateConfig.baseFlavor
+  if (candidate === "ubuntu" || candidate === "nix") {
+    return Either.right(candidate)
+  }
+  return Either.left({
+    _tag: "InvalidOption",
+    option: "--base-flavor",
+    reason: `expected one of: ubuntu, nix (got: ${candidate})`
+  })
+}
+
 export const nonEmpty = (
   option: string,
   value: string | undefined,
@@ -203,6 +217,7 @@ export const buildCreateCommand = (
     const openSsh = raw.openSsh ?? false
     const force = raw.force ?? false
     const forceEnv = raw.forceEnv ?? false
+    const baseFlavor = yield* _(parseBaseFlavor(raw.baseFlavor))
     const enableMcpPlaywright = raw.enableMcpPlaywright ?? false
 
     return {
@@ -229,6 +244,7 @@ export const buildCreateCommand = (
         codexAuthPath: paths.codexAuthPath,
         codexSharedAuthPath: paths.codexSharedAuthPath,
         codexHome: paths.codexHome,
+        baseFlavor,
         enableMcpPlaywright,
         pnpmVersion: defaultTemplateConfig.pnpmVersion
       }

--- a/packages/lib/src/core/command-options.ts
+++ b/packages/lib/src/core/command-options.ts
@@ -25,6 +25,7 @@ export interface RawOptions {
   readonly envProjectPath?: string
   readonly codexAuthPath?: string
   readonly codexHome?: string
+  readonly baseFlavor?: string
   readonly enableMcpPlaywright?: boolean
   readonly archivePath?: string
   readonly scrapMode?: string

--- a/packages/lib/src/core/domain.ts
+++ b/packages/lib/src/core/domain.ts
@@ -19,6 +19,7 @@ export interface TemplateConfig {
   readonly codexAuthPath: string
   readonly codexSharedAuthPath: string
   readonly codexHome: string
+  readonly baseFlavor: "ubuntu" | "nix"
   readonly enableMcpPlaywright: boolean
   readonly pnpmVersion: string
 }
@@ -227,7 +228,9 @@ export type Command =
   | StateCommand
   | AuthCommand
 
-export const defaultTemplateConfig = {
+type DefaultTemplateConfig = Omit<TemplateConfig, "repoUrl">
+
+export const defaultTemplateConfig: DefaultTemplateConfig = {
   containerName: "dev-ssh",
   serviceName: "dev",
   sshUser: "dev",
@@ -242,6 +245,7 @@ export const defaultTemplateConfig = {
   codexAuthPath: "./.docker-git/.orch/auth/codex",
   codexSharedAuthPath: "./.docker-git/.orch/auth/codex",
   codexHome: "/home/dev/.codex",
+  baseFlavor: "ubuntu",
   enableMcpPlaywright: false,
   pnpmVersion: "10.27.0"
 }

--- a/packages/lib/src/shell/config.ts
+++ b/packages/lib/src/shell/config.ts
@@ -34,6 +34,9 @@ const TemplateConfigSchema = Schema.Struct({
     default: () => defaultTemplateConfig.codexSharedAuthPath
   }),
   codexHome: Schema.String,
+  baseFlavor: Schema.optionalWith(Schema.Union(Schema.Literal("ubuntu"), Schema.Literal("nix")), {
+    default: () => defaultTemplateConfig.baseFlavor
+  }),
   enableMcpPlaywright: Schema.optionalWith(Schema.Boolean, {
     default: () => defaultTemplateConfig.enableMcpPlaywright
   }),


### PR DESCRIPTION
## Summary
This PR implements a safe migration path toward Nix-based containers without breaking current users.

- Adds `baseFlavor` to project template config (`ubuntu` | `nix`), default = `ubuntu`
- Adds CLI options:
  - `--base-flavor <ubuntu|nix>`
  - `--nix` / `--ubuntu` shorthand
- Adds TUI create-flow support for selecting base flavor
- Adds Nix Dockerfile rendering path (`nixos/nix` + `nix profile install ...`) while keeping existing Ubuntu path intact
- Keeps SSH/entrypoint behavior stable by preserving expected binary paths (`/usr/bin/zsh`, `/usr/sbin/sshd`)
- Adds schema fallback so old `docker-git.json` (without `baseFlavor`) still works
- Updates docs and tests

## Why this approach is practical
A hard switch to Nix for everyone is risky. This PR introduces a dual-mode system so teams can migrate project-by-project, compare stability/performance, and roll back instantly by switching flavor.

## Proof (tests)
### 1) Parser supports new flags
```bash
pnpm --filter ./packages/app exec vitest run tests/docker-git/parser.test.ts
# ✓ tests/docker-git/parser.test.ts (28 tests)
```

### 2) Template generation supports Nix flavor
```bash
pnpm --filter ./packages/docker-git test
# ✓ tests/core/templates.test.ts (includes Nix flavor assertions)
```

### 3) Type/lint checks for changed packages
```bash
pnpm --filter ./packages/lib typecheck
pnpm --filter ./packages/app typecheck
pnpm --filter ./packages/lib lint:effect
pnpm --filter ./packages/app lint:effect
pnpm --filter ./packages/docker-git lint
```

Closes #36
