### PR TITLE
fix(ci): restore checks and ssh clone e2e

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -25,6 +25,8 @@ jobs:
         uses: ./.github/actions/setup
       - name: Build (docker-git package)
         run: bun run --cwd packages/app build
+      - name: Build (api)
+        run: bun run --cwd packages/api build
 
   types:
     name: Types
@@ -38,6 +40,8 @@ jobs:
         run: bun run --cwd packages/app check
       - name: Typecheck (lib)
         run: bun run --cwd packages/lib typecheck
+      - name: Typecheck (api)
+        run: bun run --cwd packages/api typecheck
 
   lint:
     name: Lint
@@ -51,6 +55,8 @@ jobs:
         run: bun run --cwd packages/app lint
       - name: Lint (lib)
         run: bun run --cwd packages/lib lint
+      - name: Lint (api)
+        run: bun run --cwd packages/api lint
 
   test:
     name: Test
@@ -64,6 +70,8 @@ jobs:
         run: bun run --cwd packages/app test
       - name: Test (lib)
         run: bun run --cwd packages/lib test
+      - name: Test (api)
+        run: bun run --cwd packages/api test
 
   lint-effect:
     name: Lint Effect-TS
@@ -140,3 +148,16 @@ jobs:
         run: docker version && docker compose version
       - name: Runtime volumes + host SSH CLI
         run: bash scripts/e2e/runtime-volumes-ssh.sh
+
+  e2e-clone-auto-open-ssh:
+    name: E2E (Clone auto-open SSH)
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install dependencies
+        uses: ./.github/actions/setup
+      - name: Docker info
+        run: docker version && docker compose version
+      - name: Clone auto-open SSH
+        run: bash scripts/e2e/clone-auto-open-ssh.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,19 @@ jobs:
           README_BACKUP=""
           README_CREATED="false"
           BACKUP_PKG="${PKG_DIR}/.package.json.release.bak"
+          GROUP_COUNT=0
+
+          open_group() {
+            echo "::group::$1"
+            GROUP_COUNT=$((GROUP_COUNT + 1))
+          }
+
+          close_group() {
+            if [ "$GROUP_COUNT" -gt 0 ]; then
+              echo "::endgroup::"
+              GROUP_COUNT=$((GROUP_COUNT - 1))
+            fi
+          }
 
           cleanup() {
             if [ -f "$BACKUP_PKG" ]; then
@@ -53,32 +66,47 @@ jobs:
             elif [ "$README_CREATED" = "true" ] && [ -f "$README_DEST" ]; then
               rm -f "$README_DEST" || true
             fi
+            while [ "$GROUP_COUNT" -gt 0 ]; do
+              close_group
+            done
             rm -rf "$TMP_DIR"
           }
           trap cleanup EXIT
 
           mkdir -p "$LOCAL_PACK_DIR" "$REMOTE_PACK_DIR"
 
+          open_group "Resolve package metadata"
           if [ -n "${NPM_TOKEN:-}" ]; then
             printf '%s\n' "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > "$HOME/.npmrc"
           fi
 
           if ! LATEST_VERSION="$(npm view "${PKG_NAME}" version 2>/dev/null)"; then
+            close_group
             echo "Package ${PKG_NAME} not found on npm; proceeding with release."
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          echo "Package: ${PKG_NAME}"
+          echo "Latest npm version: ${LATEST_VERSION}"
+          close_group
 
-          REMOTE_TARBALL="$(npm pack "${PKG_NAME}@${LATEST_VERSION}" --silent --pack-destination "$REMOTE_PACK_DIR" | tail -n 1)"
+          open_group "Download remote package"
+          REMOTE_TARBALL="$(npm pack "${PKG_NAME}@${LATEST_VERSION}" --pack-destination "$REMOTE_PACK_DIR" | tail -n 1)"
           REMOTE_TAR_PATH="$REMOTE_PACK_DIR/$REMOTE_TARBALL"
+          echo "Remote tarball: ${REMOTE_TAR_PATH}"
           if [ ! -f "$REMOTE_TAR_PATH" ]; then
+            close_group
             echo "Unable to download ${PKG_NAME}@${LATEST_VERSION}; proceeding with release."
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          close_group
 
+          open_group "Build current package"
           bun run --cwd packages/app build
+          close_group
 
+          open_group "Prepare package README"
           if [ -f "$README_DEST" ]; then
             README_BACKUP="${TMP_DIR}/README.backup"
             cp "$README_DEST" "$README_BACKUP"
@@ -87,32 +115,42 @@ jobs:
           fi
           mkdir -p "$(dirname "$README_DEST")"
           cp README.md "$README_DEST"
+          close_group
 
+          open_group "Prune package manifest"
           cp "$PKG_PATH" "$BACKUP_PKG"
           bun x @prover-coder-ai/dist-deps-prune apply \
             --package "$PKG_PATH" \
             --prune-dev true \
-            --write \
-            --silent
+            --write
+          close_group
 
+          open_group "Pack current package"
           LOCAL_TAR_PATH="$(cd "$PKG_DIR" && bun pm pack --quiet --ignore-scripts --destination "$LOCAL_PACK_DIR" | tail -n 1 | tr -d '\r')"
+          echo "Local tarball: ${LOCAL_TAR_PATH}"
           if [ ! -f "$LOCAL_TAR_PATH" ]; then
+            close_group
             echo "Unable to pack local ${PKG_NAME}; proceeding with release."
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             exit 0
           fi
+          close_group
 
           LOCAL_DIR="${TMP_DIR}/local"
           REMOTE_DIR="${TMP_DIR}/remote"
           mkdir -p "$LOCAL_DIR" "$REMOTE_DIR"
 
+          open_group "Extract tarballs"
           tar -xzf "$LOCAL_TAR_PATH" -C "$LOCAL_DIR"
           tar -xzf "$REMOTE_TAR_PATH" -C "$REMOTE_DIR"
+          close_group
 
           LOCAL_PKG="${LOCAL_DIR}/package/package.json"
           REMOTE_PKG="${REMOTE_DIR}/package/package.json"
 
+          open_group "Normalize package metadata"
           if [ ! -f "$LOCAL_PKG" ] || [ ! -f "$REMOTE_PKG" ]; then
+            close_group
             echo "package.json missing in tarball; proceeding with release."
             echo "should_release=true" >> "$GITHUB_OUTPUT"
             exit 0
@@ -120,7 +158,9 @@ jobs:
 
           bun -e "const p=process.argv[1];const sort=(v)=>Array.isArray(v)?v.map(sort):v&&typeof v==='object'?Object.keys(v).sort().reduce((acc,k)=>{acc[k]=sort(v[k]);return acc;},{}):v;const pkg=JSON.parse(await Bun.file(p).text());delete pkg.gitHead;pkg.version='0.0.0';const norm=sort(pkg);await Bun.write(p, JSON.stringify(norm, null, 2)+'\n');" "$LOCAL_PKG"
           bun -e "const p=process.argv[1];const sort=(v)=>Array.isArray(v)?v.map(sort):v&&typeof v==='object'?Object.keys(v).sort().reduce((acc,k)=>{acc[k]=sort(v[k]);return acc;},{}):v;const pkg=JSON.parse(await Bun.file(p).text());delete pkg.gitHead;pkg.version='0.0.0';const norm=sort(pkg);await Bun.write(p, JSON.stringify(norm, null, 2)+'\n');" "$REMOTE_PKG"
+          close_group
 
+          open_group "Compare package contents"
           if diff -qr "$LOCAL_DIR/package" "$REMOTE_DIR/package" >/dev/null 2>&1; then
             echo "::notice::No changes compared to ${PKG_NAME}@${LATEST_VERSION}. Skipping release."
             echo "should_release=false" >> "$GITHUB_OUTPUT"
@@ -128,6 +168,7 @@ jobs:
             echo "Package differs from ${PKG_NAME}@${LATEST_VERSION}; proceeding with release."
             echo "should_release=true" >> "$GITHUB_OUTPUT"
           fi
+          close_group
       - name: Auto changeset (patch if no changeset exists)
         if: steps.compare_npm.outputs.should_release != 'false' && github.actor != 'github-actions[bot]'
         shell: bash

