### PR TITLE
feat: add project list scrolling and compact prompt path

### DIFF
--- a/packages/app/src/docker-git/menu-render-select.ts
+++ b/packages/app/src/docker-git/menu-render-select.ts
@@ -97,6 +97,30 @@ export const buildSelectLabels = (
     return `${prefix} ${index + 1}. ${item.displayName} (${refLabel})${runtimeSuffix}`
   })
 
+export type SelectListWindow = {
+  readonly start: number
+  readonly end: number
+}
+
+export const buildSelectListWindow = (
+  total: number,
+  selected: number,
+  maxVisible: number
+): SelectListWindow => {
+  if (total <= 0) {
+    return { start: 0, end: 0 }
+  }
+  const visible = Math.max(1, maxVisible)
+  if (total <= visible) {
+    return { start: 0, end: total }
+  }
+  const boundedSelected = Math.min(Math.max(selected, 0), total - 1)
+  const half = Math.floor(visible / 2)
+  const maxStart = total - visible
+  const start = Math.min(Math.max(boundedSelected - half, 0), maxStart)
+  return { start, end: start + visible }
+}
+
 type SelectDetailsContext = {
   readonly item: ProjectItem
   readonly refLabel: string

--- a/packages/app/tests/docker-git/menu-select-order.test.ts
+++ b/packages/app/tests/docker-git/menu-select-order.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest"
 
-import { buildSelectLabels } from "../../src/docker-git/menu-render-select.js"
+import { buildSelectLabels, buildSelectListWindow } from "../../src/docker-git/menu-render-select.js"
 import { sortItemsByLaunchTime } from "../../src/docker-git/menu-select-order.js"
 import type { SelectProjectRuntime } from "../../src/docker-git/menu-types.js"
 import { makeProjectItem } from "./fixtures/project-item.js"
@@ -69,5 +69,16 @@ describe("menu-select order", () => {
     expect(connectLabel).toContain("[started=2026-02-17 09:45 UTC]")
     expect(downLabel).toContain("running, ssh=2, started=2026-02-17 09:45 UTC")
     emitProof("UI labels show container start timestamp in Connect and Down views")
+  })
+
+  it("keeps full list visible when projects fit into viewport", () => {
+    const window = buildSelectListWindow(8, 3, 12)
+    expect(window).toEqual({ start: 0, end: 8 })
+  })
+
+  it("computes a scrolling window around selected project", () => {
+    expect(buildSelectListWindow(30, 0, 10)).toEqual({ start: 0, end: 10 })
+    expect(buildSelectListWindow(30, 15, 10)).toEqual({ start: 10, end: 20 })
+    expect(buildSelectListWindow(30, 29, 10)).toEqual({ start: 20, end: 30 })
   })
 })

--- a/packages/docker-git/tests/core/templates.test.ts
+++ b/packages/docker-git/tests/core/templates.test.ts
@@ -78,6 +78,9 @@ describe("planFiles", () => {
         expect(entrypointSpec.contents).toContain(
           "push contains commit updating managed issue block in AGENTS.md"
         )
+        expect(entrypointSpec.contents).toContain("docker_git_short_pwd()")
+        expect(entrypointSpec.contents).toContain("local base=\"[\\t] $short_pwd\"")
+        expect(entrypointSpec.contents).toContain("local base=\"[%*] $short_pwd\"")
         expect(entrypointSpec.contents).toContain("CACHE_ROOT=\"/home/dev/.docker-git/.cache/git-mirrors\"")
         expect(entrypointSpec.contents).toContain("PACKAGE_CACHE_ROOT=\"/home/dev/.docker-git/.cache/packages\"")
         expect(entrypointSpec.contents).toContain("npm_config_store_dir")


### PR DESCRIPTION
## Summary
- add viewport-based scrolling window for project selection list in TUI
- show scroll hints when entries are hidden above/below
- shorten prompt path segments for bash and zsh (e.g. `~/d/n/@changesets`)
- add tests for list window calculation and prompt template output

Closes #66
Closes #58

## Verification
- pnpm --filter ./packages/app lint
- pnpm --filter ./packages/lib lint
- pnpm --filter ./packages/app exec vitest run tests/docker-git/menu-select-order.test.ts tests/docker-git/menu-select-connect.test.ts
- pnpm --filter ./packages/docker-git test -- tests/core/templates.test.ts