### PR TITLE
feat(app): show project launch time and sort by last start

### DIFF
--- a/packages/app/src/docker-git/menu-actions.ts
+++ b/packages/app/src/docker-git/menu-actions.ts
@@ -13,7 +13,7 @@ import { runDockerComposeUpWithPortCheck } from "@effect-template/lib/usecases/p
 import { Effect, Match, pipe } from "effect"
 
 import { startCreateView } from "./menu-create.js"
-import { loadSelectView } from "./menu-select.js"
+import { loadSelectView } from "./menu-select-load.js"
 import { resumeTui, suspendTui } from "./menu-shared.js"
 import { type MenuEnv, type MenuRunner, type MenuState, type ViewState } from "./menu-types.js"
 

--- a/packages/app/src/docker-git/menu-select-load.ts
+++ b/packages/app/src/docker-git/menu-select-load.ts
@@ -1,0 +1,33 @@
+import type { ProjectItem } from "@effect-template/lib/usecases/projects"
+import { Effect, pipe } from "effect"
+
+import { loadRuntimeByProject } from "./menu-select-runtime.js"
+import { startSelectView } from "./menu-select.js"
+import type { MenuEnv, MenuViewContext } from "./menu-types.js"
+
+export const loadSelectView = <E>(
+  effect: Effect.Effect<ReadonlyArray<ProjectItem>, E, MenuEnv>,
+  purpose: "Connect" | "Down" | "Info" | "Delete",
+  context: Pick<MenuViewContext, "setView" | "setMessage">
+): Effect.Effect<void, E, MenuEnv> =>
+  pipe(
+    effect,
+    Effect.flatMap((items) =>
+      pipe(
+        loadRuntimeByProject(items),
+        Effect.flatMap((runtimeByProject) =>
+          Effect.sync(() => {
+            if (items.length === 0) {
+              context.setMessage(
+                purpose === "Down"
+                  ? "No running docker-git containers."
+                  : "No docker-git projects found."
+              )
+              return
+            }
+            startSelectView(items, purpose, context, runtimeByProject)
+          })
+        )
+      )
+    )
+  )

--- a/packages/app/src/docker-git/menu-select-order.ts
+++ b/packages/app/src/docker-git/menu-select-order.ts
@@ -1,0 +1,37 @@
+import type { ProjectItem } from "@effect-template/lib/usecases/projects"
+
+import type { SelectProjectRuntime } from "./menu-types.js"
+
+const defaultRuntime = (): SelectProjectRuntime => ({
+  running: false,
+  sshSessions: 0,
+  startedAtIso: null,
+  startedAtEpochMs: null
+})
+
+const runtimeForSort = (
+  runtimeByProject: Readonly<Record<string, SelectProjectRuntime>>,
+  item: ProjectItem
+): SelectProjectRuntime => runtimeByProject[item.projectDir] ?? defaultRuntime()
+
+const startedAtEpochForSort = (runtime: SelectProjectRuntime): number =>
+  runtime.startedAtEpochMs ?? Number.NEGATIVE_INFINITY
+
+export const sortItemsByLaunchTime = (
+  items: ReadonlyArray<ProjectItem>,
+  runtimeByProject: Readonly<Record<string, SelectProjectRuntime>>
+): ReadonlyArray<ProjectItem> =>
+  items.toSorted((left, right) => {
+    const leftRuntime = runtimeForSort(runtimeByProject, left)
+    const rightRuntime = runtimeForSort(runtimeByProject, right)
+    const leftStartedAt = startedAtEpochForSort(leftRuntime)
+    const rightStartedAt = startedAtEpochForSort(rightRuntime)
+
+    if (leftStartedAt !== rightStartedAt) {
+      return rightStartedAt - leftStartedAt
+    }
+    if (leftRuntime.running !== rightRuntime.running) {
+      return leftRuntime.running ? -1 : 1
+    }
+    return left.displayName.localeCompare(right.displayName)
+  })

--- a/packages/app/src/docker-git/menu-select-runtime.ts
+++ b/packages/app/src/docker-git/menu-select-runtime.ts
@@ -7,9 +7,20 @@ import type { MenuEnv, SelectProjectRuntime, ViewState } from "./menu-types.js"
 
 const emptyRuntimeByProject = (): Readonly<Record<string, SelectProjectRuntime>> => ({})
 
-const stoppedRuntime = (): SelectProjectRuntime => ({ running: false, sshSessions: 0 })
+const stoppedRuntime = (): SelectProjectRuntime => ({
+  running: false,
+  sshSessions: 0,
+  startedAtIso: null,
+  startedAtEpochMs: null
+})
 
 const countSshSessionsScript = "who -u 2>/dev/null | wc -l | tr -d '[:space:]'"