--- a/packages/app/src/docker-git/api-client-auth.ts
+++ b/packages/app/src/docker-git/api-client-auth.ts
@@ -1,0 +1,223 @@
+import * as FsPlatform from "@effect/platform/FileSystem"
+import * as PathPlatform from "@effect/platform/Path"
+import { Effect } from "effect"
+
+import { request, requestTextStream, requestVoid } from "./api-http.js"
+import { asObject, type JsonRequest, type JsonValue } from "./api-json.js"
+import type { ControllerRuntime } from "./controller.js"
+import type {
+  AuthCodexImportCommand,
+  AuthCodexLoginCommand,
+  AuthCodexLogoutCommand,
+  AuthCodexStatusCommand,
+  AuthGithubLoginCommand,
+  AuthGithubLogoutCommand,
+  AuthGithubStatusCommand
+} from "./frontend-lib/core/domain.js"
+import { resolvePathFromCwd } from "./frontend-lib/usecases/path-helpers.js"
+import type { ApiAuthRequiredError, ApiRequestError } from "./host-errors.js"
+
+type StreamMarkers = {
+  readonly success: string
+  readonly errorPrefix: string
+}
+
+const codexLoginMarkers: StreamMarkers = {
+  success: "__DOCKER_GIT_CODEX_LOGIN_STATUS__:ok",
+  errorPrefix: "__DOCKER_GIT_CODEX_LOGIN_STATUS__:error:"
+}
+
+const githubLoginMarkers: StreamMarkers = {
+  success: "__DOCKER_GIT_GITHUB_LOGIN_STATUS__:ok",
+  errorPrefix: "__DOCKER_GIT_GITHUB_LOGIN_STATUS__:error:"
+}
+
+const isMarkerLine = (line: string, markers: StreamMarkers): boolean =>
+  line.startsWith(markers.success) || line.startsWith(markers.errorPrefix)
+
+const visibleLines = (output: string, markers: StreamMarkers): ReadonlyArray<string> =>
+  output
+    .split(/\r?\n/u)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0 && !isMarkerLine(line, markers))
+
+const markerExitCode = (output: string, markers: StreamMarkers): string | null => {
+  const failureLine = output
+    .split(/\r?\n/u)
+    .find((line) => line.startsWith(markers.errorPrefix))
+
+  return failureLine === undefined
+    ? null
+    : failureLine.slice(markers.errorPrefix.length)
+}
+
+const makeVisibleChunkWriter = (markers: StreamMarkers) => {
+  let pending = ""
+  const flushVisiblePending = () => {
+    if (pending.length > 0 && !isMarkerLine(pending, markers)) {
+      process.stdout.write(pending)
+    }
+  }
+
+  const writeVisibleChunk = (chunk: string) => {
+    pending += chunk
+    const lines = pending.split("\n")
+    pending = lines.pop() ?? ""
+
+    for (const line of lines) {
+      if (!isMarkerLine(line, markers)) {
+        process.stdout.write(`${line}\n`)
+      }
+    }
+  }
+
+  return { flushVisiblePending, writeVisibleChunk }
+}
+
+const codexLoginFailureMessage = (output: string, exitCode: string | null): string => {
+  if (output.includes("429 Too Many Requests")) {
+    return "Codex device auth is rate-limited by OpenAI (429 Too Many Requests). Wait a few minutes and retry."
+  }
+
+  const detailedLine = visibleLines(output, codexLoginMarkers)
+    .findLast((line) => line.toLowerCase().includes("error"))
+  if (detailedLine !== undefined) {
+    return detailedLine
+  }
+
+  const lastLine = visibleLines(output, codexLoginMarkers).at(-1)
+  if (lastLine !== undefined) {
+    return lastLine
+  }
+
+  return exitCode === null
+    ? "Codex login stream ended without a completion marker."
+    : `Codex login failed (${exitCode}).`
+}
+
+const githubLoginFailureMessage = (output: string, exitCode: string | null): string => {
+  const detailedLine = visibleLines(output, githubLoginMarkers)
+    .findLast((line) => line.toLowerCase().includes("failed") || line.toLowerCase().includes("error"))
+  if (detailedLine !== undefined) {
+    return detailedLine
+  }
+
+  const lastLine = visibleLines(output, githubLoginMarkers).at(-1)
+  if (lastLine !== undefined) {
+    return lastLine
+  }
+
+  return exitCode === null
+    ? "GitHub login stream ended without a completion marker."
+    : `GitHub login failed (${exitCode}).`
+}
+
+const streamFailure = (
+  method: "POST",
+  path: string,
+  message: string
+): ApiRequestError => ({
+  _tag: "ApiRequestError",
+  method,
+  path,
+  message,
+  displayOnlyMessage: true
+})
+
+const requestMarkedAuthStream = (
+  path: string,
+  body: JsonRequest,
+  markers: StreamMarkers,
+  failureMessage: (output: string, exitCode: string | null) => string
+) =>
+  Effect.gen(function*(_) {
+    const writer = makeVisibleChunkWriter(markers)
+    const output = yield* _(requestTextStream("POST", path, body, writer.writeVisibleChunk))
+    writer.flushVisiblePending()
+
+    if (output.includes(markers.success)) {
+      return output
+    }
+
+    return yield* _(
+      Effect.fail<ApiRequestError>(
+        streamFailure("POST", path, failureMessage(output, markerExitCode(output, markers)))
+      )
+    )
+  })
+
+const githubLoginSuccessPayload = (statusPayload: JsonValue): JsonValue => {
+  const object = asObject(statusPayload)
+  return {
+    ok: true,
+    status: object === null ? statusPayload : (object["status"] ?? statusPayload)
+  }
+}
+
+const githubWebLogin = (
+  command: AuthGithubLoginCommand
+): Effect.Effect<JsonValue, ApiRequestError | ApiAuthRequiredError, ControllerRuntime> =>
+  requestMarkedAuthStream(
+    "/auth/github/login/stream",
+    {
+      label: command.label,
+      token: null,
+      scopes: command.scopes
+    },
+    githubLoginMarkers,
+    githubLoginFailureMessage
+  ).pipe(
+    Effect.flatMap(() => request("GET", "/auth/github/status")),
+    Effect.map((statusPayload) => githubLoginSuccessPayload(statusPayload))
+  )
+
+export const githubLogin = (
+  command: AuthGithubLoginCommand
+): Effect.Effect<JsonValue, ApiRequestError | ApiAuthRequiredError, ControllerRuntime> =>
+  command.token !== null && command.token.trim().length > 0
+    ? request("POST", "/auth/github/login", {
+      label: command.label,
+      token: command.token,
+      scopes: command.scopes
+    })
+    : githubWebLogin(command)
+
+export const githubStatus = (_command: AuthGithubStatusCommand) => request("GET", "/auth/github/status")
+
+export const githubLogout = (command: AuthGithubLogoutCommand) =>
+  requestVoid("POST", "/auth/github/logout", {
+    label: command.label
+  })
+
+export const codexLogin = (command: AuthCodexLoginCommand) =>
+  requestMarkedAuthStream(
+    "/auth/codex/login",
+    { label: command.label },
+    codexLoginMarkers,
+    codexLoginFailureMessage
+  ).pipe(Effect.asVoid)
+
+const readCodexAuthText = (command: AuthCodexImportCommand) =>
+  Effect.gen(function*(_) {
+    const fs = yield* _(FsPlatform.FileSystem)
+    const path = yield* _(PathPlatform.Path)
+    const resolvedCodexAuthDir = resolvePathFromCwd(path, process.cwd(), command.codexAuthPath)
+    const authFilePath = path.join(resolvedCodexAuthDir, "auth.json")
+    return yield* _(fs.readFileString(authFilePath))
+  })
+
+export const codexImport = (command: AuthCodexImportCommand) =>
+  Effect.gen(function*(_) {
+    const authText = yield* _(readCodexAuthText(command))
+    return yield* _(request("POST", "/auth/codex/import", { label: command.label, authText }))
+  })
+
+export const codexStatus = (command: AuthCodexStatusCommand) => {
+  const query = command.label === null ? "" : `?label=${encodeURIComponent(command.label)}`
+  return request("GET", `/auth/codex/status${query}`)
+}
+
+export const codexLogout = (command: AuthCodexLogoutCommand) =>
+  requestVoid("POST", "/auth/codex/logout", {
+    label: command.label
+  })

