### PR TITLE
fix(app): publish only dist in npm package

### DIFF
--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -6,6 +6,9 @@
   "bin": {
     "docker-git": "dist/src/docker-git/main.js"
   },
+  "files": [
+    "dist"
+  ],
   "directories": {
     "doc": "doc"
   },


### PR DESCRIPTION
## Summary
- add `files` whitelist in `packages/app/package.json` so npm package includes only `dist`
- keep CLI entrypoint in published tarball via `dist/src/docker-git/main.js`
- harden `scripts/e2e/local-package-cli.sh` to fail if tarball includes unexpected files

## Verification
- `pnpm --filter ./packages/app typecheck`
- `bash scripts/e2e/local-package-cli.sh`
- manual check: `npm pack` now contains only `package.json` and `dist/**`

Closes #83