### PR TITLE
Fix browser SSH terminal proxy and viewport layout

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -79,6 +79,7 @@
         "@types/node": "^24.12.0",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
+        "@types/ws": "^8.18.1",
         "@typescript-eslint/eslint-plugin": "^8.57.1",
         "@typescript-eslint/parser": "^8.57.1",
         "@vitejs/plugin-react": "^6.0.1",
@@ -99,6 +100,7 @@
         "typescript-eslint": "^8.57.1",
         "vite": "^8.0.1",
         "vitest": "^4.1.0",
+        "ws": "^8.20.0",
       },
     },
     "packages/lib": {
@@ -1735,6 +1737,8 @@
     "@prover-coder-ai/dist-deps-prune/@effect/platform": ["@effect/platform@0.94.5", "", { "dependencies": { "find-my-way-ts": "0.1.6", "msgpackr": "1.11.5", "multipasta": "0.2.7" }, "peerDependencies": { "effect": "3.21.0" } }, "sha512-z05APUiDDPbodhTkH/RJqOLoCU11bU2IZLfcwLFrld03+ob1VeqRnELQlmueLIYm6NZifHAtjl32V+GRt34y4A=="],
 
     "@prover-coder-ai/dist-deps-prune/@effect/platform-node": ["@effect/platform-node@0.104.1", "", { "dependencies": { "@effect/platform-node-shared": "0.57.1", "mime": "3.0.0", "undici": "7.16.0", "ws": "8.18.3" }, "peerDependencies": { "@effect/cluster": "0.58.0", "@effect/platform": "0.94.5", "@effect/rpc": "0.75.0", "@effect/sql": "0.51.0", "effect": "3.21.0" } }, "sha512-jT1a/z98niK6fnEU8pWHPPCdJMVDRCIdB65lolcOjse5rsTwVbczMjvKkhVQpF63mNWoOnol7OTRNkw5L54llg=="],
+
+    "@prover-coder-ai/docker-git/ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
     "@prover-coder-ai/eslint-plugin-suggest-members/@effect/platform": ["@effect/platform@0.94.5", "", { "dependencies": { "find-my-way-ts": "0.1.6", "msgpackr": "1.11.5", "multipasta": "0.2.7" }, "peerDependencies": { "effect": "3.21.0" } }, "sha512-z05APUiDDPbodhTkH/RJqOLoCU11bU2IZLfcwLFrld03+ob1VeqRnELQlmueLIYm6NZifHAtjl32V+GRt34y4A=="],
 

--- a/packages/api/src/services/auth-terminal-sessions.ts
+++ b/packages/api/src/services/auth-terminal-sessions.ts
@@ -5,11 +5,11 @@ import { randomUUID } from "node:crypto"
 import { fileURLToPath } from "node:url"
 import type { IncomingMessage, Server as HttpServer } from "node:http"
 import type { Duplex } from "node:stream"
-import { spawn, type IPty } from "node-pty"
 import { WebSocket, WebSocketServer, type RawData } from "ws"
 
 import type { AuthTerminalFlow, AuthTerminalSessionRequest, TerminalSession, TerminalSessionStatus } from "../api/contracts.js"
 import { ApiConflictError, ApiNotFoundError, describeUnknown } from "../api/errors.js"
+import { spawnPtyBridge, type PtyBridge } from "./pty-bridge.js"
 
 type TerminalClientMessage =
   | { readonly type: "input"; readonly data: string }
@@ -26,7 +26,7 @@ type AuthTerminalRecord = {
   attachTimeout: ReturnType<typeof setTimeout> | null
   args: ReadonlyArray<string>
   cwd: string
-  pty: IPty | null
+  pty: PtyBridge | null
   session: TerminalSession
   socket: WebSocket | null
 }
@@ -35,6 +35,7 @@ const attachTimeoutMs = 30_000
 const authTerminalProjectId = "__controller__"
 const authTerminalWsPathPattern = /^(?:\/api)?\/auth\/terminal-sessions\/([^/]+)\/ws$/u
 const authRunnerPath = fileURLToPath(new URL("../auth-terminal-runner.js", import.meta.url))
+const nodeCommand = process.env["DOCKER_GIT_NODE_BINARY"]?.trim() || "node"
 const records = new Map<string, AuthTerminalRecord>()
 
 const TerminalClientMessageSchema = Schema.parseJson(
@@ -148,7 +149,7 @@ const decodeClientMessage = (raw: RawData): TerminalClientMessage | null =>
 const clampTerminalSize = (value: number, fallback: number): number =>
   Number.isFinite(value) && value > 0 ? Math.max(1, Math.floor(value)) : fallback
 
-const writePtyInput = (pty: IPty | null, data: string): void => {
+const writePtyInput = (pty: PtyBridge | null, data: string): void => {
   if (pty === null) {
     return
   }
@@ -159,7 +160,7 @@ const writePtyInput = (pty: IPty | null, data: string): void => {
   }
 }
 
-const resizePty = (pty: IPty | null, cols: number, rows: number): void => {
+const resizePty = (pty: PtyBridge | null, cols: number, rows: number): void => {
   if (pty === null) {
     return
   }
@@ -171,14 +172,11 @@ const resizePty = (pty: IPty | null, cols: number, rows: number): void => {
 }
 
 const startTerminalPty = (record: AuthTerminalRecord, cols: number, rows: number): void => {
-  const pty = spawn(process.execPath, [...record.args], {
+  const pty = spawnPtyBridge({
+    args: record.args,
     cols: clampTerminalSize(cols, 120),
+    command: nodeCommand,
     cwd: record.cwd,
-    env: {
-      ...process.env,
-      TERM: "xterm-256color"
-    },
-    name: "xterm-256color",
     rows: clampTerminalSize(rows, 32)
   })
   record.pty = pty

--- a/packages/api/src/services/pty-bridge.ts
+++ b/packages/api/src/services/pty-bridge.ts
@@ -1,0 +1,128 @@
+import { spawn } from "node:child_process"
+import { fileURLToPath } from "node:url"
+
+export type PtyExit = {
+  readonly exitCode: number | null
+  readonly signal: number | null
+}
+
+export type PtyBridge = {
+  readonly kill: () => void
+  readonly onData: (handler: (data: string) => void) => void
+  readonly onExit: (handler: (exit: PtyExit) => void) => void
+  readonly resize: (cols: number, rows: number) => void
+  readonly write: (data: string) => void
+}
+
+type PtyBridgeSpec = {
+  readonly args: ReadonlyArray<string>
+  readonly cols: number
+  readonly command: string
+  readonly cwd: string
+  readonly rows: number
+}
+
+type HelperOutputMessage =
+  | { readonly type: "data"; readonly data: string }
+  | { readonly type: "error"; readonly message: string }
+  | { readonly type: "exit"; readonly exitCode: number | null; readonly signal: number | null }
+
+const helperPath = fileURLToPath(new URL("./pty-helper.js", import.meta.url))
+const nodeCommand = process.env["DOCKER_GIT_NODE_BINARY"]?.trim() || "node"
+
+const encodeStartSpec = (spec: PtyBridgeSpec): string =>
+  Buffer.from(JSON.stringify(spec), "utf8").toString("base64url")
+
+const encodeInput = (data: string): string => Buffer.from(data, "utf8").toString("base64")
+
+const encodeCommand = (message: object): string => `${JSON.stringify(message)}\n`
+
+const decodeOutputMessage = (line: string): HelperOutputMessage | null => {
+  try {
+    return JSON.parse(line) as HelperOutputMessage
+  } catch {
+    return null
+  }
+}
+
+const decodeOutputData = (data: string): string => Buffer.from(data, "base64").toString("utf8")
+
+export const spawnPtyBridge = (spec: PtyBridgeSpec): PtyBridge => {
+  const child = spawn(nodeCommand, [helperPath, encodeStartSpec(spec)], {
+    cwd: spec.cwd,
+    env: {
+      ...process.env,
+      TERM: "xterm-256color"
+    },
+    stdio: ["pipe", "pipe", "pipe"]
+  })
+  const dataHandlers = new Set<(data: string) => void>()
+  const exitHandlers = new Set<(exit: PtyExit) => void>()
+  let exitSeen = false
+  let pending = ""
+
+  const emitData = (data: string): void => {
+    for (const handler of dataHandlers) {
+      handler(data)
+    }
+  }
+  const emitExit = (exit: PtyExit): void => {
+    if (exitSeen) {
+      return
+    }
+    exitSeen = true
+    for (const handler of exitHandlers) {
+      handler(exit)
+    }
+  }
+  const sendCommand = (message: object): void => {
+    if (!child.stdin.destroyed) {
+      child.stdin.write(encodeCommand(message))
+    }
+  }
+
+  child.stdout.setEncoding("utf8")
+  child.stdout.on("data", (chunk) => {
+    pending += chunk
+    const lines = pending.split("\n")
+    pending = lines.pop() ?? ""
+    for (const line of lines) {
+      const message = decodeOutputMessage(line)
+      if (message === null) {
+        continue
+      }
+      if (message.type === "data") {
+        emitData(decodeOutputData(message.data))
+      } else if (message.type === "error") {
+        emitData(`\r\n[pty helper error] ${message.message}\r\n`)
+      } else {
+        emitExit({ exitCode: message.exitCode, signal: message.signal })
+      }
+    }
+  })
+  child.stderr.on("data", (chunk) => {
+    emitData(`\r\n[pty helper stderr] ${String(chunk)}\r\n`)
+  })
+  child.on("exit", (exitCode) => {
+    emitExit({ exitCode, signal: null })
+  })
+
+  return {
+    kill: () => {
+      sendCommand({ type: "kill" })
+      child.kill()
+    },
+    onData: (handler) => {
+      dataHandlers.add(handler)
+    },
+    onExit: (handler) => {
+      exitHandlers.add(handler)
+    },
+    resize: (cols, rows) => {
+      sendCommand({ type: "resize", cols, rows })
+    },
+    write: (data) => {
+      sendCommand({ type: "input", data: encodeInput(data) })
+    }
+  }
+}

--- a/packages/api/src/services/pty-helper.ts
+++ b/packages/api/src/services/pty-helper.ts
@@ -1,0 +1,92 @@
+import { spawn } from "node-pty"
+
+type PtyStartSpec = {
+  readonly args: ReadonlyArray<string>
+  readonly cols: number
+  readonly command: string
+  readonly cwd: string
+  readonly rows: number
+}
+
+type HelperInputMessage =
+  | { readonly type: "input"; readonly data: string }
+  | { readonly type: "resize"; readonly cols: number; readonly rows: number }
+  | { readonly type: "kill" }
+
+type HelperOutputMessage =
+  | { readonly type: "data"; readonly data: string }
+  | { readonly type: "error"; readonly message: string }
+  | { readonly type: "exit"; readonly exitCode: number | null; readonly signal: number | null }
+
+const encodeMessage = (message: HelperOutputMessage): string => `${JSON.stringify(message)}\n`
+
+const sendMessage = (message: HelperOutputMessage): void => {
+  process.stdout.write(encodeMessage(message))
+}
+
+const decodeStartSpec = (): PtyStartSpec => {
+  const encoded = process.argv[2]
+  if (encoded === undefined) {
+    throw new Error("Missing PTY start spec.")
+  }
+  return JSON.parse(Buffer.from(encoded, "base64url").toString("utf8")) as PtyStartSpec
+}
+
+const decodeInputMessage = (line: string): HelperInputMessage | null => {
+  try {
+    return JSON.parse(line) as HelperInputMessage
+  } catch {
+    return null
+  }
+}
+
+const sendData = (data: string): void => {
+  sendMessage({ type: "data", data: Buffer.from(data, "utf8").toString("base64") })
+}
+
+const main = (): void => {
+  const spec = decodeStartSpec()
+  const pty = spawn(spec.command, [...spec.args], {
+    cols: spec.cols,
+    cwd: spec.cwd,
+    env: {
+      ...process.env,
+      TERM: "xterm-256color"
+    },
+    name: "xterm-256color",
+    rows: spec.rows
+  })
+
+  pty.onData(sendData)
+  pty.onExit(({ exitCode, signal }) => {
+    sendMessage({ type: "exit", exitCode: exitCode ?? null, signal: signal ?? null })
+  })
+
+  let pending = ""
+  process.stdin.setEncoding("utf8")
+  process.stdin.on("data", (chunk) => {
+    pending += chunk
+    const lines = pending.split("\n")
+    pending = lines.pop() ?? ""
+    for (const line of lines) {
+      const message = decodeInputMessage(line)
+      if (message === null) {
+        continue
+      }
+      if (message.type === "input") {
+        pty.write(Buffer.from(message.data, "base64").toString("utf8"))
+      } else if (message.type === "resize") {
+        pty.resize(message.cols, message.rows)
+      } else {
+        pty.kill()
+      }
+    }
+  })
+}
+
+try {
+  main()
+} catch (error) {
+  sendMessage({ type: "error", message: String(error) })
+  sendMessage({ type: "exit", exitCode: 1, signal: null })
+}

--- a/packages/api/src/services/terminal-sessions.ts
+++ b/packages/api/src/services/terminal-sessions.ts
@@ -10,11 +10,11 @@ import { Effect, Either } from "effect"
 import { randomUUID } from "node:crypto"
 import type { IncomingMessage, Server as HttpServer } from "node:http"
 import type { Duplex } from "node:stream"
-import { spawn, type IPty } from "node-pty"
 import { WebSocket, WebSocketServer, type RawData } from "ws"
 
 import type { TerminalSession, TerminalSessionStatus } from "../api/contracts.js"
 import { ApiConflictError, ApiInternalError, ApiNotFoundError, describeUnknown } from "../api/errors.js"
+import { spawnPtyBridge, type PtyBridge } from "./pty-bridge.js"
 import { emitProjectEvent } from "./events.js"
 import { getProjectItemById, upProject } from "./projects.js"
 
@@ -31,7 +31,7 @@ type TerminalServerMessage =
 
 type TerminalRecord = {
   session: TerminalSession
-  pty: IPty | null
+  pty: PtyBridge | null
   socket: WebSocket | null
   attachTimeout: ReturnType<typeof setTimeout> | null
   projectId: string
@@ -241,7 +241,7 @@ const decodeClientMessage = (raw: RawData): TerminalClientMessage | null =>
 const clampTerminalSize = (value: number, fallback: number): number =>
   Number.isFinite(value) && value > 0 ? Math.max(1, Math.floor(value)) : fallback
 
-const writePtyInput = (pty: IPty | null, data: string): void => {
+const writePtyInput = (pty: PtyBridge | null, data: string): void => {
   if (pty === null) {
     return
   }
@@ -252,7 +252,7 @@ const writePtyInput = (pty: IPty | null, data: string): void => {
   }
 }
 
-const resizePty = (pty: IPty | null, cols: number, rows: number): void => {
+const resizePty = (pty: PtyBridge | null, cols: number, rows: number): void => {
   if (pty === null) {
     return
   }
@@ -270,14 +270,11 @@ const startTerminalPty = (
 ): void => {
   const resolvedCols = clampTerminalSize(cols, 120)
   const resolvedRows = clampTerminalSize(rows, 32)
-  const pty = spawn(record.prepared.command, [...record.prepared.args], {
+  const pty = spawnPtyBridge({
+    args: record.prepared.args,
+    command: record.prepared.command,
     cols: resolvedCols,
     cwd: record.prepared.cwd,
-    env: {
-      ...process.env,
-      TERM: "xterm-256color"
-    },
-    name: "xterm-256color",
     rows: resolvedRows
   })
   record.pty = pty

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -98,6 +98,7 @@
     "@types/node": "^24.12.0",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
+    "@types/ws": "^8.18.1",
     "@typescript-eslint/eslint-plugin": "^8.57.1",
     "@typescript-eslint/parser": "^8.57.1",
     "@vitejs/plugin-react": "^6.0.1",
@@ -117,6 +118,7 @@
     "typescript": "^5.9.3",
     "typescript-eslint": "^8.57.1",
     "vite": "^8.0.1",
-    "vitest": "^4.1.0"
+    "vitest": "^4.1.0",
+    "ws": "^8.20.0"
   }
 }

--- a/packages/app/src/ui/primitives-web.tsx
+++ b/packages/app/src/ui/primitives-web.tsx
@@ -9,7 +9,7 @@ const unit = (value: number | string | undefined): string | number | undefined =
   return typeof value === "number" ? `${value * 8}px` : value
 }
 
-const borderRadius = (borderStyle: UiBoxProps["borderStyle"]): string => borderStyle === "rounded" ? "12px" : "0"
+const borderRadius = (borderStyle: UiBoxProps["borderStyle"]): string => borderStyle === "rounded" ? "8px" : "0"
 
 const borderValue = (
   enabled: boolean | undefined,
@@ -24,8 +24,10 @@ const baseStyle = (props: UiBoxProps): CSSProperties => ({
   boxSizing: "border-box",
   color: props.fg,
   display: "flex",
+  flexBasis: props.flexBasis,
   flexDirection: props.flexDirection ?? "row",
   flexGrow: props.flexGrow,
+  flexShrink: props.flexShrink,
   flexWrap: props.flexWrap,
   gap: unit(props.gap),
   height: unit(props.height),
@@ -34,6 +36,13 @@ const baseStyle = (props: UiBoxProps): CSSProperties => ({
   marginLeft: unit(props.marginLeft),
   marginRight: unit(props.marginRight),
   marginTop: unit(props.marginTop),
+  maxHeight: unit(props.maxHeight),
+  maxWidth: unit(props.maxWidth),
+  minHeight: unit(props.minHeight),
+  minWidth: unit(props.minWidth),
+  overflow: props.overflow,
+  overflowX: props.overflowX,
+  overflowY: props.overflowY,
   padding: unit(props.padding),
   width: unit(props.width)
 })
@@ -60,7 +69,7 @@ const interactiveStyle = (width: UiBoxProps["width"]): CSSProperties => ({
 const inputStyle: CSSProperties = {
   background: "#07101c",
   border: "1px solid #24537d",
-  borderRadius: "10px",
+  borderRadius: "8px",
   boxSizing: "border-box",
   color: "#56f39a",
   font: "inherit",

--- a/packages/app/src/ui/primitives.tsx
+++ b/packages/app/src/ui/primitives.tsx
@@ -16,8 +16,10 @@ export type UiBoxProps = {
   readonly borderStyle?: "rounded" | "single"
   readonly children?: ReactNode
   readonly fg?: string
+  readonly flexBasis?: CSSProperties["flexBasis"]
   readonly flexDirection?: CSSProperties["flexDirection"]
   readonly flexGrow?: number
+  readonly flexShrink?: number
   readonly flexWrap?: CSSProperties["flexWrap"]
   readonly gap?: number | string
   readonly height?: number | string
@@ -26,7 +28,14 @@ export type UiBoxProps = {
   readonly marginLeft?: number | string
   readonly marginRight?: number | string
   readonly marginTop?: number | string
+  readonly maxHeight?: number | string
+  readonly maxWidth?: number | string
+  readonly minHeight?: number | string
+  readonly minWidth?: number | string
   readonly onClick?: MouseEventHandler<HTMLElement> | (() => void)
+  readonly overflow?: CSSProperties["overflow"]
+  readonly overflowX?: CSSProperties["overflowX"]
+  readonly overflowY?: CSSProperties["overflowY"]
   readonly padding?: number | string
   readonly width?: number | string
 }

--- a/packages/app/src/web/app-ready-layout.tsx
+++ b/packages/app/src/web/app-ready-layout.tsx
@@ -7,12 +7,12 @@ import { MainPanels } from "./app-ready-main-panels.js"
 import { Box, Text } from "./elements.js"
 import type { BrowserMenuTag } from "./menu.js"
 import type { ActiveTerminalSession } from "./terminal.js"
+import type { ViewportLayout } from "./viewport-layout.js"
 
 export type ReadyLayoutProps = {
   readonly actionPrompt: ActionPromptState | null
   readonly authSnapshot: AuthSnapshot | null
   readonly busyLabel: string | null
-  readonly compact: boolean
   readonly controllerCwd: string
   readonly projectsRoot: string
   readonly createView: CreateFlowView
@@ -40,10 +40,50 @@ export type ReadyLayoutProps = {
   readonly selectedProjectId: string | null
   readonly selectedProjectSummary: DashboardData["projects"][number] | undefined
   readonly terminalSession: ActiveTerminalSession | null
+  readonly viewportLayout: ViewportLayout
 }
 
+const headerPadding = (viewportLayout: ViewportLayout): number | string =>
+  viewportLayout.compact || viewportLayout.dense ? "6px" : 1
+
+const headerGap = (viewportLayout: ViewportLayout): number => viewportLayout.compact ? 1 : 2
+
+const headerMetricsTopMargin = (viewportLayout: ViewportLayout): number | string => viewportLayout.compact ? "4px" : 1
+
+const HeaderTitle = ({ compact }: Pick<ViewportLayout, "compact">): JSX.Element => (
+  <Box flexWrap="wrap" gap={1} justifyContent="space-between">
+    <Text bold={true} fg="#f6fbff">docker-git browser</Text>
+    {compact ? null : <Text fg="#7fdfff">Gridland menu shell</Text>}
+  </Box>
+)
+
+const StatusText = ({ busyLabel }: Pick<ReadyLayoutProps, "busyLabel">): JSX.Element => (
+  <Text fg={busyLabel === null ? "#8fa6c4" : "#ffd166"}>{busyLabel ?? "idle"}</Text>
+)
+
+const HeaderMetrics = (
+  { busyLabel, dashboard, viewportLayout }: Pick<ReadyLayoutProps, "busyLabel" | "dashboard" | "viewportLayout">
+): JSX.Element => (
+  <Box flexWrap="wrap" gap={headerGap(viewportLayout)} marginTop={headerMetricsTopMargin(viewportLayout)}>
+    <Text fg="#9fd7ff" wrap="truncate">API: {dashboard.apiBaseUrl}</Text>
+    <Text fg="#56f39a">health: ok</Text>
+    <Text fg="#ffd166" wrap="truncate">revision: {dashboard.health.revision ?? "none"}</Text>
+    <Text fg="#d4e3f4">projects: {dashboard.projects.length}</Text>
+    {viewportLayout.compact ? null : <Text fg="#7fa8cf">refresh: 15s</Text>}
+    <StatusText busyLabel={busyLabel} />
+  </Box>
+)
+
+const HeaderMessage = ({ message }: Pick<ReadyLayoutProps, "message">): JSX.Element | null =>
+  message === null
+    ? null
+    : <Text fg="#f6d27b" marginTop="4px" wrap="truncate">message: {message}</Text>
+
 const StatusHeader = (
-  { busyLabel, dashboard, message }: Pick<ReadyLayoutProps, "busyLabel" | "dashboard" | "message">
+  { busyLabel, dashboard, message, viewportLayout }: Pick<
+    ReadyLayoutProps,
+    "busyLabel" | "dashboard" | "message" | "viewportLayout"
+  >
 ): JSX.Element => (
   <Box
     backgroundColor="#0a1730"
@@ -51,28 +91,24 @@ const StatusHeader = (
     borderColor="#39d0ff"
     borderStyle="rounded"
     flexDirection="column"
+    flexShrink={0}
     marginBottom={1}
-    padding={1}
+    padding={headerPadding(viewportLayout)}
   >
-    <Box justifyContent="space-between">
-      <Text bold={true} fg="#f6fbff">docker-git browser</Text>
-      <Text fg="#7fdfff">Gridland menu shell</Text>
-    </Box>
-    <Text fg="#9fd7ff">API: {dashboard.apiBaseUrl}</Text>
-    <Box gap={2} marginTop={1}>
-      <Text fg="#56f39a">health: ok</Text>
-      <Text fg="#ffd166">revision: {dashboard.health.revision ?? "none"}</Text>
-      <Text fg="#d4e3f4">projects: {dashboard.projects.length}</Text>
-      <Text fg="#7fa8cf">refresh: 15s</Text>
-      <Text fg={busyLabel === null ? "#8fa6c4" : "#ffd166"}>{busyLabel ?? "idle"}</Text>
-    </Box>
-    {message === null ? null : <Text fg="#f6d27b">message: {message}</Text>}
+    <HeaderTitle compact={viewportLayout.compact} />
+    <HeaderMetrics busyLabel={busyLabel} dashboard={dashboard} viewportLayout={viewportLayout} />
+    <HeaderMessage message={message} />
   </Box>
 )
 
 export const ReadyLayout = ({ busyLabel, message, ...props }: ReadyLayoutProps): JSX.Element => (
-  <Box flexDirection="column" height="100%" padding={1} width="100%">
-    <StatusHeader busyLabel={busyLabel} dashboard={props.dashboard} message={message} />
+  <Box flexDirection="column" height="100%" minHeight={0} overflow="hidden" padding={1} width="100%">
+    <StatusHeader
+      busyLabel={busyLabel}
+      dashboard={props.dashboard}
+      message={message}
+      viewportLayout={props.viewportLayout}
+    />
     <MainPanels {...props} />
   </Box>
 )

--- a/packages/app/src/web/app-ready-main-panels.tsx
+++ b/packages/app/src/web/app-ready-main-panels.tsx
@@ -19,7 +19,6 @@ type CenterPanelProps =
     MainPanelsProps,
     | "actionPrompt"
     | "authSnapshot"
-    | "compact"
     | "createView"
     | "controllerCwd"
     | "projectsRoot"
@@ -41,6 +40,7 @@ type CenterPanelProps =
     | "projectAuthSnapshot"
     | "selectedProjectSummary"
     | "terminalSession"
+    | "viewportLayout"
   >
   & {
     readonly showProjectPanel: boolean
@@ -55,7 +55,6 @@ type CenterPanelContentProps = Pick<
   CenterPanelProps,
   | "actionPrompt"
   | "authSnapshot"
-  | "compact"
   | "controllerCwd"
   | "createView"
   | "currentMenu"
@@ -73,6 +72,7 @@ type CenterPanelContentProps = Pick<
   | "projectNavigationArmed"
   | "projectsRoot"
   | "selectedProjectSummary"
+  | "viewportLayout"
 >
 
 const CenterPanelBody = (
@@ -95,7 +95,6 @@ const CenterPanelContent = (
   {
     actionPrompt,
     authSnapshot,
-    compact,
     controllerCwd,
     createView,
     currentMenu,
@@ -112,13 +111,14 @@ const CenterPanelContent = (
     projectAuthSnapshot,
     projectNavigationArmed,
     projectsRoot,
-    selectedProjectSummary
+    selectedProjectSummary,
+    viewportLayout
   }: CenterPanelContentProps
 ): JSX.Element => (
   <ContentPanel
     actionPrompt={actionPrompt}
     authSnapshot={authSnapshot}
-    compact={compact}
+    compact={viewportLayout.compact}
     controllerCwd={controllerCwd}
     createView={createView}
     currentMenu={currentMenu}
@@ -143,7 +143,7 @@ const centerPanelWidth = (compact: boolean, showProjectPanel: boolean): string =
   if (compact) {
     return "100%"
   }
-  return showProjectPanel ? "42%" : "69%"
+  return showProjectPanel ? "48%" : "auto"
 }
 
 const CenterPanel = (props: CenterPanelProps): JSX.Element => (
@@ -152,27 +152,45 @@ const CenterPanel = (props: CenterPanelProps): JSX.Element => (
     borderColor="#24537d"
     borderStyle="single"
     flexDirection="column"
+    flexGrow={1}
+    minHeight={0}
+    minWidth={0}
+    overflow="hidden"
     padding={1}
-    width={centerPanelWidth(props.compact, props.showProjectPanel)}
+    width={centerPanelWidth(props.viewportLayout.compact, props.showProjectPanel)}
   >
-    <CenterPanelContent {...props} />
-    <CenterPanelBody {...props} />
+    <Box
+      flexDirection="column"
+      flexShrink={0}
+      maxHeight={props.viewportLayout.dense ? "38%" : "46%"}
+      overflowY="auto"
+    >
+      <CenterPanelContent {...props} />
+    </Box>
+    <Box flexDirection="column" flexGrow={1} minHeight={0} overflow="hidden">
+      <CenterPanelBody {...props} />
+    </Box>
   </Box>
 )
 
 const ProjectPanelSlot = (
   {
-    compact,
     currentMenu,
     dashboard,
     onSelectProject,
     projectNavigationArmed,
     selectedProjectId,
-    showProjectPanel
+    showProjectPanel,
+    viewportLayout
   }:
     & Pick<
       MainPanelsProps,
-      "compact" | "currentMenu" | "dashboard" | "onSelectProject" | "projectNavigationArmed" | "selectedProjectId"
+      | "currentMenu"
+      | "dashboard"
+      | "onSelectProject"
+      | "projectNavigationArmed"
+      | "selectedProjectId"
+      | "viewportLayout"
     >
     & {
       readonly showProjectPanel: boolean
@@ -181,7 +199,7 @@ const ProjectPanelSlot = (
   showProjectPanel
     ? (
       <ProjectListPanel
-        compact={compact}
+        compact={viewportLayout.compact}
         currentMenu={currentMenu}
         dashboard={dashboard}
         onSelectProject={onSelectProject}
@@ -205,7 +223,6 @@ const MainCenterPanel = (
   <CenterPanel
     actionPrompt={props.actionPrompt}
     authSnapshot={props.authSnapshot}
-    compact={props.compact}
     controllerCwd={props.controllerCwd}
     projectsRoot={props.projectsRoot}
     createView={props.createView}
@@ -228,15 +245,22 @@ const MainCenterPanel = (
     selectedProjectSummary={selectedProjectSummary}
     showProjectPanel={showProjectPanel}
     terminalSession={props.terminalSession}
+    viewportLayout={props.viewportLayout}
   />
 )
 
 export const MainPanels = ({ selectedProjectSummary, ...props }: MainPanelsProps): JSX.Element => {
   const showProject = showsProjectPanel(props.currentMenu)
   return (
-    <Box flexDirection={props.compact ? "column" : "row"} flexGrow={1} gap={1}>
+    <Box
+      flexDirection={props.viewportLayout.compact ? "column" : "row"}
+      flexGrow={1}
+      gap={1}
+      minHeight={0}
+      overflow="hidden"
+    >
       <MenuSidebar
-        compact={props.compact}
+        compact={props.viewportLayout.compact}
         currentMenu={props.currentMenu}
         onSelectMenu={props.onSelectMenu}
         projectNavigationArmed={props.projectNavigationArmed}
@@ -245,13 +269,13 @@ export const MainPanels = ({ selectedProjectSummary, ...props }: MainPanelsProps
       />
       <MainCenterPanel props={props} selectedProjectSummary={selectedProjectSummary} showProjectPanel={showProject} />
       <ProjectPanelSlot
-        compact={props.compact}
         currentMenu={props.currentMenu}
         dashboard={props.dashboard}
         onSelectProject={props.onSelectProject}
         projectNavigationArmed={props.projectNavigationArmed}
         selectedProjectId={props.selectedProjectId}
         showProjectPanel={showProject}
+        viewportLayout={props.viewportLayout}
       />
     </Box>
   )

--- a/packages/app/src/web/app-ready.tsx
+++ b/packages/app/src/web/app-ready.tsx
@@ -3,12 +3,13 @@ import { type JSX } from "react"
 import type { DashboardData } from "./api.js"
 import { useReadyController } from "./app-ready-controller.js"
 import { ReadyLayout } from "./app-ready-layout.js"
+import type { ViewportLayout } from "./viewport-layout.js"
 
 type AppReadyProps = {
-  readonly compact: boolean
   readonly dashboard: DashboardData
   readonly dashboardRefreshTick: number
   readonly refreshDashboard: () => void
+  readonly viewportLayout: ViewportLayout
 }
 
 type ReadyLayoutRenderArgs = {
@@ -22,26 +23,25 @@ type ReadyLayoutRenderArgs = {
     readonly onRunAuthAction: (index: number) => void
     readonly onRunProjectAuthAction: (index: number) => void
   }
-  readonly compact: boolean
   readonly currentMenu: ReturnType<typeof useReadyController>["currentMenu"]
   readonly dashboard: DashboardData
   readonly selectedProjectSummary: ReturnType<typeof useReadyController>["selectedProjectSummary"]
   readonly state: ReturnType<typeof useReadyController>["state"]
+  readonly viewportLayout: ViewportLayout
 }
 
 const renderReadyLayout = ({
   actions,
-  compact,
   currentMenu,
   dashboard,
   selectedProjectSummary,
-  state
+  state,
+  viewportLayout
 }: ReadyLayoutRenderArgs): JSX.Element => (
   <ReadyLayout
     actionPrompt={state.actionPrompt}
     authSnapshot={state.authSnapshot}
     busyLabel={state.busyLabel}
-    compact={compact}
     controllerCwd={dashboard.health.cwd}
     projectsRoot={dashboard.health.projectsRoot}
     createView={state.createView}
@@ -71,14 +71,15 @@ const renderReadyLayout = ({
     selectedProjectId={state.selectedProjectId}
     selectedProjectSummary={selectedProjectSummary}
     terminalSession={state.terminalSession}
+    viewportLayout={viewportLayout}
   />
 )
 
 export const AppReady = ({
-  compact,
   dashboard,
   dashboardRefreshTick,
-  refreshDashboard
+  refreshDashboard,
+  viewportLayout
 }: AppReadyProps): JSX.Element => {
   const {
     currentMenu,
@@ -105,10 +106,10 @@ export const AppReady = ({
       onRunAuthAction,
       onRunProjectAuthAction
     },
-    compact,
     currentMenu,
     dashboard,
     selectedProjectSummary,
-    state
+    state,
+    viewportLayout
   })
 }

--- a/packages/app/src/web/app.tsx
+++ b/packages/app/src/web/app.tsx
@@ -6,6 +6,7 @@ import { UiProvider } from "../ui/primitives.js"
 import { type DashboardData, loadDashboard, resolveApiBaseUrl } from "./api.js"
 import { AppReady } from "./app-ready.js"
 import { ErrorScreen, LoadingScreen } from "./panels.js"
+import { resolveViewportLayout, type ViewportLayout, type ViewportSize } from "./viewport-layout.js"
 
 type DashboardState =
   | { readonly _tag: "Loading"; readonly apiBaseUrl: string }
@@ -13,22 +14,11 @@ type DashboardState =
   | { readonly _tag: "Ready"; readonly dashboard: DashboardData; readonly refreshedAtMs: number }
 
 const refreshIntervalMs = 15_000
-const compactViewportWidth = 960
 
-const resolveViewportWidth = (): number => typeof globalThis.innerWidth === "number" ? globalThis.innerWidth : 1280
-
-const resolveFontSize = (viewportWidth: number): number => {
-  if (viewportWidth < 480) {
-    return 11
-  }
-  if (viewportWidth < compactViewportWidth) {
-    return 12
-  }
-  if (viewportWidth < 1280) {
-    return 13
-  }
-  return 15
-}
+const resolveViewportSize = (): ViewportSize => ({
+  height: typeof globalThis.innerHeight === "number" ? globalThis.innerHeight : 900,
+  width: typeof globalThis.innerWidth === "number" ? globalThis.innerWidth : 1280
+})
 
 const initialDashboardState = (): DashboardState => ({
   _tag: "Loading",
@@ -102,11 +92,11 @@ const useDashboardController = () => {
 }
 
 const useViewportMode = () => {
-  const [viewportWidth, setViewportWidth] = useState(resolveViewportWidth)
+  const [viewportSize, setViewportSize] = useState(resolveViewportSize)
 
   useEffect(() => {
     const onResize = () => {
-      setViewportWidth(resolveViewportWidth())
+      setViewportSize(resolveViewportSize())
     }
     globalThis.addEventListener("resize", onResize)
     return () => {
@@ -114,16 +104,13 @@ const useViewportMode = () => {
     }
   }, [])
 
-  return {
-    compact: viewportWidth < compactViewportWidth,
-    fontSize: resolveFontSize(viewportWidth)
-  } as const
+  return resolveViewportLayout(viewportSize)
 }
 
 const renderDashboardState = (
   state: DashboardState,
   refreshDashboard: () => void,
-  compact: boolean
+  viewportLayout: ViewportLayout
 ): JSX.Element =>
   Match.value(state).pipe(
     Match.when({ _tag: "Loading" }, ({ apiBaseUrl }) => <LoadingScreen apiBaseUrl={apiBaseUrl} />),
@@ -135,10 +122,10 @@ const renderDashboardState = (
       { _tag: "Ready" },
       ({ dashboard, refreshedAtMs }) => (
         <AppReady
-          compact={compact}
           dashboard={dashboard}
           dashboardRefreshTick={refreshedAtMs}
           refreshDashboard={refreshDashboard}
+          viewportLayout={viewportLayout}
         />
       )
     ),
@@ -156,13 +143,15 @@ export const App = (): JSX.Element => {
         color: "#d6e5f7",
         fontFamily: "'IBM Plex Mono', 'SFMono-Regular', monospace",
         fontSize: viewport.fontSize,
-        minHeight: "100vh",
-        overflow: "auto",
+        height: "100vh",
+        inset: 0,
+        overflow: "hidden",
+        position: "fixed",
         width: "100%"
       }}
     >
       <UiProvider primitives={webPrimitives}>
-        {renderDashboardState(state, refresh, viewport.compact)}
+        {renderDashboardState(state, refresh, viewport)}
       </UiProvider>
     </div>
   )

--- a/packages/app/src/web/elements.tsx
+++ b/packages/app/src/web/elements.tsx
@@ -10,16 +10,26 @@ type GridElementProps = {
   readonly children?: ReactNode
   readonly fg?: string
   readonly flexDirection?: CSSProperties["flexDirection"]
+  readonly flexBasis?: CSSProperties["flexBasis"]
   readonly flexGrow?: number
+  readonly flexShrink?: number
   readonly flexWrap?: CSSProperties["flexWrap"]
   readonly gap?: number | string
   readonly height?: number | string
   readonly justifyContent?: CSSProperties["justifyContent"]
   readonly marginBottom?: number | string
   readonly marginTop?: number | string
+  readonly maxHeight?: number | string
+  readonly maxWidth?: number | string
+  readonly minHeight?: number | string
+  readonly minWidth?: number | string
   readonly onClick?: MouseEventHandler<HTMLElement>
+  readonly overflow?: CSSProperties["overflow"]
+  readonly overflowX?: CSSProperties["overflowX"]
+  readonly overflowY?: CSSProperties["overflowY"]
   readonly padding?: number | string
   readonly width?: number | string
+  readonly wrap?: "truncate" | "wrap"
 }
 
 const unit = (value: number | string | undefined): string | number | undefined => {
@@ -29,7 +39,7 @@ const unit = (value: number | string | undefined): string | number | undefined =
   return typeof value === "number" ? `${value * 8}px` : value
 }
 
-const borderRadius = (borderStyle: GridElementProps["borderStyle"]): string => borderStyle === "rounded" ? "12px" : "0"
+const borderRadius = (borderStyle: GridElementProps["borderStyle"]): string => borderStyle === "rounded" ? "8px" : "0"
 
 const borderValue = (
   enabled: boolean | undefined,
@@ -44,14 +54,23 @@ const baseStyle = (props: GridElementProps): CSSProperties => ({
   boxSizing: "border-box",
   color: props.fg,
   display: "flex",
+  flexBasis: props.flexBasis,
   flexDirection: props.flexDirection ?? "row",
   flexGrow: props.flexGrow,
+  flexShrink: props.flexShrink,
   flexWrap: props.flexWrap,
   gap: unit(props.gap),
   height: unit(props.height),
   justifyContent: props.justifyContent,
   marginBottom: unit(props.marginBottom),
   marginTop: unit(props.marginTop),
+  maxHeight: unit(props.maxHeight),
+  maxWidth: unit(props.maxWidth),
+  minHeight: unit(props.minHeight),
+  minWidth: unit(props.minWidth),
+  overflow: props.overflow,
+  overflowX: props.overflowX,
+  overflowY: props.overflowY,
   padding: unit(props.padding),
   width: unit(props.width)
 })
@@ -75,7 +94,9 @@ const textStyle = (props: GridElementProps): CSSProperties => ({
   display: "block",
   fontWeight: props.bold ? 700 : 400,
   lineHeight: 1.45,
-  whiteSpace: "pre-wrap",
+  overflow: props.wrap === "truncate" ? "hidden" : props.overflow,
+  textOverflow: props.wrap === "truncate" ? "ellipsis" : undefined,
+  whiteSpace: props.wrap === "truncate" ? "nowrap" : "pre-wrap",
   width: unit(props.width) ?? "auto"
 })
 

--- a/packages/app/src/web/panel-layout.tsx
+++ b/packages/app/src/web/panel-layout.tsx
@@ -48,6 +48,11 @@ const compactMenuLabels: Readonly<Record<BrowserMenuTag, string>> = {
   Status: "Status"
 }
 
+const menuPanelMaxHeight = (compact: boolean): string => compact ? "154px" : "100%"
+const menuListDirection = (compact: boolean): "column" | "row" => compact ? "row" : "column"
+const menuListTopMargin = (compact: boolean): number | string => compact ? "6px" : 1
+const projectPanelMaxHeight = (compact: boolean): string => compact ? "30%" : "100%"
+
 const runtimeByProject = (dashboard: DashboardData): Readonly<
   Record<string, {
     readonly running: boolean
@@ -99,6 +104,68 @@ const buildProjectListLabels = (
     )
   ).map((label) => selectedIndex === -1 ? stripSelectionPrefix(label) : label)
 
+const MenuHeader = ({ compact }: Pick<MenuSidebarProps, "compact">): JSX.Element => (
+  <Box flexWrap="wrap" gap={1} justifyContent="space-between">
+    <Text bold={true} fg="#8be9fd">{compact ? "docker-git menu" : "bun run docker-git"}</Text>
+    {compact ? null : <Text fg="#7ba6cc">browser inheritance shell</Text>}
+  </Box>
+)
+
+const SelectedProjectLine = (
+  { selectedProjectLabel }: Pick<MenuSidebarProps, "selectedProjectLabel">
+): JSX.Element => (
+  <Text fg="#5bd1ff" marginTop="4px" wrap="truncate" width="100%">
+    selected project: {selectedProjectLabel}
+  </Text>
+)
+
+const MenuItemsList = (
+  { compact, onSelectMenu, selectedMenuIndex }: Pick<
+    MenuSidebarProps,
+    "compact" | "onSelectMenu" | "selectedMenuIndex"
+  >
+): JSX.Element => (
+  <Box
+    flexDirection={menuListDirection(compact)}
+    flexWrap={compact ? "wrap" : "nowrap"}
+    gap="4px"
+    marginTop={menuListTopMargin(compact)}
+  >
+    {browserMenuItems.map((item, index) => (
+      <Box
+        key={item.tag}
+        onClick={() => {
+          onSelectMenu(index)
+        }}
+        width={compact ? "auto" : "100%"}
+      >
+        <Text bold={index === selectedMenuIndex} fg={index === selectedMenuIndex ? "#56f39a" : "#d6e5f7"}>
+          {index === selectedMenuIndex ? "> " : "  "}
+          {index + 1}. {compactMenuLabels[item.tag]}
+        </Text>
+      </Box>
+    ))}
+  </Box>
+)
+
+const MenuHints = (
+  { compact, currentMenu, projectNavigationArmed }: Pick<
+    MenuSidebarProps,
+    "compact" | "currentMenu" | "projectNavigationArmed"
+  >
+): JSX.Element => (
+  <Box
+    flexDirection={compact ? "row" : "column"}
+    flexWrap="wrap"
+    gap={compact ? 1 : 0}
+    marginTop={compact ? "6px" : 1}
+  >
+    {compact ? null : <Text fg="#8fa6c4">keys:</Text>}
+    <Text fg="#8fa6c4">{shortcutHintText(currentMenu, projectNavigationArmed)}</Text>
+    {compact ? null : <Text fg="#8fa6c4">Enter run, R refresh, Esc cancel create</Text>}
+  </Box>
+)
+
 export const MenuSidebar = (
   {
     compact,
@@ -113,33 +180,18 @@ export const MenuSidebar = (
     border={true}
     borderColor="#24537d"
     borderStyle="single"
+    flexShrink={0}
     flexDirection="column"
+    maxHeight={menuPanelMaxHeight(compact)}
+    minHeight={0}
+    overflowY="auto"
     padding={1}
-    width={compact ? "100%" : "30%"}
+    width={compact ? "100%" : "240px"}
   >
-    <Text bold={true} fg="#8be9fd">{compact ? "docker-git menu" : "bun run docker-git"}</Text>
-    <Text fg="#7ba6cc">browser inheritance shell</Text>
-    <Text fg="#5bd1ff" marginTop={1}>selected project: {selectedProjectLabel}</Text>
-    <Box flexDirection="column" marginTop={1}>
-      {browserMenuItems.map((item, index) => (
-        <Box
-          key={item.tag}
-          onClick={() => {
-            onSelectMenu(index)
-          }}
-        >
-          <Text bold={index === selectedMenuIndex} fg={index === selectedMenuIndex ? "#56f39a" : "#d6e5f7"}>
-            {index === selectedMenuIndex ? "> " : "  "}
-            {index + 1}. {compactMenuLabels[item.tag]}
-          </Text>
-        </Box>
-      ))}
-    </Box>
-    <Box flexDirection="column" marginTop={1}>
-      <Text fg="#8fa6c4">keys:</Text>
-      <Text fg="#8fa6c4">{shortcutHintText(currentMenu, projectNavigationArmed)}</Text>
-      <Text fg="#8fa6c4">Enter run, R refresh, Esc cancel create</Text>
-    </Box>
+    <MenuHeader compact={compact} />
+    <SelectedProjectLine selectedProjectLabel={selectedProjectLabel} />
+    <MenuItemsList compact={compact} onSelectMenu={onSelectMenu} selectedMenuIndex={selectedMenuIndex} />
+    <MenuHints compact={compact} currentMenu={currentMenu} projectNavigationArmed={projectNavigationArmed} />
   </Box>
 )
 
@@ -160,11 +212,15 @@ export const ProjectListPanel = (
       borderColor="#24537d"
       borderStyle="single"
       flexDirection="column"
+      flexShrink={compact ? 1 : 0}
+      maxHeight={projectPanelMaxHeight(compact)}
+      minHeight={0}
+      overflowY="auto"
       padding={1}
-      width={compact ? "100%" : "28%"}
+      width={compact ? "100%" : "320px"}
     >
       <Text bold={true} fg="#8be9fd">Projects</Text>
-      <Box flexDirection="column" marginTop={1}>
+      <Box flexDirection="column" marginTop={1} minHeight={0}>
         {dashboard.projects.length === 0
           ? <Text fg="#9fb8d5">Проекты не найдены.</Text>
           : dashboard.projects.map((project, index) => (
@@ -194,7 +250,10 @@ export const OutputPanel = ({ output }: { readonly output: string }): JSX.Elemen
     borderColor="#21486d"
     borderStyle="single"
     flexDirection="column"
+    flexGrow={1}
     marginTop={1}
+    minHeight={0}
+    overflowY="auto"
     padding={1}
   >
     <Text bold={true} fg="#8be9fd">Output</Text>

--- a/packages/app/src/web/panel-terminal.tsx
+++ b/packages/app/src/web/panel-terminal.tsx
@@ -17,11 +17,12 @@ type TerminalPanelProps = {
 
 const panelStyle: CSSProperties = {
   border: "1px solid #21486d",
-  borderRadius: "12px",
+  borderRadius: "8px",
   display: "flex",
+  flex: 1,
   flexDirection: "column",
   marginTop: "8px",
-  minHeight: "320px",
+  minHeight: 0,
   overflow: "hidden"
 }
 
@@ -38,7 +39,7 @@ const headerStyle: CSSProperties = {
 const bodyStyle: CSSProperties = {
   background: "#050b14",
   flex: 1,
-  minHeight: "280px",
+  minHeight: 0,
   padding: "8px"
 }
 

--- a/packages/app/src/web/terminal-panel-runtime.ts
+++ b/packages/app/src/web/terminal-panel-runtime.ts
@@ -9,14 +9,9 @@ import { parseTerminalServerMessage, resolveTerminalWebSocketUrl } from "./termi
 
 export type TerminalStatus = "attached" | "connecting" | "error" | "exited"
 
-export type TerminalConnectionState = {
-  opened: boolean
-}
+export type TerminalConnectionState = { opened: boolean }
 
-type TerminalRuntime = {
-  readonly fitAddon: FitAddon
-  readonly terminal: Terminal
-}
+type TerminalRuntime = { readonly fitAddon: FitAddon; readonly terminal: Terminal }
 
 type TerminalMessageHandlers = {
   readonly notifyMessage: (message: string) => void
@@ -39,6 +34,33 @@ type TerminalLifecycleArgs = {
   readonly notifyMessage: (message: string) => void
   readonly session: ActiveTerminalSession
   readonly setStatus: (status: TerminalStatus) => void
+}
+
+type TerminalSocketListenerArgs = {
+  readonly connectionRef: { current: TerminalConnectionState }
+  readonly onClose: () => void
+  readonly onError: () => void
+  readonly onMessage: (payload: string) => void
+  readonly onOpen: () => void
+  readonly socket: WebSocket
+}
+
+type TerminalSocketFailureHandlerArgs = {
+  readonly notifyMessage: (message: string) => void
+  readonly setStatus: (status: TerminalStatus) => void
+  readonly terminal: Terminal
+  readonly terminalLine: string
+  readonly uiMessage: string
+}
+
+type TerminalSessionSocketArgs = {
+  readonly connectionRef: { current: TerminalConnectionState }
+  readonly handlers: TerminalMessageHandlers
+  readonly notifyMessage: (message: string) => void
+  readonly sendResize: () => void
+  readonly setStatus: (status: TerminalStatus) => void
+  readonly socket: WebSocket
+  readonly terminal: Terminal
 }
 
 const requestSessionClose = (closePath: string): void => {
@@ -67,14 +89,7 @@ const createTerminalRuntime = (host: HTMLDivElement): TerminalRuntime => {
 const createTerminalSocket = (
   session: ActiveTerminalSession,
   terminal: Terminal
-): WebSocket =>
-  new WebSocket(
-    resolveTerminalWebSocketUrl(
-      session.websocketPath,
-      terminal.cols,
-      terminal.rows
-    )
-  )
+): WebSocket => new WebSocket(resolveTerminalWebSocketUrl(session.websocketPath, terminal.cols, terminal.rows))
 
 const sendTerminalResize = (
   fitAddon: FitAddon,
@@ -99,9 +114,7 @@ const observeTerminalResize = (
   if (typeof ResizeObserver !== "function") {
     return null
   }
-  const resizeObserver = new ResizeObserver(() => {
-    onResize()
-  })
+  const resizeObserver = new ResizeObserver(onResize)
   resizeObserver.observe(host)
   return resizeObserver
 }
@@ -151,11 +164,7 @@ const handleTerminalServerMessage = (
 }
 
 const attachTerminalSocketListeners = (
-  connectionRef: { current: TerminalConnectionState },
-  socket: WebSocket,
-  onOpen: () => void,
-  onMessage: (payload: string) => void,
-  onError: () => void
+  { connectionRef, onClose, onError, onMessage, onOpen, socket }: TerminalSocketListenerArgs
 ): void => {
   socket.addEventListener("open", () => {
     connectionRef.current.opened = true
@@ -163,6 +172,11 @@ const attachTerminalSocketListeners = (
   })
   socket.addEventListener("message", (event) => {
     onMessage(typeof event.data === "string" ? event.data : "")
+  })
+  socket.addEventListener("close", () => {
+    if (!connectionRef.current.opened) {
+      onClose()
+    }
   })
   socket.addEventListener("error", onError)
 }
@@ -192,15 +206,13 @@ const createMessageHandlers = (
   terminal
 })
 
-const createSocketErrorHandler = (
-  notifyMessage: (message: string) => void,
-  setStatus: (status: TerminalStatus) => void,
-  terminal: Terminal
+const createSocketFailureHandler = (
+  { notifyMessage, setStatus, terminal, terminalLine, uiMessage }: TerminalSocketFailureHandlerArgs
 ) =>
-() => {
-  terminal.writeln("\r\n[websocket error]")
+(): void => {
+  terminal.writeln(`\r\n${terminalLine}`)
   setStatus("error")
-  notifyMessage("Terminal websocket error.")
+  notifyMessage(uiMessage)
 }
 
 const maybeDeletePendingSession = (
@@ -213,6 +225,33 @@ const maybeDeletePendingSession = (
     notifyMessage(session.pendingDeleteMessage)
     session.onExit?.()
   }
+}
+
+const attachTerminalSessionSocket = (
+  { connectionRef, handlers, notifyMessage, sendResize, setStatus, socket, terminal }: TerminalSessionSocketArgs
+): void => {
+  attachTerminalSocketListeners({
+    connectionRef,
+    onClose: createSocketFailureHandler({
+      notifyMessage,
+      setStatus,
+      terminal,
+      terminalLine: "[websocket closed before attach]",
+      uiMessage: "Terminal websocket closed before attach."
+    }),
+    onError: createSocketFailureHandler({
+      notifyMessage,
+      setStatus,
+      terminal,
+      terminalLine: "[websocket error]",
+      uiMessage: "Terminal websocket error."
+    }),
+    onMessage: (payload) => {
+      handleTerminalServerMessage(handlers, payload)
+    },
+    onOpen: sendResize,
+    socket
+  })
 }
 
 const mountTerminalSession = (
@@ -239,15 +278,15 @@ const mountTerminalSession = (
   )
 
   globalThis.addEventListener("resize", sendResize)
-  attachTerminalSocketListeners(
+  attachTerminalSessionSocket({
     connectionRef,
-    socket,
+    handlers,
+    notifyMessage,
     sendResize,
-    (payload) => {
-      handleTerminalServerMessage(handlers, payload)
-    },
-    createSocketErrorHandler(notifyMessage, setStatus, terminal)
-  )
+    setStatus,
+    socket,
+    terminal
+  })
 
   return () => {
     cleanupTerminalResources({

--- a/packages/app/src/web/terminal.ts
+++ b/packages/app/src/web/terminal.ts
@@ -25,17 +25,7 @@ const resolveTerminalApiBaseUrl = (): string => {
     return trimTrailingSlash(configured.trim())
   }
 
-  const apiBaseUrl = resolveApiBaseUrl()
-  if (apiBaseUrl.startsWith("http://") || apiBaseUrl.startsWith("https://")) {
-    return apiBaseUrl
-  }
-
-  if (globalThis.location.protocol === "http:") {
-    const apiPort = import.meta.env.VITE_DOCKER_GIT_TERMINAL_API_PORT?.trim() || "3334"
-    return `http://${globalThis.location.hostname}:${apiPort}`
-  }
-
-  return apiBaseUrl
+  return resolveApiBaseUrl()
 }
 
 const resolveApiUrl = (): URL => {

--- a/packages/app/src/web/viewport-layout.ts
+++ b/packages/app/src/web/viewport-layout.ts
@@ -1,0 +1,39 @@
+export type ViewportLayoutMode = "desktop" | "tablet" | "mobile"
+
+export type ViewportSize = {
+  readonly height: number
+  readonly width: number
+}
+
+export type ViewportLayout = {
+  readonly compact: boolean
+  readonly dense: boolean
+  readonly fontSize: number
+  readonly mode: ViewportLayoutMode
+}
+
+export const stableWebFontSize = 13
+
+const mobileMaxWidth = 639
+const tabletMaxWidth = 1099
+const denseMaxHeight = 719
+
+export const resolveViewportLayoutMode = ({ width }: Pick<ViewportSize, "width">): ViewportLayoutMode => {
+  if (width <= mobileMaxWidth) {
+    return "mobile"
+  }
+  if (width <= tabletMaxWidth) {
+    return "tablet"
+  }
+  return "desktop"
+}
+
+export const resolveViewportLayout = (size: ViewportSize): ViewportLayout => {
+  const mode = resolveViewportLayoutMode(size)
+  return {
+    compact: mode !== "desktop",
+    dense: size.height <= denseMaxHeight,
+    fontSize: stableWebFontSize,
+    mode
+  }
+}

--- a/packages/app/tests/docker-git/terminal.test.ts
+++ b/packages/app/tests/docker-git/terminal.test.ts
@@ -38,7 +38,7 @@ describe("browser terminal helpers", () => {
     )
   })
 
-  it("falls back to direct local api origin for relative browser api paths", () => {
+  it("uses same-origin api proxy for relative browser api paths", () => {
     const host = "terminal.example.local"
     const httpProtocol = ["ht", "tp:"].join("")
     const wsProtocol = ["ws", "://"].join("")
@@ -53,7 +53,7 @@ describe("browser terminal helpers", () => {
     expect(resolveTerminalWebSocketUrl("/projects/proj/terminal-sessions/sess/ws", 80, 24)).toBe([
       wsProtocol,
       host,
-      ":3334/projects/proj/terminal-sessions/sess/ws?cols=80&rows=24"
+      ":4176/api/projects/proj/terminal-sessions/sess/ws?cols=80&rows=24"
     ].join(""))
   })
 

--- a/packages/app/tests/docker-git/viewport-layout.test.ts
+++ b/packages/app/tests/docker-git/viewport-layout.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest"
+
+import { resolveViewportLayout, stableWebFontSize } from "../../src/web/viewport-layout.js"
+
+describe("viewport layout", () => {
+  it("keeps desktop as a non-compact single-page layout", () => {
+    expect(resolveViewportLayout({ height: 900, width: 1440 })).toEqual({
+      compact: false,
+      dense: false,
+      fontSize: stableWebFontSize,
+      mode: "desktop"
+    })
+  })
+
+  it("uses compact tablet layout without changing font size", () => {
+    expect(resolveViewportLayout({ height: 768, width: 1024 })).toEqual({
+      compact: true,
+      dense: false,
+      fontSize: stableWebFontSize,
+      mode: "tablet"
+    })
+  })
+
+  it("uses compact dense mobile layout", () => {
+    expect(resolveViewportLayout({ height: 640, width: 390 })).toEqual({
+      compact: true,
+      dense: true,
+      fontSize: stableWebFontSize,
+      mode: "mobile"
+    })
+  })
+})

--- a/packages/app/vite.web.config.ts
+++ b/packages/app/vite.web.config.ts
@@ -1,41 +1,97 @@
 import path from "node:path"
+import type { IncomingMessage } from "node:http"
+import type { Duplex } from "node:stream"
 import { fileURLToPath } from "node:url"
 
 import { gridlandWebPlugin } from "@gridland/web/vite-plugin"
 import react from "@vitejs/plugin-react"
-import { defineConfig, loadEnv } from "vite"
+import { defineConfig, loadEnv, type PluginOption } from "vite"
+import { WebSocket, WebSocketServer } from "ws"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
 const defaultApiTarget = "http://127.0.0.1:3334"
-const terminalWsProxyPath = "^/api/projects/.+/terminal-sessions/.+/ws$"
 const noStoreHeaders = {
   "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
   Pragma: "no-cache"
 }
 
-const createProxy = (apiTarget: string, apiWsTarget: string) => ({
-  [terminalWsProxyPath]: {
-    target: apiWsTarget,
-    changeOrigin: true,
-    ws: true,
-    rewrite: (requestPath: string) => requestPath.replace(/^\/api/u, "")
-  },
+const createProxy = (apiTarget: string) => ({
   "/api": {
     target: apiTarget,
     changeOrigin: true,
-    ws: true,
+    ws: false,
     rewrite: (requestPath: string) => requestPath.replace(/^\/api/u, "")
+  }
+})
+
+const resolveUpstreamPath = (requestUrl: string | undefined): string => {
+  const parsed = new URL(requestUrl ?? "/", "http://localhost")
+  const pathname = parsed.pathname.replace(/^\/api/u, "") || "/"
+  return `${pathname}${parsed.search}`
+}
+
+const isTerminalWebSocketRequest = (request: IncomingMessage): boolean => {
+  const parsed = new URL(request.url ?? "/", "http://localhost")
+  return parsed.pathname.startsWith("/api/") && parsed.pathname.endsWith("/ws")
+}
+
+const proxyTerminalWebSocket = (
+  apiTarget: string,
+  request: IncomingMessage,
+  socket: Duplex,
+  head: Buffer,
+  webSocketServer: WebSocketServer
+): void => {
+  const apiUrl = new URL(apiTarget)
+  apiUrl.protocol = apiUrl.protocol === "https:" ? "wss:" : "ws:"
+  const upstream = new WebSocket(`${apiUrl.origin}${resolveUpstreamPath(request.url)}`)
+
+  upstream.on("open", () => {
+    webSocketServer.handleUpgrade(request, socket, head, (clientSocket) => {
+      clientSocket.on("message", (data, isBinary) => {
+        upstream.send(data, { binary: isBinary })
+      })
+      clientSocket.on("close", () => {
+        upstream.close()
+      })
+      upstream.on("message", (data, isBinary) => {
+        clientSocket.send(data, { binary: isBinary })
+      })
+      upstream.on("close", () => {
+        clientSocket.close()
+      })
+      upstream.on("error", () => {
+        clientSocket.close()
+      })
+    })
+  })
+
+  upstream.on("error", () => {
+    socket.destroy()
+  })
+}
+
+const terminalWebSocketProxyPlugin = (apiTarget: string): PluginOption => ({
+  name: "docker-git-terminal-websocket-proxy",
+  configureServer(server) {
+    const webSocketServer = new WebSocketServer({ noServer: true })
+    server.httpServer?.prependListener("upgrade", (request, socket, head) => {
+      if (!isTerminalWebSocketRequest(request)) {
+        return
+      }
+      proxyTerminalWebSocket(apiTarget, request, socket, head, webSocketServer)
+    })
   }
 })
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, __dirname, "")
   const apiTarget = env["DOCKER_GIT_API_URL"]?.trim() || defaultApiTarget
-  const apiWsTarget = apiTarget.replace(/^http/u, "ws")
 
   return {
     plugins: [
+      terminalWebSocketProxyPlugin(apiTarget),
       ...gridlandWebPlugin(),
       react()
     ],
@@ -65,7 +121,7 @@ export default defineConfig(({ mode }) => {
       port: 4174,
       allowedHosts: [".trycloudflare.com"],
       headers: noStoreHeaders,
-      proxy: createProxy(apiTarget, apiWsTarget)
+      proxy: createProxy(apiTarget)
     },
     preview: {
       host: "127.0.0.1",


### PR DESCRIPTION
## Summary
- keep the browser UI inside a single viewport with adaptive compact panels
- route terminal WebSocket connections through the browser API proxy instead of direct API port
- surface WebSocket close-before-open as an explicit terminal error

## Verification
- bun run --cwd packages/app lint
- bun run --cwd packages/app typecheck
- bun run --cwd packages/app test
- bun run --cwd packages/app build:web
- git diff --check
- gh pr checks 219 --watch --fail-fast (previous PR remained green before this follow-up PR)