--- a/packages/app/src/docker-git/api-client-events.ts
+++ b/packages/app/src/docker-git/api-client-events.ts
@@ -1,0 +1,126 @@
+import { Duration, Effect, Ref, Schedule } from "effect"
+import * as Fiber from "effect/Fiber"
+
+import { request } from "./api-http.js"
+import { asArray, asObject, asString, type JsonValue } from "./api-json.js"
+import { formatProjectEventLine } from "./project-event-lines.js"
+
+const projectPath = (projectId: string, suffix = ""): string => `/projects/${encodeURIComponent(projectId)}${suffix}`
+const projectEventPollInterval = Duration.millis(250)
+
+type ProjectEvent = {
+  readonly seq: number
+  readonly type: string
+  readonly payload: JsonValue | undefined
+}
+
+type ProjectEventPollResponse = {
+  readonly cursor: number
+  readonly events: ReadonlyArray<ProjectEvent>
+}
+
+export type ProjectEventPolling = {
+  readonly cursorRef: Ref.Ref<number>
+  readonly fiber: Fiber.RuntimeFiber<number>
+  readonly projectId: string
+}
+
+const asNumber = (value: JsonValue | undefined): number | null =>
+  typeof value === "number" && Number.isFinite(value) ? value : null
+
+const decodeProjectEvent = (payload: JsonValue): ProjectEvent | null => {
+  const object = asObject(payload)
+  if (object === null) {
+    return null
+  }
+
+  const seq = asNumber(object["seq"])
+  const type = asString(object["type"])
+  if (seq === null || type === null) {
+    return null
+  }
+
+  return {
+    seq,
+    type,
+    payload: object["payload"]
+  }
+}
+
+const decodeProjectEventPollResponse = (payload: JsonValue): ProjectEventPollResponse | null => {
+  const object = asObject(payload)
+  if (object === null) {
+    return null
+  }
+
+  const cursor = asNumber(object["cursor"])
+  if (cursor === null) {
+    return null
+  }
+
+  return {
+    cursor,
+    events: asArray(object["events"])
+      .map((event) => decodeProjectEvent(event))
+      .filter((event): event is ProjectEvent => event !== null)
+  }
+}
+
+const writeProjectEventLines = (events: ReadonlyArray<ProjectEvent>) =>
+  Effect.sync(() => {
+    for (const event of events) {
+      const line = formatProjectEventLine(event)
+      if (line !== null) {
+        process.stdout.write(`${line}\n`)
+      }
+    }
+  })
+
+export const readProjectEventCursor = (projectId: string) =>
+  request("GET", projectPath(projectId, "/events-poll")).pipe(
+    Effect.map((payload) => decodeProjectEventPollResponse(payload)?.cursor ?? 0)
+  )
+
+const pollProjectEventsOnce = (
+  projectId: string,
+  cursorRef: Ref.Ref<number>
+) =>
+  Effect.gen(function*(_) {
+    const cursor = yield* _(Ref.get(cursorRef))
+    const payload = yield* _(request("GET", projectPath(projectId, `/events-poll?cursor=${cursor}`)))
+    const response = decodeProjectEventPollResponse(payload)
+    if (response === null) {
+      return
+    }
+
+    yield* _(Ref.set(cursorRef, response.cursor))
+    yield* _(writeProjectEventLines(response.events))
+  })
+
+export const startProjectEventPolling = (projectId: string, initialCursor: number) =>
+  Effect.gen(function*(_) {
+    const cursorRef = yield* _(Ref.make(initialCursor))
+    const fiber = yield* _(
+      pollProjectEventsOnce(projectId, cursorRef).pipe(
+        Effect.ignore,
+        Effect.repeat(
+          Schedule.addDelay(
+            Schedule.forever,
+            () => projectEventPollInterval
+          )
+        ),
+        Effect.fork
+      )
+    )
+
+    return { cursorRef, fiber, projectId } satisfies ProjectEventPolling
+  })
+
+export const stopProjectEventPolling = (polling: ProjectEventPolling) =>
+  Fiber.interrupt(polling.fiber).pipe(
+    Effect.zipRight(
+      pollProjectEventsOnce(polling.projectId, polling.cursorRef).pipe(
+        Effect.ignore
+      )
+    )
+  )

--- a/packages/app/src/docker-git/api-client-helpers.ts
+++ b/packages/app/src/docker-git/api-client-helpers.ts
@@ -12,6 +12,12 @@ import {
   resolvePathFromCwd
 } from "./frontend-lib/usecases/path-helpers.js"
 
