### PR TITLE
fix(ci): harden Bun install in Docker build steps

### DIFF
--- a/packages/lib/src/core/templates/dockerfile.ts
+++ b/packages/lib/src/core/templates/dockerfile.ts
@@ -34,7 +34,19 @@ const renderDockerfileBunPrelude = (config: TemplateConfig): string =>
   `# Tooling: pnpm + Codex CLI + oh-my-opencode (bun) + Claude Code CLI (npm)
 RUN corepack enable && corepack prepare pnpm@${config.pnpmVersion} --activate
 ENV TERM=xterm-256color
-RUN curl -fsSL https://bun.sh/install | BUN_INSTALL=/usr/local/bun bash
+RUN set -eu; \
+  for attempt in 1 2 3 4 5; do \
+    if curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://bun.sh/install -o /tmp/bun-install.sh \
+      && BUN_INSTALL=/usr/local/bun bash /tmp/bun-install.sh; then \
+      rm -f /tmp/bun-install.sh; \
+      exit 0; \
+    fi; \
+    echo "bun install attempt \${attempt} failed; retrying..." >&2; \
+    rm -f /tmp/bun-install.sh; \
+    sleep $((attempt * 2)); \
+  done; \
+  echo "bun install failed after retries" >&2; \
+  exit 1
 RUN ln -sf /usr/local/bun/bin/bun /usr/local/bin/bun
 RUN BUN_INSTALL=/usr/local/bun script -q -e -c "bun add -g @openai/codex@latest oh-my-opencode@latest" /dev/null
 RUN ln -sf /usr/local/bun/bin/codex /usr/local/bin/codex

--- a/packages/lib/tests/usecases/prepare-files.test.ts
+++ b/packages/lib/tests/usecases/prepare-files.test.ts
@@ -117,6 +117,10 @@ describe("prepareProjectFiles", () => {
         const composeBefore = yield* _(fs.readFileString(path.join(outDir, "docker-compose.yml")))
         expect(dockerfile).toContain("docker-compose-v2")
         expect(dockerfile).toContain("gitleaks version")
+        expect(dockerfile).toContain(
+          "curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://bun.sh/install -o /tmp/bun-install.sh"
+        )
+        expect(dockerfile).toContain("bun install attempt ${attempt} failed; retrying...")
         expect(entrypoint).toContain('DOCKER_GIT_HOME="/home/dev/.docker-git"')
         expect(entrypoint).toContain('SOURCE_SHARED_AUTH="/home/dev/.codex-shared/auth.json"')
         expect(entrypoint).toContain('CODEX_LABEL_RAW="$CODEX_AUTH_LABEL"')


### PR DESCRIPTION
## Summary
- make Bun installation resilient in generated project Dockerfiles by adding retry logic around `bun.sh/install`
- apply the same retry logic in the dedicated Codex auth image Dockerfile template
- add regression assertions in `prepare-files` tests to ensure retry flags/loop stay in generated Dockerfile

## Why
`Check` workflow run `22253904583`, job `64381928972` failed in `E2E (Login context)` because Bun installer download returned HTTP 502.

## Verification
- `pnpm --filter ./packages/lib typecheck`
- `pnpm --filter ./packages/lib test -- tests/usecases/prepare-files.test.ts`
- `bash scripts/e2e/login-context.sh` (local run completed successfully with the retry-enabled Bun install step)
