### PR TITLE
fix(app): make npm cli bin executable via shebang

### DIFF
--- a/packages/app/src/docker-git/main.ts
+++ b/packages/app/src/docker-git/main.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { NodeContext, NodeRuntime } from "@effect/platform-node"
 import { Effect } from "effect"
 

--- a/scripts/e2e/local-package-cli.sh
+++ b/scripts/e2e/local-package-cli.sh
@@ -10,7 +10,8 @@ ROOT="$(mktemp -d "$ROOT_BASE/local-package-cli.XXXXXX")"
 KEEP="${KEEP:-0}"
 
 PACK_LOG="$ROOT/npm-pack.log"
-HELP_LOG="$ROOT/docker-git-help.log"
+HELP_LOG_PNPM="$ROOT/docker-git-help-pnpm.log"
+HELP_LOG_NPM="$ROOT/docker-git-help-npm.log"
 TAR_LIST="$ROOT/tar-list.txt"
 PACKED_TARBALL=""
 
@@ -26,9 +27,13 @@ on_error() {
     echo "--- npm pack log ---" >&2
     cat "$PACK_LOG" >&2 || true
   fi
-  if [[ -f "$HELP_LOG" ]]; then
-    echo "--- docker-git --help log ---" >&2
-    cat "$HELP_LOG" >&2 || true
+  if [[ -f "$HELP_LOG_PNPM" ]]; then
+    echo "--- pnpm docker-git --help log ---" >&2
+    cat "$HELP_LOG_PNPM" >&2 || true
+  fi
+  if [[ -f "$HELP_LOG_NPM" ]]; then
+    echo "--- npm exec docker-git --help log ---" >&2
+    cat "$HELP_LOG_NPM" >&2 || true
   fi
 }
 
@@ -68,6 +73,12 @@ done <"$TAR_LIST"
 grep -Fxq "package/dist/src/docker-git/main.js" "$TAR_LIST" \
   || fail "packed tarball does not include dist/src/docker-git/main.js"
 
+main_entry_tmp="$ROOT/main-entry.js"
+tar -xOf "$PACKED_TARBALL" package/dist/src/docker-git/main.js >"$main_entry_tmp"
+main_first_line="$(head -n 1 "$main_entry_tmp" | tr -d '\r')"
+[[ "$main_first_line" == "#!/usr/bin/env node" ]] \
+  || fail "packed CLI entrypoint missing shebang: expected '#!/usr/bin/env node', got '$main_first_line'"
+
 dep_keys="$(tar -xOf "$PACKED_TARBALL" package/package.json | node -e 'let s="";process.stdin.on("data",(c)=>{s+=c});process.stdin.on("end",()=>{const pkg=JSON.parse(s);const deps=Object.keys(pkg.dependencies ?? {});if (deps.includes("@effect-template/lib")) {console.error("@effect-template/lib must not be a runtime dependency in packed package");process.exit(1)}process.stdout.write(deps.join(","));});')"
 [[ "$dep_keys" == *"effect"* ]] || fail "packed dependency set looks invalid: $dep_keys"
 
@@ -75,9 +86,18 @@ mkdir -p "$ROOT/project"
 cd "$ROOT/project"
 npm init -y >/dev/null
 pnpm add "$PACKED_TARBALL" --silent --lockfile=false
-pnpm docker-git --help >"$HELP_LOG" 2>&1
+pnpm docker-git --help >"$HELP_LOG_PNPM" 2>&1
 
-grep -Fq -- "docker-git clone <url> [options]" "$HELP_LOG" \
+grep -Fq -- "docker-git clone <url> [options]" "$HELP_LOG_PNPM" \
   || fail "expected docker-git help output from local packed package"
 
-echo "e2e/local-package-cli: local tarball install + pnpm docker-git --help OK" >&2
+mkdir -p "$ROOT/project-npm"
+cd "$ROOT/project-npm"
+npm init -y >/dev/null
+npm install "$PACKED_TARBALL" --silent --no-audit --fund=false
+npm exec -- docker-git --help >"$HELP_LOG_NPM" 2>&1
+
+grep -Fq -- "docker-git clone <url> [options]" "$HELP_LOG_NPM" \
+  || fail "expected docker-git help output via npm exec from local packed package"
+
+echo "e2e/local-package-cli: local tarball install + pnpm/npm CLI execution OK" >&2


### PR DESCRIPTION
## TDD proof (publisher vs consumer game)
We model release as a two-player game:
- Player A (publisher): chooses package layout and CLI entrypoint bytes.
- Player B (consumer): runs `docker-git` via package managers (`pnpm`, `npm`, `npx`).

A stable outcome requires both strategies to succeed on the same tarball.

### Red (failing test before fix)
`bash scripts/e2e/local-package-cli.sh` failed with:
- `packed CLI entrypoint missing shebang: expected '#!/usr/bin/env node'`
- and runtime symptom from npm users: `import: not found` when invoking `docker-git`.

### Green (fix)
- add shebang to CLI entrypoint source: `packages/app/src/docker-git/main.ts`
- extend release e2e test to verify:
  1. packed `dist/src/docker-git/main.js` starts with `#!/usr/bin/env node`
  2. local tarball works via `pnpm docker-git --help`
  3. local tarball works via `npm exec -- docker-git --help`

### Result
The same TDD test now passes end-to-end:
- `bash scripts/e2e/local-package-cli.sh` ✅

## Verification
- `pnpm --filter ./packages/app build:docker-git`
- `bash scripts/e2e/local-package-cli.sh`
- `pnpm --filter ./packages/app typecheck`
- `pnpm --filter ./packages/app test`