+type ClientPathContext = {
+  readonly cwd: string
+  readonly fs: FileSystem.FileSystem
+  readonly path: Path.Path
+}
+
 export const readProjectOutput = (payload: JsonValue): string => {
   const object = asObject(payload)
   return asString(object?.["output"]) ?? ""
@@ -47,40 +53,49 @@ const normalizeAuthorizedKeysContents = (value: string): string | undefined => {
   return trimmed.length === 0 ? undefined : `${trimmed}\n`
 }
 
-const resolveManagedAuthorizedKeysContents = () =>
+const readClientPathContext = (): Effect.Effect<ClientPathContext, never, FileSystem.FileSystem | Path.Path> =>
   Effect.gen(function*(_) {
     const fs = yield* _(FileSystem.FileSystem)
     const path = yield* _(Path.Path)
-    const cwd = process.cwd()
-    const sshPrivateKey = yield* _(findSshPrivateKey(fs, path, cwd))
-    const matchingPublicKey = sshPrivateKey === null ? null : yield* _(findExistingPath(fs, `${sshPrivateKey}.pub`))
+    return {
+      cwd: process.cwd(),
+      fs,
+      path
+    }
+  })
+
+const resolveManagedAuthorizedKeysContents = () =>
+  Effect.gen(function*(_) {
+    const context = yield* _(readClientPathContext())
+    const sshPrivateKey = yield* _(findSshPrivateKey(context.fs, context.path, context.cwd))
+    const matchingPublicKey = sshPrivateKey === null
+      ? null
+      : yield* _(findExistingPath(context.fs, `${sshPrivateKey}.pub`))
     const source = matchingPublicKey === null
-      ? yield* _(findAuthorizedKeysSource(fs, path, cwd))
+      ? yield* _(findAuthorizedKeysSource(context.fs, context.path, context.cwd))
       : matchingPublicKey
 
     if (source === null) {
       return missingAuthorizedKeysContents()
     }
 
-    const contents = yield* _(fs.readFileString(source))
+    const contents = yield* _(context.fs.readFileString(source))
     return normalizeAuthorizedKeysContents(contents)
   })
 
 export const resolveCreateRequestPaths = (command: CreateCommand) =>
   Effect.gen(function*(_) {
-    const fs = yield* _(FileSystem.FileSystem)
-    const path = yield* _(Path.Path)
-    const cwd = process.cwd()
+    const context = yield* _(readClientPathContext())
     const authorizedKeysPath = command.config.authorizedKeysPath === defaultTemplateConfig.authorizedKeysPath
       ? command.config.authorizedKeysPath
-      : resolveClientCreatePath(path, cwd, command.config.authorizedKeysPath)
+      : resolveClientCreatePath(context.path, context.cwd, command.config.authorizedKeysPath)
     const authorizedKeysContents = authorizedKeysPath === defaultTemplateConfig.authorizedKeysPath
       ? yield* _(resolveManagedAuthorizedKeysContents())
       : yield* _(
-        fs.exists(authorizedKeysPath).pipe(
+        context.fs.exists(authorizedKeysPath).pipe(
           Effect.flatMap((exists) =>
             exists
-              ? fs.readFileString(authorizedKeysPath).pipe(
+              ? context.fs.readFileString(authorizedKeysPath).pipe(
                 Effect.map((contents) => normalizeAuthorizedKeysContents(contents))
               )
               : Effect.sync(missingAuthorizedKeysContents)

--- a/packages/app/src/docker-git/api-client.ts
+++ b/packages/app/src/docker-git/api-client.ts
@@ -1,31 +1,28 @@
-import * as FsPlatform from "@effect/platform/FileSystem"
-import * as PathPlatform from "@effect/platform/Path"
-import { Duration, Effect, Ref } from "effect"
-import * as Fiber from "effect/Fiber"
+import { Effect } from "effect"
 
 import { buildCreateProjectRequest } from "./api-client-create.js"
+import { readProjectEventCursor, startProjectEventPolling, stopProjectEventPolling } from "./api-client-events.js"
 import { readProjectOutput, resolveCreateRequestPaths } from "./api-client-helpers.js"
-import { request, requestTextStream, requestVoid } from "./api-http.js"
+import { request, requestVoid } from "./api-http.js"
 import { asArray, asObject, asString, type JsonValue } from "./api-json.js"
 import { decodeProjectDetails, decodeProjectSummary } from "./api-project-codec.js"
 import { decodeTerminalSession } from "./api-terminal-codec.js"
 import type {
-  AuthCodexImportCommand,
-  AuthCodexLoginCommand,
-  AuthCodexLogoutCommand,
-  AuthCodexStatusCommand,
-  AuthGithubLoginCommand,
-  AuthGithubLogoutCommand,
-  AuthGithubStatusCommand,
   CreateCommand,
   StateCommitCommand,
   StateInitCommand,
   StateSyncCommand
 } from "./frontend-lib/core/domain.js"
-import type { ControllerRuntime } from "./controller.js"
-import { resolvePathFromCwd } from "./frontend-lib/usecases/path-helpers.js"
-import type { ApiAuthRequiredError, ApiRequestError } from "./host-errors.js"
 
+export {
+  codexImport,
+  codexLogin,
+  codexLogout,
+  codexStatus,
+  githubLogin,
+  githubLogout,
+  githubStatus
+} from "./api-client-auth.js"
 export { type JsonObject, type JsonRequest, type JsonValue, renderJsonPayload } from "./api-json.js"
 export {
   type ApiProjectDetails,
@@ -37,206 +34,12 @@ export {
 export { type ApiTerminalSession } from "./api-terminal-codec.js"
 
 const projectPath = (projectId: string, suffix = ""): string => `/projects/${encodeURIComponent(projectId)}${suffix}`
-const codexLoginSuccessMarker = "__DOCKER_GIT_CODEX_LOGIN_STATUS__:ok"
-const codexLoginErrorMarkerPrefix = "__DOCKER_GIT_CODEX_LOGIN_STATUS__:error:"
-const githubLoginSuccessMarker = "__DOCKER_GIT_GITHUB_LOGIN_STATUS__:ok"
-const githubLoginErrorMarkerPrefix = "__DOCKER_GIT_GITHUB_LOGIN_STATUS__:error:"
-
-type ProjectEvent = {
-  readonly seq: number
-  readonly type: string
-  readonly payload: JsonValue | undefined
-}
-
-type ProjectEventPollResponse = {
-  readonly cursor: number
-  readonly events: ReadonlyArray<ProjectEvent>
-}
-
-const asNumber = (value: JsonValue | undefined): number | null =>
-  typeof value === "number" && Number.isFinite(value) ? value : null
-
-const readProjectEventPayloadField = (
-  payload: JsonValue | undefined,
-  key: string
-): string | null => {
-  const object = asObject(payload)
-  return object === null ? null : asString(object[key])
-}
-
-const formatProjectEventLine = (event: ProjectEvent): string | null => {
-  if (event.type === "project.deployment.status") {
-    const phase = readProjectEventPayloadField(event.payload, "phase")
-    const message = readProjectEventPayloadField(event.payload, "message")
-    if (message === null) {
-      return null
-    }
-    return phase === null ? message : `[${phase}] ${message}`
-  }
-
-  if (event.type === "project.deployment.log") {
-    return readProjectEventPayloadField(event.payload, "line")
-  }
-
-  if (event.type === "project.ssh.session") {
-    const phase = readProjectEventPayloadField(event.payload, "phase")
-    const sessionId = readProjectEventPayloadField(event.payload, "sessionId")
-    if (phase === null) {
-      return null
-    }
-    return sessionId === null ? `[ssh] ${phase}` : `[ssh] ${phase} (${sessionId})`
-  }
-
-  return null
-}
-
-const decodeProjectEvent = (payload: JsonValue): ProjectEvent | null => {
-  const object = asObject(payload)
-  if (object === null) {
-    return null
-  }
-
-  const seq = asNumber(object["seq"])
-  const type = asString(object["type"])
-  if (seq === null || type === null) {
-    return null
-  }
-
-  return {
-    seq,
-    type,
-    payload: object["payload"]
-  }
-}
-
-const decodeProjectEventPollResponse = (payload: JsonValue): ProjectEventPollResponse | null => {
-  const object = asObject(payload)
-  if (object === null) {
-    return null
-  }
-
-  const cursor = asNumber(object["cursor"])
-  if (cursor === null) {
-    return null
-  }
-
-  return {
-    cursor,
-    events: asArray(object["events"])
-      .map((event) => decodeProjectEvent(event))
-      .filter((event): event is ProjectEvent => event !== null)
-  }
-}
-
-const writeProjectEventLines = (events: ReadonlyArray<ProjectEvent>) =>
-  Effect.sync(() => {
-    for (const event of events) {
-      const line = formatProjectEventLine(event)
-      if (line !== null) {
-        process.stdout.write(`${line}\n`)
-      }
-    }
-  })
-
-const readProjectEventCursor = (projectId: string) =>
-  request("GET", projectPath(projectId, "/events-poll")).pipe(
-    Effect.map((payload) => decodeProjectEventPollResponse(payload)?.cursor ?? 0)
-  )
-
-const pollProjectEventsOnce = (
-  projectId: string,
-  cursorRef: Ref.Ref<number>
-) =>
-  Effect.gen(function*(_) {
-    const cursor = yield* _(Ref.get(cursorRef))
-    const payload = yield* _(request("GET", projectPath(projectId, `/events-poll?cursor=${cursor}`)))
-    const response = decodeProjectEventPollResponse(payload)
-    if (response === null) {
-      return
-    }
-
-    yield* _(Ref.set(cursorRef, response.cursor))
-    yield* _(writeProjectEventLines(response.events))
-  })
-
-const startProjectEventPolling = (projectId: string, initialCursor: number) =>
-  Effect.gen(function*(_) {
-    const cursorRef = yield* _(Ref.make(initialCursor))
-    const fiber = yield* _(
-      Effect.gen(function*(_) {
-        while (true) {
-          yield* _(
-            pollProjectEventsOnce(projectId, cursorRef).pipe(
-              Effect.catchAll(() => Effect.void)
-            )
-          )
-          yield* _(Effect.sleep(Duration.millis(250)))
-        }
-      }).pipe(Effect.fork)
-    )
-
-    return { cursorRef, fiber, projectId }
-  })
 
 const decodeProjectResponse = (payload: JsonValue) => {
   const object = asObject(payload)
   return object === null
     ? decodeProjectDetails(payload)
     : decodeProjectDetails(object["project"] ?? payload)
-}
-
-const codexLoginFailureMessage = (output: string, exitCode: string | null): string => {
-  if (output.includes("429 Too Many Requests")) {
-    return "Codex device auth is rate-limited by OpenAI (429 Too Many Requests). Wait a few minutes and retry."
-  }
-
-  const lines = output
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter((line) =>
-      line.length > 0 &&
-      !line.startsWith(codexLoginSuccessMarker) &&
-      !line.startsWith(codexLoginErrorMarkerPrefix)
-    )
-
-  const detailedLine = lines.findLast((line) => line.toLowerCase().includes("error"))
-  if (detailedLine !== undefined) {
-    return detailedLine
-  }
-
-  const lastLine = lines.at(-1)
-  if (lastLine !== undefined) {
-    return lastLine
-  }
-
-  return exitCode === null
-    ? "Codex login stream ended without a completion marker."
-    : `Codex login failed (${exitCode}).`
-}
-
-const githubLoginFailureMessage = (output: string, exitCode: string | null): string => {
-  const lines = output
-    .split(/\r?\n/u)
-    .map((line) => line.trim())
-    .filter((line) =>
-      line.length > 0 &&
-      !line.startsWith(githubLoginSuccessMarker) &&
-      !line.startsWith(githubLoginErrorMarkerPrefix)
-    )
-
-  const detailedLine = lines.findLast((line) => line.toLowerCase().includes("failed") || line.toLowerCase().includes("error"))
-  if (detailedLine !== undefined) {
-    return detailedLine
-  }
-
-  const lastLine = lines.at(-1)
-  if (lastLine !== undefined) {
-    return lastLine
-  }
-
-  return exitCode === null
-    ? "GitHub login stream ended without a completion marker."
-    : `GitHub login failed (${exitCode}).`
 }
 
 export const listProjects = () =>
@@ -269,7 +72,7 @@ const createProjectWithResolvedPaths = (
       ? null
       : yield* _(
         readProjectEventCursor(projectId).pipe(
-          Effect.catchAll(() => Effect.succeed(0))
+          Effect.orElseSucceed(() => 0)
         )
       )
     const eventPolling = projectId === null || initialCursor === null
@@ -280,13 +83,7 @@ const createProjectWithResolvedPaths = (
         Effect.ensuring(
           eventPolling === null
             ? Effect.void
-            : Fiber.interrupt(eventPolling.fiber).pipe(
-              Effect.zipRight(
-                pollProjectEventsOnce(eventPolling.projectId, eventPolling.cursorRef).pipe(
-                  Effect.catchAll(() => Effect.void)
-                )
-              )
-            )
+            : stopProjectEventPolling(eventPolling)
         )
       )
     )
@@ -384,166 +181,3 @@ export const pushState = () =>
   request("POST", "/state/push").pipe(
     Effect.map((payload) => readProjectOutput(payload))
   )
-
-export const githubLogin = (
-  command: AuthGithubLoginCommand
-): Effect.Effect<JsonValue, ApiRequestError | ApiAuthRequiredError, ControllerRuntime> =>
-  command.token !== null && command.token.trim().length > 0
-    ? request("POST", "/auth/github/login", {
-      label: command.label,
-      token: command.token,
-      scopes: command.scopes
-    })
-    : Effect.gen(function*(_) {
-      let pending = ""
-      const writeVisibleChunk = (chunk: string) => {
-        pending += chunk
-        const lines = pending.split("\n")
-        pending = lines.pop() ?? ""
-
-        for (const line of lines) {
-          if (line.startsWith(githubLoginSuccessMarker) || line.startsWith(githubLoginErrorMarkerPrefix)) {
-            continue
-          }
-          process.stdout.write(`${line}\n`)
-        }
-      }
-
-      const output = yield* _(
-        requestTextStream(
-          "POST",
-          "/auth/github/login/stream",
-          {
-            label: command.label,
-            token: null,
-            scopes: command.scopes
-          },
-          writeVisibleChunk
-        )
-      )
-
-      if (
-        pending.length > 0 &&
-        !pending.startsWith(githubLoginSuccessMarker) &&
-        !pending.startsWith(githubLoginErrorMarkerPrefix)
-      ) {
-        process.stdout.write(pending)
-      }
-
-      if (!output.includes(githubLoginSuccessMarker)) {
-        const failureLine = output
-          .split(/\r?\n/u)
-          .find((line) => line.startsWith(githubLoginErrorMarkerPrefix))
-
-        const exitCode = failureLine === undefined
-          ? null
-          : failureLine.slice(githubLoginErrorMarkerPrefix.length)
-        const failureMessage = githubLoginFailureMessage(output, exitCode)
-
-        return yield* _(
-          Effect.fail<ApiRequestError>({
-            _tag: "ApiRequestError",
-            method: "POST",
-            path: "/auth/github/login/stream",
-            message: failureMessage,
-            displayOnlyMessage: true
-          })
-        )
-      }
-
-      const statusPayload = yield* _(request("GET", "/auth/github/status"))
-      const object = asObject(statusPayload)
-      return {
-        ok: true,
-        status: object === null ? statusPayload : (object["status"] ?? statusPayload)
-      } satisfies JsonValue
-    })
-
-export const githubStatus = (_command: AuthGithubStatusCommand) => request("GET", "/auth/github/status")
-
-export const githubLogout = (command: AuthGithubLogoutCommand) =>
-  requestVoid("POST", "/auth/github/logout", {
-    label: command.label
-  })
-
-export const codexLogin = (command: AuthCodexLoginCommand) =>
-  Effect.gen(function*(_) {
-    let pending = ""
-    const writeVisibleChunk = (chunk: string) => {
-      pending += chunk
-      const lines = pending.split("\n")
-      pending = lines.pop() ?? ""
-
-      for (const line of lines) {
-        if (line.startsWith(codexLoginSuccessMarker) || line.startsWith(codexLoginErrorMarkerPrefix)) {
-          continue
-        }
-        process.stdout.write(`${line}\n`)
-      }
-    }
-
-    const output = yield* _(
-      requestTextStream(
-        "POST",
-        "/auth/codex/login",
-        { label: command.label },
-        writeVisibleChunk
-      )
-    )
-
-    if (
-      pending.length > 0 &&
-      !pending.startsWith(codexLoginSuccessMarker) &&
-      !pending.startsWith(codexLoginErrorMarkerPrefix)
-    ) {
-      process.stdout.write(pending)
-    }
-
-    if (output.includes(codexLoginSuccessMarker)) {
-      return
-    }
-
-    const failureLine = output
-      .split(/\r?\n/u)
-      .find((line) => line.startsWith(codexLoginErrorMarkerPrefix))
-
-    const exitCode = failureLine === undefined
-      ? null
-      : failureLine.slice(codexLoginErrorMarkerPrefix.length)
-    const failureMessage = codexLoginFailureMessage(output, exitCode)
-
-    return yield* _(
-      Effect.fail<ApiRequestError>({
-        _tag: "ApiRequestError",
-        method: "POST",
-        path: "/auth/codex/login",
-        message: failureMessage,
-        displayOnlyMessage: true
-      })
-    )
-  })
-
-const readCodexAuthText = (command: AuthCodexImportCommand) =>
-  Effect.gen(function*(_) {
-    const fs = yield* _(FsPlatform.FileSystem)
-    const path = yield* _(PathPlatform.Path)
-    const resolvedCodexAuthDir = resolvePathFromCwd(path, process.cwd(), command.codexAuthPath)
-    const authFilePath = path.join(resolvedCodexAuthDir, "auth.json")
-    return yield* _(fs.readFileString(authFilePath))
-  })
-
-export const codexImport = (command: AuthCodexImportCommand) =>
-  Effect.gen(function*(_) {
-    const authText = yield* _(readCodexAuthText(command))
-    return yield* _(request("POST", "/auth/codex/import", { label: command.label, authText }))
-  })
-
-export const codexStatus = (command: AuthCodexStatusCommand) => {
-  const query = command.label === null ? "" : `?label=${encodeURIComponent(command.label)}`
-  return request("GET", `/auth/codex/status${query}`)
-}
-
-export const codexLogout = (command: AuthCodexLogoutCommand) =>
-  requestVoid("POST", "/auth/codex/logout", {
-    label: command.label
-  })

--- a/packages/app/src/docker-git/cli/parser-clone.ts
+++ b/packages/app/src/docker-git/cli/parser-clone.ts
@@ -45,6 +45,6 @@ export const parseClone = (args: ReadonlyArray<string>): Either.Either<Command, 
       : withDefaults
     const openSsh = raw.openSsh ?? true
     const create = yield* _(buildCreateCommand(withRef))
-    return { ...create, waitForClone: false, openSsh }
+    return { ...create, waitForClone: true, openSsh }
   })
 }

--- a/packages/app/src/docker-git/controller-docker.ts
+++ b/packages/app/src/docker-git/controller-docker.ts
@@ -4,7 +4,11 @@ import * as FileSystem from "@effect/platform/FileSystem"
 import * as Path from "@effect/platform/Path"
 import { Effect } from "effect"
 
-import { runCommandCapture, runCommandExitCode, runCommandExitCodeStreaming } from "./frontend-lib/shell/command-runner.js"
+import {
+  runCommandCapture,
+  runCommandExitCode,
+  runCommandExitCodeStreaming
+} from "./frontend-lib/shell/command-runner.js"
 
 import { type DockerNetworkIps, parseDockerNetworkIps, uniqueStrings } from "./controller-reachability.js"
 import {

--- a/packages/app/src/docker-git/frontend-lib/shell/command-runner.ts
+++ b/packages/app/src/docker-git/frontend-lib/shell/command-runner.ts
@@ -96,7 +96,8 @@ const writeStreamText = (
     Stream.runForEach((chunk) =>
       Effect.sync(() => {
         write(chunk)
-      }))
+      })
+    )
   )
 
 const combineCommandOutput = (stdout: string, stderr: string): string =>

--- a/packages/app/src/docker-git/menu-render-select.ts
+++ b/packages/app/src/docker-git/menu-render-select.ts
@@ -39,6 +39,14 @@ export type SelectColumnWidths = {
   readonly listWidth: number
 }
 
+type RenderSelectDetailsInput = {
+  readonly connectEnableMcpPlaywright: boolean
+  readonly detailsWidth: number | null
+  readonly item: ProjectItem | undefined
+  readonly purpose: SelectPurpose
+  readonly runtimeByProject: Readonly<Record<string, SelectProjectRuntime>>
+}
+
 export const computeSelectColumnWidths = (labels: ReadonlyArray<string>): SelectColumnWidths => {
   const preferredListWidth = computeListWidth(labels)
   const columns = readStdoutColumns()
@@ -61,25 +69,23 @@ export const computeSelectColumnWidths = (labels: ReadonlyArray<string>): Select
 
 export const renderSelectDetails = (
   el: typeof React.createElement,
-  purpose: SelectPurpose,
-  item: ProjectItem | undefined,
-  runtimeByProject: Readonly<Record<string, SelectProjectRuntime>>,
-  connectEnableMcpPlaywright: boolean,
-  detailsWidth: number | null
+  input: RenderSelectDetailsInput
 ): ReadonlyArray<React.ReactElement> => {
-  const runtime = item === undefined
+  const runtime = input.item === undefined
     ? { running: false, sshSessions: 0, startedAtIso: null, startedAtEpochMs: null }
-    : (runtimeByProject[item.projectDir] ?? {
+    : (input.runtimeByProject[input.item.projectDir] ?? {
       running: false,
       sshSessions: 0,
       startedAtIso: null,
       startedAtEpochMs: null
     })
-  const details = buildSelectDetailsModel(purpose, item, runtime, connectEnableMcpPlaywright)
-  const widthProps = detailsWidth === null ? {} : { width: detailsWidth }
+  const details = buildSelectDetailsModel(input.purpose, input.item, runtime, input.connectEnableMcpPlaywright)
+  const widthProps = input.detailsWidth === null ? {} : { width: input.detailsWidth }
   return [
     el(Text, { fg: "cyan", bold: true, wrap: "truncate", ...widthProps }, details.title),
-    ...details.lines.map((line, index) => el(Text, { key: `${details.title}-${index}`, wrap: "wrap", ...widthProps }, line))
+    ...details.lines.map((line, index) =>
+      el(Text, { key: `${details.title}-${index}`, wrap: "wrap", ...widthProps }, line)
+    )
   ]
 }
 

--- a/packages/app/src/docker-git/menu-render.ts
+++ b/packages/app/src/docker-git/menu-render.ts
@@ -203,11 +203,13 @@ const renderSelectDetailsBox = (
 ): React.ReactElement => {
   const details = renderSelectDetails(
     el,
-    input.purpose,
-    input.items[input.selected],
-    input.runtimeByProject,
-    input.connectEnableMcpPlaywright,
-    input.detailsWidth
+    {
+      connectEnableMcpPlaywright: input.connectEnableMcpPlaywright,
+      detailsWidth: input.detailsWidth,
+      item: input.items[input.selected],
+      purpose: input.purpose,
+      runtimeByProject: input.runtimeByProject
+    }
   )
   return el(
     Box,

--- a/packages/app/src/docker-git/open-project-ssh.ts
+++ b/packages/app/src/docker-git/open-project-ssh.ts
@@ -1,11 +1,11 @@
-import * as FileSystem from "@effect/platform/FileSystem"
 import type { PlatformError } from "@effect/platform/Error"
+import * as FileSystem from "@effect/platform/FileSystem"
 import * as Path from "@effect/platform/Path"
 import { Duration, Effect } from "effect"
 
 import { createProjectTerminalSession } from "./api-client.js"
 import type { ApiTerminalSession } from "./api-terminal-codec.js"
-import { isRemoteDockerHost, type ControllerRuntime } from "./controller.js"
+import { type ControllerRuntime, isRemoteDockerHost } from "./controller.js"
 import { runCommandWithExitCodes } from "./frontend-lib/shell/command-runner.js"
 import { CommandFailedError } from "./frontend-lib/shell/errors.js"
 import { findSshPrivateKey } from "./frontend-lib/usecases/path-helpers.js"
@@ -50,7 +50,7 @@ export const openResolvedProjectSshEffect = (
   })
 
 export type OpenHostProjectSshDeps<E, R> = {
-  readonly writeHeader: (item: ProjectItem) => Effect.Effect<void, never>
+  readonly writeHeader: (item: ProjectItem) => Effect.Effect<void>
   readonly runCommand: (item: ProjectItem) => Effect.Effect<void, E, R>
 }
 
@@ -75,11 +75,11 @@ const resolveSshHost = (sshCommand: string): string | null => {
   }
 
   const atIndex = target.lastIndexOf("@")
-  return atIndex >= 0 ? target.slice(atIndex + 1) : null
+  return atIndex === -1 ? null : target.slice(atIndex + 1)
 }
 
 const resolveSshPort = (sshCommand: string, fallback: number): number => {
-  const match = sshCommand.match(sshPortPattern)
+  const match = sshPortPattern.exec(sshCommand)
   if (match === null) {
     return fallback
   }
@@ -171,8 +171,7 @@ const runProjectSshCommand = (
         ? Effect.sleep(Duration.seconds(1)).pipe(
           Effect.zipRight(runProjectSshCommand(launch, attempt + 1))
         )
-        : Effect.fail(error)
-    )
+        : Effect.fail(error))
   )
 
 export const openHostProjectSshEffect = <E, R>(

--- a/packages/app/src/docker-git/open-project.ts
+++ b/packages/app/src/docker-git/open-project.ts
@@ -15,12 +15,12 @@ export type DockerContainerRuntimeInfo = {
 }
 
 export {
-  openResolvedProjectSsh,
-  openResolvedProjectSshViaController,
-  openHostProjectSshEffect,
-  type OpenResolvedProjectSshDeps,
   type OpenHostProjectSshDeps,
-  openResolvedProjectSshEffect
+  openHostProjectSshEffect,
+  openResolvedProjectSsh,
+  type OpenResolvedProjectSshDeps,
+  openResolvedProjectSshEffect,
+  openResolvedProjectSshViaController
 } from "./open-project-ssh.js"
 
 type ResolveOpenProjectDeps<E, R> = {

--- a/packages/app/src/docker-git/project-event-lines.ts
+++ b/packages/app/src/docker-git/project-event-lines.ts
@@ -1,0 +1,48 @@
+import { asObject, asString, type JsonValue } from "./api-json.js"
+
+export type ProjectEventLineSource = {
+  readonly payload: JsonValue | undefined
+  readonly type: string
+}
+
+const readProjectEventPayloadField = (
+  payload: JsonValue | undefined,
+  key: string
+): string | null => {
+  const object = asObject(payload)
+  return object === null ? null : asString(object[key])
+}
+
+const formatProjectStatusLine = (payload: JsonValue | undefined): string | null => {
+  const phase = readProjectEventPayloadField(payload, "phase")
+  const message = readProjectEventPayloadField(payload, "message")
+  if (message === null) {
+    return null
+  }
+  return phase === null ? message : `[${phase}] ${message}`
+}
+
+const formatProjectSshLine = (payload: JsonValue | undefined): string | null => {
+  const phase = readProjectEventPayloadField(payload, "phase")
+  const sessionId = readProjectEventPayloadField(payload, "sessionId")
+  if (phase === null) {
+    return null
+  }
+  return sessionId === null ? `[ssh] ${phase}` : `[ssh] ${phase} (${sessionId})`
+}
+
+export const formatProjectEventLine = (event: ProjectEventLineSource): string | null => {
+  if (event.type === "project.deployment.status") {
+    return formatProjectStatusLine(event.payload)
+  }
+
+  if (event.type === "project.deployment.log") {
+    return readProjectEventPayloadField(event.payload, "line")
+  }
+
+  if (event.type === "project.ssh.session") {
+    return formatProjectSshLine(event.payload)
+  }
+
+  return null
+}

--- a/packages/app/src/ui/primitives-gridland.tsx
+++ b/packages/app/src/ui/primitives-gridland.tsx
@@ -50,7 +50,7 @@ const boxProps = ({ children, ...props }: UiBoxProps): GridlandBoxHostProps => (
   children
 })
 
-const textProps = ({ children, backgroundColor, wrap, ...props }: UiTextProps): GridlandTextHostProps => ({
+const textProps = ({ backgroundColor, children, wrap, ...props }: UiTextProps): GridlandTextHostProps => ({
   ...props,
   ...(backgroundColor === undefined ? {} : { bg: backgroundColor }),
   ...(wrap === "truncate" ? { truncate: true } : {}),
@@ -68,28 +68,29 @@ const textProps = ({ children, backgroundColor, wrap, ...props }: UiTextProps): 
 // EFFECT: n/a
 // INVARIANT: Gridland TUI primitives always return React elements with supported host tags
 // COMPLEXITY: O(1)
-export const createGridlandPrimitives = (_gridland: GridlandModule) => ({
-  Box: ({ children, ...props }: UiBoxProps): JSX.Element =>
-    React.createElement("box", {
-      ...boxProps({ ...props, children })
-    }),
-  Button: ({ label, onPress }: UiButtonProps): JSX.Element =>
-    React.createElement("text", {
-      children: `[${label}]`,
-      fg: "cyan",
-      onClick: onPress
-    }),
-  Text: ({ children, ...props }: UiTextProps): JSX.Element =>
-    React.createElement("text", {
-      ...textProps({ ...props, children })
-    }),
-  TextInput: (props: UiTextInputProps): JSX.Element =>
-    React.createElement("input", {
-      ...inputProps(props),
-      focused: props.autoFocus,
-      onChange: props.onChange,
-      onSubmit: () => {
-        props.onEnter?.(false)
-      }
-    })
-}) as const
+export const createGridlandPrimitives = (_gridland: GridlandModule) =>
+  ({
+    Box: ({ children, ...props }: UiBoxProps): JSX.Element =>
+      React.createElement("box", {
+        ...boxProps({ ...props, children })
+      }),
+    Button: ({ label, onPress }: UiButtonProps): JSX.Element =>
+      React.createElement("text", {
+        children: `[${label}]`,
+        fg: "cyan",
+        onClick: onPress
+      }),
+    Text: ({ children, ...props }: UiTextProps): JSX.Element =>
+      React.createElement("text", {
+        ...textProps({ ...props, children })
+      }),
+    TextInput: (props: UiTextInputProps): JSX.Element =>
+      React.createElement("input", {
+        ...inputProps(props),
+        focused: props.autoFocus,
+        onChange: props.onChange,
+        onSubmit: () => {
+          props.onEnter?.(false)
+        }
+      })
+  }) as const

--- a/packages/app/src/web/project-events.ts
+++ b/packages/app/src/web/project-events.ts
@@ -1,7 +1,6 @@
 import { Effect } from "effect"
 
-import { asObject, asString } from "../docker-git/api-json.js"
-import type { JsonValue } from "../docker-git/api-json.js"
+import { formatProjectEventLine } from "../docker-git/project-event-lines.js"
 import type { ApiEvent } from "./api.js"
 import { loadProjectEvents } from "./api.js"
 
@@ -12,53 +11,6 @@ type EventStreamControls = {
 type EventStreamHandlers = {
   readonly onLine: (line: string) => void
   readonly onRateLimit: () => void
-}
-
-const readPayloadString = (
-  payload: JsonValue | undefined,
-  key: string
-): string | null => {
-  const object = asObject(payload)
-  if (object === null) {
-    return null
-  }
-  return asString(object[key])
-}
-
-const formatStatusLine = (payload: JsonValue | undefined): string | null => {
-  const phase = readPayloadString(payload, "phase")
-  const message = readPayloadString(payload, "message")
-  if (message === null) {
-    return null
-  }
-  return phase === null ? message : `[${phase}] ${message}`
-}
-
-const formatLogLine = (payload: JsonValue | undefined): string | null => readPayloadString(payload, "line")
-
-const formatSshLine = (payload: JsonValue | undefined): string | null => {
-  const phase = readPayloadString(payload, "phase")
-  const sessionId = readPayloadString(payload, "sessionId")
-  if (phase === null) {
-    return null
-  }
-  if (sessionId === null) {
-    return `[ssh] ${phase}`
-  }
-  return `[ssh] ${phase} (${sessionId})`
-}
-
-const formatEventLine = (event: ApiEvent): string | null => {
-  if (event.type === "project.deployment.status") {
-    return formatStatusLine(event.payload)
-  }
-  if (event.type === "project.deployment.log") {
-    return formatLogLine(event.payload)
-  }
-  if (event.type === "project.ssh.session") {
-    return formatSshLine(event.payload)
-  }
-  return null
 }
 
 type PollState = {
@@ -113,7 +65,7 @@ const handlePollSuccess = (
   }
   state.cursor = response.cursor
   for (const event of response.events) {
-    const line = formatEventLine(event)
+    const line = formatProjectEventLine(event)
     if (line !== null) {
       onLine(line)
     }

--- a/packages/app/tests/docker-git/open-project-ssh.test.ts
+++ b/packages/app/tests/docker-git/open-project-ssh.test.ts
@@ -4,10 +4,7 @@ import { Effect } from "effect"
 
 import type { ApiTerminalSession } from "../../src/docker-git/api-terminal-codec.js"
 import type { HostError } from "../../src/docker-git/host-errors.js"
-import {
-  openHostProjectSshEffect,
-  openResolvedProjectSshEffect
-} from "../../src/docker-git/open-project.js"
+import { openHostProjectSshEffect, openResolvedProjectSshEffect } from "../../src/docker-git/open-project.js"
 import { makeProjectItem } from "./fixtures/project-item.js"
 
 const makeSession = (): ApiTerminalSession => ({
@@ -85,7 +82,7 @@ const captureOpenResolvedProjectSshEvents = (
 
 const captureOpenHostProjectSshEvents = (
   item: ReturnType<typeof makeProjectItem>
-): Effect.Effect<ReadonlyArray<string>, never> =>
+): Effect.Effect<ReadonlyArray<string>> =>
   Effect.gen(function*(_) {
     const events: Array<string> = []
     yield* _(

--- a/scripts/e2e/clone-auto-open-ssh.sh
+++ b/scripts/e2e/clone-auto-open-ssh.sh
@@ -1,0 +1,264 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RUN_ID="$(date +%s)-$RANDOM"
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+source "$REPO_ROOT/scripts/e2e/_lib.sh"
+ROOT_BASE="${DOCKER_GIT_E2E_ROOT_BASE:-$REPO_ROOT/.docker-git/e2e-root}"
+mkdir -p "$ROOT_BASE"
+ROOT="$(mktemp -d "$ROOT_BASE/clone-auto-open-ssh.XXXXXX")"
+chmod 0777 "$ROOT"
+mkdir -p "$ROOT/e2e"
+chmod 0777 "$ROOT/e2e"
+KEEP="${KEEP:-0}"
+
+E2E_BIN="$ROOT/.e2e-bin"
+mkdir -p "$E2E_BIN"
+dg_ensure_docker "$E2E_BIN"
+dg_prepare_docker_git_cli "$REPO_ROOT" "$E2E_BIN"
+
+export DOCKER_GIT_PROJECTS_ROOT="$ROOT"
+export DOCKER_GIT_STATE_AUTO_SYNC=0
+
+REPO_URL="https://github.com/octocat/Hello-World/issues/1"
+TARGET_DIR="/home/dev/workspaces/octocat/hello-world/issue-1"
+OUT_DIR_REL=".docker-git/e2e/clone-auto-open-ssh-$RUN_ID"
+OUT_DIR="$ROOT/e2e/clone-auto-open-ssh-$RUN_ID"
+CONTAINER_NAME="dg-e2e-clone-auto-ssh-$RUN_ID"
+SERVICE_NAME="dg-e2e-clone-auto-ssh-$RUN_ID"
+VOLUME_NAME="dg-e2e-clone-auto-ssh-$RUN_ID-home"
+SSH_PORT="$(( (RANDOM % 1000) + 24000 ))"
+SSH_KEY="$ROOT/dev_ssh_key"
+SSH_PUB_KEY="$ROOT/dev_ssh_key.pub"
+CLONE_LOG="$ROOT/clone-auto-open-ssh.log"
+SSH_INVOCATION_LOG="$ROOT/ssh-invocation.log"
+SSH_SESSION_LOG="$ROOT/ssh-session.log"
+RUN_SCRIPT="$ROOT/run-clone-auto-open-ssh.sh"
+CLONE_AUTO_OPEN_TIMEOUT="${DOCKER_GIT_E2E_CLONE_AUTO_OPEN_TIMEOUT:-300s}"
+FAILURE_DUMPED=0
+
+fail() {
+  echo "e2e/clone-auto-open-ssh: $*" >&2
+  if [[ "$FAILURE_DUMPED" == "0" ]]; then
+    on_error "fail"
+  fi
+  exit 1
+}
+
+on_error() {
+  local line="$1"
+  if [[ "$FAILURE_DUMPED" == "1" ]]; then
+    return
+  fi
+  FAILURE_DUMPED=1
+  echo "e2e/clone-auto-open-ssh: failed at line $line" >&2
+  docker ps -a --format 'table {{.Names}}\t{{.Status}}\t{{.Ports}}' | head -n 80 || true
+  if docker ps -a --format '{{.Names}}' | grep -qx "$CONTAINER_NAME" 2>/dev/null; then
+    docker inspect "$CONTAINER_NAME" || true
+    docker logs "$CONTAINER_NAME" --tail 200 || true
+  fi
+  if [[ -f "$CLONE_LOG" ]]; then
+    echo "--- clone log ---" >&2
+    cat "$CLONE_LOG" >&2 || true
+  fi
+  if [[ -f "$SSH_INVOCATION_LOG" ]]; then
+    echo "--- ssh invocation log ---" >&2
+    cat "$SSH_INVOCATION_LOG" >&2 || true
+  fi
+  if [[ -f "$SSH_SESSION_LOG" ]]; then
+    echo "--- ssh session log ---" >&2
+    cat "$SSH_SESSION_LOG" >&2 || true
+  fi
+  if [[ -d "$OUT_DIR" ]] && [[ -f "$OUT_DIR/docker-compose.yml" ]]; then
+    (cd "$OUT_DIR" && docker compose ps) || true
+    (cd "$OUT_DIR" && docker compose logs --no-color --tail 200) || true
+  fi
+}
+
+cleanup() {
+  if [[ "$KEEP" == "1" ]]; then
+    echo "e2e/clone-auto-open-ssh: KEEP=1 set; preserving temp dir: $ROOT" >&2
+    echo "e2e/clone-auto-open-ssh: container name: $CONTAINER_NAME" >&2
+    echo "e2e/clone-auto-open-ssh: out dir: $OUT_DIR" >&2
+    return
+  fi
+  if [[ -d "$OUT_DIR" ]] && [[ -f "$OUT_DIR/docker-compose.yml" ]]; then
+    (cd "$OUT_DIR" && docker compose down -v --remove-orphans) >/dev/null 2>&1 || true
+  fi
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  docker volume rm \
+    "$VOLUME_NAME" \
+    "${VOLUME_NAME}-bootstrap" \
+    "${SERVICE_NAME}_${VOLUME_NAME}" \
+    "${SERVICE_NAME}_${VOLUME_NAME}-bootstrap" \
+    >/dev/null 2>&1 || true
+  rm -rf "$ROOT" >/dev/null 2>&1 || true
+}
+
+trap 'on_error $LINENO' ERR
+trap cleanup EXIT
+
+command -v script >/dev/null 2>&1 || fail "missing 'script' command (util-linux)"
+command -v timeout >/dev/null 2>&1 || fail "missing 'timeout' command"
+command -v ssh-keygen >/dev/null 2>&1 || fail "missing 'ssh-keygen' command"
+REAL_SSH="$(command -v ssh)" || fail "missing 'ssh' command"
+
+ssh-keygen -q -t ed25519 -N "" -C "docker-git-e2e-auto-open" -f "$SSH_KEY" >/dev/null
+cp "$SSH_PUB_KEY" "$ROOT/authorized_keys"
+chmod 0600 "$SSH_KEY" || true
+chmod 0644 "$ROOT/authorized_keys" || true
+dg_write_docker_host_file "$SSH_KEY" 600 < "$SSH_KEY"
+dg_write_docker_host_file "$SSH_PUB_KEY" 644 < "$SSH_PUB_KEY"
+dg_write_docker_host_file "$ROOT/authorized_keys" 644 < "$SSH_PUB_KEY"
+
+mkdir -p "$OUT_DIR/.orch/env"
+chmod 0777 "$OUT_DIR" "$OUT_DIR/.orch" "$OUT_DIR/.orch/env"
+dg_write_docker_host_file "$OUT_DIR/authorized_keys" 644 < "$SSH_PUB_KEY"
+cat > "$OUT_DIR/.orch/env/project.env" <<'EOF_ENV'
+# docker-git project env (e2e)
+CODEX_AUTO_UPDATE=0
+CODEX_SHARE_AUTH=1
+EOF_ENV
+
+cat > "$E2E_BIN/ssh" <<'EOF_SSH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+: "${DOCKER_GIT_E2E_REAL_SSH:?}"
+: "${DOCKER_GIT_E2E_SSH_INVOCATION_LOG:?}"
+: "${DOCKER_GIT_E2E_SSH_SESSION_LOG:?}"
+
+REMOTE_COMMAND="bash -lic 'codex --version >/dev/null && exit'"
+
+{
+  printf "argv:"
+  for arg in "$@"; do
+    printf " <%s>" "$arg"
+  done
+  printf "\n"
+} >> "$DOCKER_GIT_E2E_SSH_INVOCATION_LOG"
+
+run_ssh() {
+  "$DOCKER_GIT_E2E_REAL_SSH" "$@" "$REMOTE_COMMAND" \
+    >> "$DOCKER_GIT_E2E_SSH_SESSION_LOG" 2>&1
+}
+
+container_ip() {
+  if [[ -z "${DOCKER_GIT_E2E_CONTAINER_NAME:-}" ]]; then
+    return 1
+  fi
+
+  docker inspect \
+    --format '{{range .NetworkSettings.Networks}}{{println .IPAddress}}{{end}}' \
+    "$DOCKER_GIT_E2E_CONTAINER_NAME" 2>/dev/null \
+    | sed '/^$/d' \
+    | head -n 1
+}
+
+run_ssh_via_container_ip() {
+  local ip
+  ip="$(container_ip)"
+  if [[ -z "$ip" ]]; then
+    return 255
+  fi
+
+  local rewritten=()
+  local replace_port=0
+  local arg
+  for arg in "$@"; do
+    if [[ "$replace_port" == "1" ]]; then
+      rewritten+=("22")
+      replace_port=0
+      continue
+    fi
+
+    case "$arg" in
+      -p)
+        rewritten+=("-p")
+        replace_port=1
+        ;;
+      *@127.0.0.1|*@localhost)
+        rewritten+=("${arg%@*}@$ip")
+        ;;
+      *)
+        rewritten+=("$arg")
+        ;;
+    esac
+  done
+
+  printf "fallback-target: <%s>\n" "$ip" >> "$DOCKER_GIT_E2E_SSH_INVOCATION_LOG"
+  run_ssh "${rewritten[@]}"
+}
+
+set +e
+run_ssh "$@"
+exit_code=$?
+if [[ "$exit_code" -eq 255 ]]; then
+  run_ssh_via_container_ip "$@"
+  exit_code=$?
+fi
+set -e
+
+printf "exit: %s\n" "$exit_code" >> "$DOCKER_GIT_E2E_SSH_INVOCATION_LOG"
+exit "$exit_code"
+EOF_SSH
+chmod +x "$E2E_BIN/ssh"
+
+cat > "$RUN_SCRIPT" <<'EOF_RUN'
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$REPO_ROOT"
+bun packages/app/dist/src/docker-git/main.js clone "$REPO_URL" \
+  --force \
+  --gh-skip \
+  --authorized-keys "$ROOT/authorized_keys" \
+  --ssh-port "$SSH_PORT" \
+  --out-dir "$OUT_DIR_REL" \
+  --container-name "$CONTAINER_NAME" \
+  --service-name "$SERVICE_NAME" \
+  --volume-name "$VOLUME_NAME"
+EOF_RUN
+chmod +x "$RUN_SCRIPT"
+
+export PATH="$E2E_BIN:$PATH"
+export DOCKER_GIT_E2E_REAL_SSH="$REAL_SSH"
+export DOCKER_GIT_E2E_SSH_INVOCATION_LOG="$SSH_INVOCATION_LOG"
+export DOCKER_GIT_E2E_SSH_SESSION_LOG="$SSH_SESSION_LOG"
+export DOCKER_GIT_E2E_CONTAINER_NAME="$CONTAINER_NAME"
+export DOCKER_GIT_SSH_KEY="$SSH_KEY"
+export REPO_ROOT REPO_URL ROOT SSH_PORT OUT_DIR_REL CONTAINER_NAME SERVICE_NAME VOLUME_NAME
+
+timeout "$CLONE_AUTO_OPEN_TIMEOUT" script -q -e -c "$RUN_SCRIPT" /dev/null >"$CLONE_LOG" 2>&1 \
+  || fail "clone auto-open command failed"
+
+grep -Fq -- "Project created: octocat/hello-world" "$CLONE_LOG" \
+  || fail "expected clone log to confirm project creation"
+
+grep -Fq -- "SSH terminal: octocat/hello-world" "$CLONE_LOG" \
+  || fail "expected clone log to show SSH auto-open header"
+
+[[ -f "$SSH_INVOCATION_LOG" ]] || fail "expected ssh wrapper to be invoked"
+grep -Fq -- "<-tt>" "$SSH_INVOCATION_LOG" || fail "expected ssh to request a tty"
+grep -Fq -- "<-Y>" "$SSH_INVOCATION_LOG" || fail "expected ssh to enable trusted X11 forwarding"
+grep -Fq -- "<-o> <LogLevel=ERROR>" "$SSH_INVOCATION_LOG" || fail "expected ssh LogLevel=ERROR option"
+grep -Fq -- "<-o> <StrictHostKeyChecking=no>" "$SSH_INVOCATION_LOG" \
+  || fail "expected ssh StrictHostKeyChecking=no option"
+grep -Fq -- "<-o> <UserKnownHostsFile=/dev/null>" "$SSH_INVOCATION_LOG" \
+  || fail "expected ssh UserKnownHostsFile=/dev/null option"
+grep -Fq -- "<-p> <$SSH_PORT>" "$SSH_INVOCATION_LOG" || fail "expected ssh port $SSH_PORT"
+grep -Eq -- '<dev@(127[.]0[.]0[.]1|localhost)>' "$SSH_INVOCATION_LOG" \
+  || fail "expected ssh target to be dev@127.0.0.1 or dev@localhost"
+grep -Fq -- "exit: 0" "$SSH_INVOCATION_LOG" || fail "expected ssh command to succeed"
+
+docker exec -u dev "$CONTAINER_NAME" bash -lc "test -d '$TARGET_DIR/.git'" \
+  || fail "expected cloned repo at: $TARGET_DIR"
+
+grep -Fq -- "Контекст workspace: issue #1 (https://github.com/octocat/Hello-World/issues/1)" "$SSH_SESSION_LOG" \
+  || fail "expected issue workspace context in auto-open SSH output"
+
+grep -Fq -- "codex resume" "$SSH_SESSION_LOG" \
+  || fail "expected codex resume hint in auto-open SSH output"
+
+echo "e2e/clone-auto-open-ssh: clone auto-open SSH flow verified" >&2

--- a/scripts/e2e/run-all.sh
+++ b/scripts/e2e/run-all.sh
@@ -5,7 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 cases=("$@")
 if [[ "${#cases[@]}" -eq 0 ]]; then
-  cases=("local-package-cli" "clone-cache" "login-context" "runtime-volumes-ssh" "opencode-autoconnect")
+  cases=("local-package-cli" "clone-cache" "login-context" "runtime-volumes-ssh" "clone-auto-open-ssh" "opencode-autoconnect")
 fi
 
 for case_name in "${cases[@]}"; do

--- a/scripts/e2e/runtime-volumes-ssh.sh
+++ b/scripts/e2e/runtime-volumes-ssh.sh
@@ -72,6 +72,13 @@ cleanup() {
   if [[ -d "$OUT_DIR" ]] && [[ -f "$OUT_DIR/docker-compose.yml" ]]; then
     (cd "$OUT_DIR" && docker compose down -v --remove-orphans) >/dev/null 2>&1 || true
   fi
+  docker rm -f "$CONTAINER_NAME" >/dev/null 2>&1 || true
+  docker volume rm \
+    "$VOLUME_NAME" \
+    "${VOLUME_NAME}-bootstrap" \
+    "${SERVICE_NAME}_${VOLUME_NAME}" \
+    "${SERVICE_NAME}_${VOLUME_NAME}-bootstrap" \
+    >/dev/null 2>&1 || true
   rm -rf "$ROOT" >/dev/null 2>&1 || true
 }
 


### PR DESCRIPTION
## Summary
- restore CI coverage for app/lib/api build, typecheck, lint, and test jobs
- split docker-git API client helpers into focused auth/events modules
- add an e2e test that verifies `docker-git clone` auto-opens SSH through a TTY and reaches the container over SSH
- harden SSH e2e cleanup so temporary containers and volumes are removed reliably

## Verification
- `bash scripts/e2e/clone-auto-open-ssh.sh`
- `bash scripts/e2e/runtime-volumes-ssh.sh`
- `bun run --cwd packages/app build`
- `bun run --cwd packages/app check`
- `bun run --cwd packages/app lint`
- `bun run --cwd packages/app lint:effect`
- `bun run --cwd packages/app test`
- `bun run --cwd packages/lib typecheck`
- `bun run --cwd packages/lib lint`
- `bun run --cwd packages/lib lint:effect`
- `bun run --cwd packages/lib test`
- `bun run --cwd packages/api build`
- `bun run --cwd packages/api typecheck`
- `bun run --cwd packages/api lint`
- `bun run --cwd packages/api test`
- `git diff --check`
