### PR TITLE
Fix GitHub auth lint failures and harden CI setup

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -10,7 +10,7 @@ runs:
   using: composite
   steps:
     - name: Install pnpm
-      uses: pnpm/action-setup@v3
+      uses: pnpm/action-setup@v5
     - name: Install node
       uses: actions/setup-node@v6
       with:
@@ -18,4 +18,4 @@ runs:
         node-version: ${{ inputs.node-version }}
     - name: Install dependencies
       shell: bash
-      run: pnpm install
+      run: pnpm install --frozen-lockfile

--- a/packages/lib/src/usecases/auth-github.ts
+++ b/packages/lib/src/usecases/auth-github.ts
@@ -125,15 +125,27 @@ const renderGithubTokenStatusLine = (entry: GithubTokenStatusEntry): string =>
     Match.when("valid", () =>
       entry.login === null
         ? `- ${entry.label}: valid (owner unavailable)`
-        : `- ${entry.label}: valid (owner: ${entry.login})`
-    ),
+        : `- ${entry.label}: valid (owner: ${entry.login})`),
     Match.when("invalid", () => `- ${entry.label}: invalid`),
     Match.when("unknown", () => `- ${entry.label}: unknown (validation unavailable)`),
     Match.exhaustive
   )
 
 const renderGithubTokenStatusReport = (entries: ReadonlyArray<GithubTokenStatusEntry>): string =>
-  [`GitHub tokens (${entries.length}):`, ...entries.map(renderGithubTokenStatusLine)].join("\n")
+  [`GitHub tokens (${entries.length}):`, ...entries.map((entry) => renderGithubTokenStatusLine(entry))].join("\n")
+
+const validateGithubTokenEntry = (
+  entry: GithubTokenEntry
+): Effect.Effect<GithubTokenStatusEntry> =>
+  validateGithubToken(entry.token).pipe(
+    Effect.map((validation) => ({
+      key: entry.key,
+      label: entry.label,
+      token: entry.token,
+      status: validation.status,
+      login: validation.login
+    }))
+  )
 
 const resolveGithubTokenFromGh = (
   cwd: string,
@@ -291,19 +303,7 @@ export const authGithubStatus = (
         return
       }
 
-      const statuses = yield* _(
-        Effect.forEach(tokens, (entry) =>
-          validateGithubToken(entry.token).pipe(
-            Effect.map((validation) => ({
-              key: entry.key,
-              label: entry.label,
-              token: entry.token,
-              status: validation.status,
-              login: validation.login
-            }))
-          )
-        )
-      )
+      const statuses = yield* _(Effect.all(tokens.map((entry) => validateGithubTokenEntry(entry))))
 
       yield* _(Effect.log(renderGithubTokenStatusReport(statuses)))
     }))

--- a/packages/lib/src/usecases/github-token-validation.ts
+++ b/packages/lib/src/usecases/github-token-validation.ts
@@ -1,7 +1,7 @@
 import { FetchHttpClient, HttpClient } from "@effect/platform"
 import * as ParseResult from "@effect/schema/ParseResult"
 import * as Schema from "@effect/schema/Schema"
-import { Either, Effect } from "effect"
+import { Effect, Either } from "effect"
 
 const githubTokenValidationUrl = "https://api.github.com/user"
 
@@ -23,14 +23,15 @@ export type GithubTokenValidationResult = {
 const GithubUserSchema: Schema.Schema<GithubUser> = Schema.Struct({
   login: Schema.String
 })
+const GithubUserJsonSchema = Schema.parseJson(GithubUserSchema)
 
 const unknownGithubTokenValidationResult = (): GithubTokenValidationResult => ({
   status: "unknown",
   login: null
 })
 
-const decodeGithubUserLogin = (input: unknown): string | null =>
-  Either.match(ParseResult.decodeUnknownEither(GithubUserSchema)(input), {
+const decodeGithubUserLogin = (input: string): string | null =>
+  Either.match(ParseResult.decodeUnknownEither(GithubUserJsonSchema)(input), {
     onLeft: () => null,
     onRight: (user) => user.login
   })
@@ -72,7 +73,7 @@ export const validateGithubToken = (token: string): Effect.Effect<GithubTokenVal
       } satisfies GithubTokenValidationResult
     }
 
-    const body = yield* _(response.json)
+    const body = yield* _(response.text)
     return {
       status,
       login: decodeGithubUserLogin(body)


### PR DESCRIPTION
## Summary
- replace the GitHub user decode path with `Schema.parseJson(...)` so token validation no longer uses a forbidden `unknown` boundary type
- refactor GitHub auth status aggregation to avoid callback-reference lint violations and reduce nested inline logic
- keep the status report behavior unchanged while making the lib lint step pass again
- update the shared GitHub Actions setup to use `pnpm/action-setup@v5`
- switch the shared dependency install step to `pnpm install --frozen-lockfile` so `Check` and dependency validation run with the same install mode

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm --filter ./packages/app check`
- `pnpm --filter ./packages/lib typecheck`
- `pnpm --filter ./packages/lib exec eslint src/usecases/auth-github.ts src/usecases/github-token-validation.ts --ext .ts`