+const dockerZeroStartedAt = "0001-01-01T00:00:00Z"
+
+type ContainerStartTime = {
+  readonly startedAtIso: string
+  readonly startedAtEpochMs: number
+}
 
 const parseSshSessionCount = (raw: string): number => {
   const parsed = Number.parseInt(raw.trim(), 10)
@@ -17,6 +28,21 @@ const parseSshSessionCount = (raw: string): number => {
     return 0
   }
   return parsed
+}
+
+const parseContainerStartedAt = (raw: string): ContainerStartTime | null => {
+  const trimmed = raw.trim()
+  if (trimmed.length === 0 || trimmed === dockerZeroStartedAt) {
+    return null
+  }
+  const startedAtEpochMs = Date.parse(trimmed)
+  if (Number.isNaN(startedAtEpochMs)) {
+    return null
+  }
+  return {
+    startedAtIso: trimmed,
+    startedAtEpochMs
+  }
 }
 
 const toRuntimeMap = (
@@ -48,16 +74,35 @@ const countContainerSshSessions = (
     })
   )
 
+const inspectContainerStartedAt = (
+  containerName: string
+): Effect.Effect<ContainerStartTime | null, never, MenuEnv> =>
+  pipe(
+    runCommandCapture(
+      {
+        cwd: process.cwd(),
+        command: "docker",
+        args: ["inspect", "--format", "{{.State.StartedAt}}", containerName]
+      },
+      [0],
+      (exitCode) => ({ _tag: "CommandFailedError", command: "docker inspect .State.StartedAt", exitCode })
+    ),
+    Effect.match({
+      onFailure: () => null,
+      onSuccess: (raw) => parseContainerStartedAt(raw)
+    })
+  )
+
 // CHANGE: enrich select items with runtime state and SSH session counts
 // WHY: prevent stopping/deleting containers that are currently used via SSH
 // QUOTE(ТЗ): "писать скок SSH подключений к контейнеру сейчас"
 // REF: issue-47
 // SOURCE: n/a
-// FORMAT THEOREM: forall p: runtime(p) -> {running(p), ssh_sessions(p)}
+// FORMAT THEOREM: forall p: runtime(p) -> {running(p), ssh_sessions(p), started_at(p)}
 // PURITY: SHELL
 // EFFECT: Effect<Record<string, SelectProjectRuntime>, never, MenuEnv>
-// INVARIANT: stopped containers always have sshSessions = 0
-// COMPLEXITY: O(n + docker_ps + docker_exec)
+// INVARIANT: projects without a known container start have startedAt = null
+// COMPLEXITY: O(n + docker_ps + docker_exec + docker_inspect)
 export const loadRuntimeByProject = (
   items: ReadonlyArray<ProjectItem>
 ): Effect.Effect<Readonly<Record<string, SelectProjectRuntime>>, never, MenuEnv> =>
