### PR TITLE
fix(shell): drain stdout/stderr to prevent command hanging on large output

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-03-18T07:23:53.375Z for PR creation at branch issue-153-39dda3815f4e for issue https://github.com/ProverCoderAI/docker-git/issues/153


### PR DESCRIPTION
## Problem

`pnpm run docker-git clone <repo> --force --mcp-playwright` hangs indefinitely and never completes.

### Root Cause

In `packages/lib/src/shell/command-runner.ts`, both `runCommandExitCode` and `runCommandCapture` start child processes with `"pipe"` mode for stdout/stderr but do not drain those streams. The OS pipe buffer is typically ~64 KB. When a sub-command (e.g. `git push` or `git stash pop` during `autoSyncState` after a successful clone) writes more than that to stdout or stderr, the child process blocks waiting for the buffer to drain — and since nobody is reading it, it hangs forever.

## Fix

### `runCommandExitCode`
Rewrote from a simple `Effect.map(Command.exitCode(...), Number)` to an `Effect.scoped` block that:
1. Manually starts the process via `executor.start`
2. Forks daemon fibers to drain **both** `process.stdout` and `process.stderr` concurrently
3. Awaits `process.exitCode`

### `runCommandCapture`
Added `yield* _(Effect.forkDaemon(Stream.runDrain(process.stderr)))` before collecting stdout, so large stderr output no longer causes a deadlock.

## Mathematical Guarantees

### Invariants
- `∀ cmd: runCommandExitCode(cmd)` terminates iff `cmd` terminates (no buffer deadlock)
- `∀ cmd: runCommandCapture(cmd)` terminates iff `cmd` terminates

### Preconditions
- Command process started with `"pipe"` for stdout, stderr, stdin

### Postconditions
- `runCommandExitCode`: returns numeric exit code, stdout/stderr fully consumed
- `runCommandCapture`: returns decoded stdout string, stderr fully consumed, exit code validated

## Test plan
- [ ] Run `pnpm run docker-git clone <repo> --force --mcp-playwright` and verify it completes without hanging
- [ ] CI checks pass (Build, Types, Lint, Test, E2E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


Fixes ProverCoderAI/docker-git#153