@@ -68,13 +113,17 @@ export const loadRuntimeByProject = (
         items,
         (item) => {
           const running = runningNames.includes(item.containerName)
-          if (!running) {
-            const entry: readonly [string, SelectProjectRuntime] = [item.projectDir, stoppedRuntime()]
-            return Effect.succeed(entry)
-          }
+          const sshSessionsEffect = running
+            ? countContainerSshSessions(item.containerName)
+            : Effect.succeed(0)
           return pipe(
-            countContainerSshSessions(item.containerName),
-            Effect.map((sshSessions): SelectProjectRuntime => ({ running: true, sshSessions })),
+            Effect.all([sshSessionsEffect, inspectContainerStartedAt(item.containerName)]),
+            Effect.map(([sshSessions, startedAt]): SelectProjectRuntime => ({
+              running,
+              sshSessions,
+              startedAtIso: startedAt?.startedAtIso ?? null,
+              startedAtEpochMs: startedAt?.startedAtEpochMs ?? null
+            })),
             Effect.map((runtime): readonly [string, SelectProjectRuntime] => [item.projectDir, runtime])
           )
         },

--- a/packages/app/src/docker-git/menu-types.ts
+++ b/packages/app/src/docker-git/menu-types.ts
@@ -86,6 +86,8 @@ export type ViewState =
 export type SelectProjectRuntime = {
   readonly running: boolean
   readonly sshSessions: number
+  readonly startedAtIso: string | null
+  readonly startedAtEpochMs: number | null
 }
 
 export const menuItems: ReadonlyArray<{ readonly id: MenuAction; readonly label: string }> = [

--- a/packages/app/tests/docker-git/menu-select-order.test.ts
+++ b/packages/app/tests/docker-git/menu-select-order.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "vitest"
+
+import { buildSelectLabels } from "../../src/docker-git/menu-render-select.js"
+import { sortItemsByLaunchTime } from "../../src/docker-git/menu-select-order.js"
+import type { SelectProjectRuntime } from "../../src/docker-git/menu-types.js"
+import { makeProjectItem } from "./fixtures/project-item.js"
+
+const makeRuntime = (
+  overrides: Partial<SelectProjectRuntime> = {}
+): SelectProjectRuntime => ({
+  running: false,
+  sshSessions: 0,
+  startedAtIso: null,
+  startedAtEpochMs: null,
+  ...overrides
+})
+
+const emitProof = (message: string): void => {
+  process.stdout.write(`[issue-57-proof] ${message}\n`)
+}
+
+describe("menu-select order", () => {
+  it("sorts projects by last container start time (newest first)", () => {
+    const newest = makeProjectItem({ projectDir: "/home/dev/.docker-git/newest", displayName: "org/newest" })
+    const older = makeProjectItem({ projectDir: "/home/dev/.docker-git/older", displayName: "org/older" })
+    const neverStarted = makeProjectItem({ projectDir: "/home/dev/.docker-git/never", displayName: "org/never" })
+    const startedNewest = "2026-02-17T11:30:00Z"
+    const startedOlder = "2026-02-16T07:15:00Z"
+    const runtimeByProject: Readonly<Record<string, SelectProjectRuntime>> = {
+      [newest.projectDir]: makeRuntime({
+        running: true,
+        sshSessions: 1,
+        startedAtIso: startedNewest,
+        startedAtEpochMs: Date.parse(startedNewest)
+      }),
+      [older.projectDir]: makeRuntime({
+        running: true,
+        sshSessions: 0,
+        startedAtIso: startedOlder,
+        startedAtEpochMs: Date.parse(startedOlder)
+      }),
+      [neverStarted.projectDir]: makeRuntime()
+    }
+
+    const sorted = sortItemsByLaunchTime([neverStarted, older, newest], runtimeByProject)
+    expect(sorted.map((item) => item.projectDir)).toEqual([
+      newest.projectDir,
+      older.projectDir,
+      neverStarted.projectDir
+    ])
+    emitProof("sorting by launch time works: newest container is selected first")
+  })
+
+  it("shows container launch timestamp in select labels", () => {
+    const item = makeProjectItem({ projectDir: "/home/dev/.docker-git/example", displayName: "org/example" })
+    const startedAtIso = "2026-02-17T09:45:00Z"
+    const runtimeByProject: Readonly<Record<string, SelectProjectRuntime>> = {
+      [item.projectDir]: makeRuntime({
+        running: true,
+        sshSessions: 2,
+        startedAtIso,
+        startedAtEpochMs: Date.parse(startedAtIso)
+      })
+    }
+
+    const connectLabel = buildSelectLabels([item], 0, "Connect", runtimeByProject)[0]
+    const downLabel = buildSelectLabels([item], 0, "Down", runtimeByProject)[0]
+
+    expect(connectLabel).toContain("[started=2026-02-17 09:45 UTC]")
+    expect(downLabel).toContain("running, ssh=2, started=2026-02-17 09:45 UTC")
+    emitProof("UI labels show container start timestamp in Connect and Down views")
+  })
+})


### PR DESCRIPTION
## Summary
- add runtime start timestamp (`StartedAt`) for each project container in Select view
- sort Select-project list by last container start time (newest first)
- show launch timestamp in both list labels and details panel
- add tests that verify sorting and timestamp rendering
- print explicit proof markers in test output for issue #57

Closes #57

## Proof
Command:
`pnpm -C /home/dev/provercoderai/docker-git/issue-57/packages/app test`

Evidence from test output:
- `[issue-57-proof] sorting by launch time works: newest container is selected first`
- `[issue-57-proof] UI labels show container start timestamp in Connect and Down views`

Result:
- `Test Files  6 passed (6)`
- `Tests  37 passed (37)`

## Validation
- `pnpm -C /home/dev/provercoderai/docker-git/issue-57/packages/app lint`
- `pnpm -C /home/dev/provercoderai/docker-git/issue-57/packages/app typecheck`
- `pnpm -C /home/dev/provercoderai/docker-git/issue-57/packages/app test`
