### PR TITLE
[codex] harden web ssh terminal reconnect

### DIFF
--- a/packages/api/src/services/auth-terminal-sessions.ts
+++ b/packages/api/src/services/auth-terminal-sessions.ts
@@ -10,6 +10,7 @@ import { WebSocket, WebSocketServer, type RawData } from "ws"
 import type { AuthTerminalFlow, AuthTerminalSessionRequest, TerminalSession, TerminalSessionStatus } from "../api/contracts.js"
 import { ApiConflictError, ApiNotFoundError, describeUnknown } from "../api/errors.js"
 import { spawnPtyBridge, type PtyBridge } from "./pty-bridge.js"
+import { attachWebSocketHeartbeat } from "./websocket-heartbeat.js"
 
 type TerminalClientMessage =
   | { readonly type: "input"; readonly data: string }
@@ -26,12 +27,14 @@ type AuthTerminalRecord = {
   attachTimeout: ReturnType<typeof setTimeout> | null
   args: ReadonlyArray<string>
   cwd: string
+  detachTimeout: ReturnType<typeof setTimeout> | null
   pty: PtyBridge | null
   session: TerminalSession
   socket: WebSocket | null
 }
 
 const attachTimeoutMs = 30_000
+const reconnectGraceMs = 60_000
 const authTerminalProjectId = "__controller__"
 const authTerminalWsPathPattern = /^(?:\/api)?\/auth\/terminal-sessions\/([^/]+)\/ws$/u
 const authRunnerPath = fileURLToPath(new URL("../auth-terminal-runner.js", import.meta.url))
@@ -95,6 +98,13 @@ const clearAttachTimeout = (record: AuthTerminalRecord): void => {
   }
 }
 
+const clearDetachTimeout = (record: AuthTerminalRecord): void => {
+  if (record.detachTimeout !== null) {
+    clearTimeout(record.detachTimeout)
+    record.detachTimeout = null
+  }
+}
+
 const closeSocket = (socket: WebSocket | null): void => {
   if (socket === null || socket.readyState === WebSocket.CLOSED) {
     return
@@ -104,6 +114,7 @@ const closeSocket = (socket: WebSocket | null): void => {
 
 const cleanupRecord = (record: AuthTerminalRecord): void => {
   clearAttachTimeout(record)
+  clearDetachTimeout(record)
   if (record.pty !== null) {
     record.pty.kill()
     record.pty = null
@@ -130,6 +141,7 @@ const finalizeRecord = (
   record.socket = null
   record.pty = null
   clearAttachTimeout(record)
+  clearDetachTimeout(record)
   records.delete(record.session.id)
 }
 
@@ -172,6 +184,10 @@ const resizePty = (pty: PtyBridge | null, cols: number, rows: number): void => {
 }
 
 const startTerminalPty = (record: AuthTerminalRecord, cols: number, rows: number): void => {
+  if (record.pty !== null) {
+    resizePty(record.pty, clampTerminalSize(cols, 120), clampTerminalSize(rows, 32))
+    return
+  }
   const pty = spawnPtyBridge({
     args: record.args,
     cols: clampTerminalSize(cols, 120),
@@ -217,6 +233,7 @@ const registerRecord = (request: AuthTerminalSessionRequest): TerminalSession =>
     args: resolveRunnerArgs(request.flow, request.label),
     attachTimeout: null,
     cwd: process.cwd(),
+    detachTimeout: null,
     pty: null,
     session,
     socket: null
@@ -224,6 +241,27 @@ const registerRecord = (request: AuthTerminalSessionRequest): TerminalSession =>
   record.attachTimeout = createAttachTimeout(session.id)
   records.set(session.id, record)
   return session
+}
+
+const createDetachTimeout = (sessionId: string): ReturnType<typeof setTimeout> =>
+  setTimeout(() => {
+    const record = records.get(sessionId)
+    if (record !== undefined && record.socket === null) {
+      cleanupRecord(record)
+    }
+  }, reconnectGraceMs)
+
+const detachSocketFromRecord = (
+  record: AuthTerminalRecord,
+  socket: WebSocket
+): void => {
+  const current = records.get(record.session.id)
+  if (current === undefined || current.socket !== socket) {
+    return
+  }
+  current.socket = null
+  clearDetachTimeout(current)
+  current.detachTimeout = createDetachTimeout(current.session.id)
 }
 
 const handleSocketMessage = (record: AuthTerminalRecord, raw: RawData): void => {
@@ -249,21 +287,20 @@ const attachSocketToRecord = (
   cols: number,
   rows: number
 ): void => {
-  if (record.socket !== null) {
+  if (record.socket !== null && record.socket.readyState !== WebSocket.CLOSED) {
     throw new ApiConflictError({ message: `Auth terminal session already attached: ${record.session.id}` })
   }
   clearAttachTimeout(record)
+  clearDetachTimeout(record)
   record.socket = socket
+  attachWebSocketHeartbeat(socket)
   startTerminalPty(record, cols, rows)
   sendServerMessage(socket, { type: "ready", session: record.session })
   socket.on("message", (raw: RawData) => {
     handleSocketMessage(record, raw)
   })
   socket.on("close", () => {
-    const current = records.get(record.session.id)
-    if (current !== undefined) {
-      cleanupRecord(current)
-    }
+    detachSocketFromRecord(record, socket)
   })
 }
 

--- a/packages/api/src/services/terminal-sessions.ts
+++ b/packages/api/src/services/terminal-sessions.ts
@@ -17,6 +17,7 @@ import { ApiConflictError, ApiInternalError, ApiNotFoundError, describeUnknown }
 import { spawnPtyBridge, type PtyBridge } from "./pty-bridge.js"
 import { emitProjectEvent } from "./events.js"
 import { getProjectItemById, upProject } from "./projects.js"
+import { attachWebSocketHeartbeat } from "./websocket-heartbeat.js"
 
 type TerminalClientMessage =
   | { readonly type: "input"; readonly data: string }
@@ -34,12 +35,14 @@ type TerminalRecord = {
   pty: PtyBridge | null
   socket: WebSocket | null
   attachTimeout: ReturnType<typeof setTimeout> | null
+  detachTimeout: ReturnType<typeof setTimeout> | null
   projectId: string
   prepared: ReturnType<typeof prepareProjectSsh>
 }
 
 const records = new Map<string, TerminalRecord>()
 const attachTimeoutMs = 30_000
+const reconnectGraceMs = 60_000
 const terminalWsPathPattern = /^(?:\/api)?\/projects\/([^/]+)\/terminal-sessions\/([^/]+)\/ws$/u
 
 const TerminalClientMessageSchema = Schema.parseJson(
@@ -187,6 +190,13 @@ const clearAttachTimeout = (record: TerminalRecord): void => {
   }
 }
 
+const clearDetachTimeout = (record: TerminalRecord): void => {
+  if (record.detachTimeout !== null) {
+    clearTimeout(record.detachTimeout)
+    record.detachTimeout = null
+  }
+}
+
 const closeSocket = (socket: WebSocket | null): void => {
   if (socket === null || socket.readyState === WebSocket.CLOSED) {
     return
@@ -196,6 +206,7 @@ const closeSocket = (socket: WebSocket | null): void => {
 
 const cleanupRecord = (record: TerminalRecord): void => {
   clearAttachTimeout(record)
+  clearDetachTimeout(record)
   if (record.pty !== null) {
     record.pty.kill()
     record.pty = null
@@ -222,6 +233,7 @@ const finalizeRecord = (
   record.socket = null
   record.pty = null
   clearAttachTimeout(record)
+  clearDetachTimeout(record)
   records.delete(record.session.id)
 }
 
@@ -268,6 +280,10 @@ const startTerminalPty = (
   cols: number,
   rows: number
 ): void => {
+  if (record.pty !== null) {
+    resizePty(record.pty, clampTerminalSize(cols, 120), clampTerminalSize(rows, 32))
+    return
+  }
   const resolvedCols = clampTerminalSize(cols, 120)
   const resolvedRows = clampTerminalSize(rows, 32)
   const pty = spawnPtyBridge({
@@ -316,6 +332,7 @@ const registerRecord = (
   }
   const record: TerminalRecord = {
     attachTimeout: null,
+    detachTimeout: null,
     prepared,
     projectId,
     pty: null,
@@ -399,6 +416,27 @@ const handleCloseMessage = (record: TerminalRecord): void => {
   cleanupRecord(record)
 }
 
+const createDetachTimeout = (sessionId: string): ReturnType<typeof setTimeout> =>
+  setTimeout(() => {
+    const record = records.get(sessionId)
+    if (record !== undefined && record.socket === null) {
+      cleanupRecord(record)
+    }
+  }, reconnectGraceMs)
+
+const detachSocketFromRecord = (
+  record: TerminalRecord,
+  socket: WebSocket
+): void => {
+  const current = records.get(record.session.id)
+  if (current === undefined || current.socket !== socket) {
+    return
+  }
+  current.socket = null
+  clearDetachTimeout(current)
+  current.detachTimeout = createDetachTimeout(current.session.id)
+}
+
 const handleSocketMessage = (record: TerminalRecord, raw: RawData): void => {
   const message = decodeClientMessage(raw)
   if (message === null) {
@@ -422,22 +460,21 @@ const attachSocketToRecord = (
   cols: number,
   rows: number
 ): void => {
-  if (record.socket !== null) {
+  if (record.socket !== null && record.socket.readyState !== WebSocket.CLOSED) {
     throw new ApiConflictError({ message: `Terminal session already attached: ${record.session.id}` })
   }
 
   clearAttachTimeout(record)
+  clearDetachTimeout(record)
   record.socket = socket
+  attachWebSocketHeartbeat(socket)
   startTerminalPty(record, cols, rows)
   sendServerMessage(socket, { type: "ready", session: record.session })
   socket.on("message", (raw: RawData) => {
     handleSocketMessage(record, raw)
   })
   socket.on("close", () => {
-    const current = records.get(record.session.id)
-    if (current !== undefined) {
-      cleanupRecord(current)
-    }
+    detachSocketFromRecord(record, socket)
   })
 }
 

--- a/packages/api/src/services/websocket-heartbeat.ts
+++ b/packages/api/src/services/websocket-heartbeat.ts
@@ -1,0 +1,31 @@
+import { WebSocket } from "ws"
+
+const defaultHeartbeatIntervalMs = 25_000
+
+export const attachWebSocketHeartbeat = (
+  socket: WebSocket,
+  intervalMs = defaultHeartbeatIntervalMs
+): void => {
+  let alive = true
+  const interval = setInterval(() => {
+    if (socket.readyState !== WebSocket.OPEN) {
+      return
+    }
+    if (!alive) {
+      socket.terminate()
+      return
+    }
+    alive = false
+    socket.ping()
+  }, intervalMs)
+
+  socket.on("pong", () => {
+    alive = true
+  })
+  socket.on("close", () => {
+    clearInterval(interval)
+  })
+  socket.on("error", () => {
+    clearInterval(interval)
+  })
+}

--- a/packages/app/scripts/serve-dist-web.mjs
+++ b/packages/app/scripts/serve-dist-web.mjs
@@ -176,6 +176,32 @@ const proxyHttp = (
 }
 
 const webSocketServer = new WebSocketServer({ noServer: true })
+const webSocketHeartbeatIntervalMs = 25_000
+
+const attachWebSocketHeartbeat = (socket) => {
+  let alive = true
+  const interval = setInterval(() => {
+    if (socket.readyState !== WebSocket.OPEN) {
+      return
+    }
+    if (!alive) {
+      socket.terminate()
+      return
+    }
+    alive = false
+    socket.ping()
+  }, webSocketHeartbeatIntervalMs)
+
+  socket.on("pong", () => {
+    alive = true
+  })
+  socket.on("close", () => {
+    clearInterval(interval)
+  })
+  socket.on("error", () => {
+    clearInterval(interval)
+  })
+}
 
 const bridgeWebSockets = (clientSocket, upstream) => {
   const pending = []
@@ -184,6 +210,8 @@ const bridgeWebSockets = (clientSocket, upstream) => {
       socket.send(data, { binary: isBinary })
     }
   }
+  attachWebSocketHeartbeat(clientSocket)
+  attachWebSocketHeartbeat(upstream)
   const flushPending = () => {
     for (const message of pending.splice(0)) {
       sendWhenOpen(upstream, message.data, message.isBinary)

--- a/packages/app/src/lib/usecases/projects-ssh.ts
+++ b/packages/app/src/lib/usecases/projects-ssh.ts
@@ -55,6 +55,10 @@ const buildSshArgs = (item: ProjectItem): ReadonlyArray<string> => {
     "StrictHostKeyChecking=no",
     "-o",
     "UserKnownHostsFile=/dev/null",
+    "-o",
+    "ServerAliveInterval=30",
+    "-o",
+    "ServerAliveCountMax=3",
     "-p",
     String(port),
     `${item.sshUser}@${host}`

--- a/packages/app/src/web/app-dashboard-state.ts
+++ b/packages/app/src/web/app-dashboard-state.ts
@@ -12,3 +12,8 @@ export const mergeDashboardRefreshState = (
   next._tag === "Error" && current._tag === "Ready"
     ? current
     : next
+
+export const createDashboardRefreshReducer =
+  (next: DashboardState) =>
+  (current: DashboardState): DashboardState =>
+    mergeDashboardRefreshState(current, next)

--- a/packages/app/src/web/app-dashboard-state.ts
+++ b/packages/app/src/web/app-dashboard-state.ts
@@ -1,0 +1,14 @@
+import type { DashboardData } from "./api.js"
+
+export type DashboardState =
+  | { readonly _tag: "Loading"; readonly apiBaseUrl: string }
+  | { readonly _tag: "Error"; readonly apiBaseUrl: string; readonly message: string }
+  | { readonly _tag: "Ready"; readonly dashboard: DashboardData; readonly refreshedAtMs: number }
+
+export const mergeDashboardRefreshState = (
+  current: DashboardState,
+  next: DashboardState
+): DashboardState =>
+  next._tag === "Error" && current._tag === "Ready"
+    ? current
+    : next

--- a/packages/app/src/web/app-ready-terminal-screen.tsx
+++ b/packages/app/src/web/app-ready-terminal-screen.tsx
@@ -1,5 +1,7 @@
+import { Effect } from "effect"
 import type { JSX } from "react"
 
+import { deleteTerminalSessionByPath } from "./api.js"
 import { canOpenProjectBrowser } from "./app-ready-browser-openable.js"
 import type { ReadyLayoutProps } from "./app-ready-layout.js"
 import { Box } from "./elements.js"
@@ -16,20 +18,26 @@ type TerminalScreenProps = Pick<
   | "terminalSession"
 >
 
+const requestTerminalSessionClose = (closePath: string): void => {
+  void Effect.runPromise(deleteTerminalSessionByPath(closePath).pipe(Effect.either, Effect.asVoid))
+}
+
 export const TerminalScreen = (props: TerminalScreenProps): JSX.Element | null => {
-  if (props.terminalSession === null) {
+  const terminalSession = props.terminalSession
+  if (terminalSession === null) {
     return null
   }
-  const browserProjectId = props.terminalSession.browserProjectId
+  const browserProjectId = terminalSession.browserProjectId
   const canOpenBrowser = canOpenProjectBrowser(props.projectBrowser, browserProjectId)
-  const returnScreen: BrowserScreen = props.terminalSession.closePath.startsWith("/auth/")
+  const returnScreen: BrowserScreen = terminalSession.closePath.startsWith("/auth/")
     ? { tag: "Auth" }
     : projectPickerScreen()
   return (
     <Box flexDirection="column" flexGrow={1} minHeight={0} overflow="hidden">
       <TerminalPanel
-        key={props.terminalSession.session.id}
+        key={terminalSession.session.id}
         onClose={() => {
+          requestTerminalSessionClose(terminalSession.closePath)
           props.onTerminalClose()
           props.onSetActiveScreen(returnScreen)
         }}
@@ -39,7 +47,7 @@ export const TerminalScreen = (props: TerminalScreenProps): JSX.Element | null =
             props.onOpenProjectBrowserById(browserProjectId)
           }}
         onMessage={props.onTerminalMessage}
-        session={props.terminalSession}
+        session={terminalSession}
       />
     </Box>
   )

--- a/packages/app/src/web/app.tsx
+++ b/packages/app/src/web/app.tsx
@@ -3,15 +3,11 @@ import { type JSX, startTransition, useEffect, useEffectEvent, useState } from "
 
 import { webPrimitives } from "../ui/primitives-web.js"
 import { UiProvider } from "../ui/primitives.js"
-import { type DashboardData, loadDashboard, resolveApiBaseUrl } from "./api.js"
+import { loadDashboard, resolveApiBaseUrl } from "./api.js"
+import { type DashboardState, mergeDashboardRefreshState } from "./app-dashboard-state.js"
 import { AppReady } from "./app-ready.js"
 import { ErrorScreen, LoadingScreen } from "./panels.js"
 import { resolveViewportLayout, type ViewportLayout, type ViewportSize } from "./viewport-layout.js"
-
-type DashboardState =
-  | { readonly _tag: "Loading"; readonly apiBaseUrl: string }
-  | { readonly _tag: "Error"; readonly apiBaseUrl: string; readonly message: string }
-  | { readonly _tag: "Ready"; readonly dashboard: DashboardData; readonly refreshedAtMs: number }
 
 const refreshIntervalMs = 15_000
 
@@ -73,7 +69,7 @@ const useDashboardController = () => {
   const refresh = () => {
     void Effect.runPromise(loadDashboardState()).then((nextState) => {
       startTransition(() => {
-        setState(nextState)
+        setState((current) => mergeDashboardRefreshState(current, nextState))
       })
     })
   }

--- a/packages/app/src/web/app.tsx
+++ b/packages/app/src/web/app.tsx
@@ -4,7 +4,7 @@ import { type JSX, startTransition, useEffect, useEffectEvent, useState } from "
 import { webPrimitives } from "../ui/primitives-web.js"
 import { UiProvider } from "../ui/primitives.js"
 import { loadDashboard, resolveApiBaseUrl } from "./api.js"
-import { type DashboardState, mergeDashboardRefreshState } from "./app-dashboard-state.js"
+import { createDashboardRefreshReducer, type DashboardState } from "./app-dashboard-state.js"
 import { AppReady } from "./app-ready.js"
 import { ErrorScreen, LoadingScreen } from "./panels.js"
 import { resolveViewportLayout, type ViewportLayout, type ViewportSize } from "./viewport-layout.js"
@@ -69,7 +69,7 @@ const useDashboardController = () => {
   const refresh = () => {
     void Effect.runPromise(loadDashboardState()).then((nextState) => {
       startTransition(() => {
-        setState((current) => mergeDashboardRefreshState(current, nextState))
+        setState(createDashboardRefreshReducer(nextState))
       })
     })
   }

--- a/packages/app/src/web/panel-terminal.tsx
+++ b/packages/app/src/web/panel-terminal.tsx
@@ -122,7 +122,7 @@ const TerminalHeader = (
 export const TerminalPanel = (
   { onClose, onMessage, onOpenBrowser, session }: TerminalPanelProps
 ): JSX.Element => {
-  const connectionRef = useRef<TerminalConnectionState>({ opened: false })
+  const connectionRef = useRef<TerminalConnectionState>({ closing: false, opened: false })
   const hostRef = useRef<HTMLDivElement | null>(null)
   const [status, setStatus] = useState<TerminalStatus>("connecting")
   const notifyMessage = useEffectEvent(onMessage)
@@ -137,7 +137,15 @@ export const TerminalPanel = (
 
   return (
     <div style={panelStyle}>
-      <TerminalHeader onClose={onClose} onOpenBrowser={onOpenBrowser} session={session} status={status} />
+      <TerminalHeader
+        onClose={() => {
+          connectionRef.current.closing = true
+          onClose()
+        }}
+        onOpenBrowser={onOpenBrowser}
+        session={session}
+        status={status}
+      />
       <div ref={hostRef} style={bodyStyle} />
     </div>
   )

--- a/packages/app/src/web/terminal-panel-runtime-core.ts
+++ b/packages/app/src/web/terminal-panel-runtime-core.ts
@@ -1,0 +1,307 @@
+import { Effect, Either } from "effect"
+import { Terminal } from "xterm"
+import { FitAddon } from "xterm-addon-fit"
+
+import { deleteTerminalSessionByPath } from "./api.js"
+import type {
+  TerminalCleanupArgs,
+  TerminalLifecycleState,
+  TerminalMessageHandlers,
+  TerminalRuntime,
+  TerminalSocketConnectArgs,
+  TerminalSocketListenerArgs,
+  TerminalSocketRef
+} from "./terminal-panel-runtime-types.js"
+import { resolveTerminalReconnectDelay, terminalReconnectGraceMs } from "./terminal-reconnect.js"
+import { parseTerminalServerMessage, resolveTerminalWebSocketUrl } from "./terminal.js"
+
+const requestSessionClose = (closePath: string): void => {
+  void Effect.runPromise(deleteTerminalSessionByPath(closePath).pipe(Effect.either, Effect.asVoid))
+}
+
+const runOptionalTerminalOperation = (operation: () => void): boolean =>
+  Either.isRight(
+    Effect.runSync(
+      Effect.either(
+        Effect.try({
+          try: operation,
+          catch: (error) => error
+        })
+      )
+    )
+  )
+
+export const createLifecycleState = (): TerminalLifecycleState => ({
+  attachedOnce: false,
+  disposed: false,
+  readyNotified: false,
+  reconnectAttempt: 0,
+  reconnectStartedAtMs: null,
+  reconnectTimer: null,
+  terminalEnded: false
+})
+
+const clearReconnectTimer = (lifecycle: TerminalLifecycleState): void => {
+  if (lifecycle.reconnectTimer !== null) {
+    clearTimeout(lifecycle.reconnectTimer)
+    lifecycle.reconnectTimer = null
+  }
+}
+
+export const createTerminalRuntime = (host: HTMLDivElement): TerminalRuntime => {
+  const terminal = new Terminal({
+    convertEol: false,
+    cursorBlink: true,
+    fontFamily: "'IBM Plex Mono', 'SFMono-Regular', monospace",
+    fontSize: 14,
+    theme: { background: "#080a0d", foreground: "#f4f7fb" }
+  })
+  const fitAddon = new FitAddon()
+  terminal.loadAddon(fitAddon)
+  terminal.open(host)
+  fitAddon.fit()
+  terminal.focus()
+  return { fitAddon, terminal }
+}
+
+const createTerminalSocket = (
+  session: TerminalSocketConnectArgs["session"],
+  terminal: Terminal
+): WebSocket => new WebSocket(resolveTerminalWebSocketUrl(session.websocketPath, terminal.cols, terminal.rows))
+
+export const sendTerminalResize = (
+  fitAddon: FitAddon,
+  socketRef: TerminalSocketRef,
+  terminal: Terminal
+): void => {
+  if (
+    !runOptionalTerminalOperation(() => {
+      fitAddon.fit()
+    })
+  ) {
+    return
+  }
+  const socket = socketRef.current
+  if (socket === null || socket.readyState !== WebSocket.OPEN) {
+    return
+  }
+  socket.send(JSON.stringify({
+    cols: terminal.cols,
+    rows: terminal.rows,
+    type: "resize"
+  }))
+}
+
+export const observeTerminalResize = (
+  host: HTMLDivElement,
+  onResize: () => void
+): ResizeObserver | null => {
+  if (typeof ResizeObserver !== "function") {
+    return null
+  }
+  const resizeObserver = new ResizeObserver(onResize)
+  resizeObserver.observe(host)
+  return resizeObserver
+}
+
+export const attachTerminalInput = (
+  terminal: Terminal,
+  socketRef: TerminalSocketRef
+) =>
+  terminal.onData((data) => {
+    const socket = socketRef.current
+    if (socket === null || socket.readyState !== WebSocket.OPEN) {
+      return
+    }
+    socket.send(JSON.stringify({ data, type: "input" }))
+  })
+
+const notifyTerminalReady = (
+  handlers: TerminalMessageHandlers
+): void => {
+  handlers.lifecycle.attachedOnce = true
+  handlers.connectionRef.current.opened = true
+  handlers.lifecycle.reconnectAttempt = 0
+  handlers.lifecycle.reconnectStartedAtMs = null
+  clearReconnectTimer(handlers.lifecycle)
+  handlers.setStatus("attached")
+  if (handlers.lifecycle.readyNotified) {
+    handlers.notifyMessage("Terminal reconnected.")
+    return
+  }
+  handlers.lifecycle.readyNotified = true
+  handlers.notifyMessage(handlers.session.readyMessage)
+  handlers.session.onReady?.()
+}
+
+const endTerminalSession = (
+  handlers: TerminalMessageHandlers,
+  status: "error" | "exited",
+  line: string,
+  message: string
+): void => {
+  handlers.lifecycle.terminalEnded = true
+  clearReconnectTimer(handlers.lifecycle)
+  handlers.terminal.writeln(line)
+  handlers.setStatus(status)
+  handlers.notifyMessage(message)
+  if (status === "exited") {
+    handlers.session.onExit?.()
+  }
+}
+
+const handleTerminalServerMessage = (
+  handlers: TerminalMessageHandlers,
+  payload: string
+): void => {
+  const message = parseTerminalServerMessage(payload)
+  if (message === null) {
+    endTerminalSession(handlers, "error", "\r\n[terminal protocol error]", "Terminal protocol error.")
+    return
+  }
+  if (message.type === "ready") {
+    notifyTerminalReady(handlers)
+    return
+  }
+  if (message.type === "output") {
+    handlers.terminal.write(message.data)
+    return
+  }
+  if (message.type === "error") {
+    endTerminalSession(handlers, "error", `\r\n[error] ${message.message}`, message.message)
+    return
+  }
+  endTerminalSession(handlers, "exited", "\r\n[session ended]", handlers.session.exitMessage)
+}
+
+const attachTerminalSocketListeners = (
+  { lifecycle, onClose, onError, onMessage, onOpen, socket }: TerminalSocketListenerArgs
+): void => {
+  socket.addEventListener("open", onOpen)
+  socket.addEventListener("message", (event) => {
+    onMessage(typeof event.data === "string" ? event.data : "")
+  })
+  socket.addEventListener("close", () => {
+    onClose(socket)
+  })
+  socket.addEventListener("error", () => {
+    if (!lifecycle.disposed) {
+      onError(socket)
+    }
+  })
+}
+
+const closeSocket = (socket: WebSocket | null): void => {
+  if (socket === null || socket.readyState === WebSocket.CLOSED) {
+    return
+  }
+  runOptionalTerminalOperation(() => {
+    socket.close()
+  })
+}
+
+export const cleanupTerminalResources = (
+  args: TerminalCleanupArgs
+): void => {
+  args.lifecycle.disposed = true
+  clearReconnectTimer(args.lifecycle)
+  args.removeInput()
+  args.resizeObserver?.disconnect()
+  args.removeResize()
+  closeSocket(args.socketRef.current)
+  args.socketRef.current = null
+  args.terminal.dispose()
+  if (!args.connectionRef.current.opened && !args.connectionRef.current.closing) {
+    requestSessionClose(args.session.closePath)
+    args.notifyMessage(args.session.pendingDeleteMessage)
+    args.session.onExit?.()
+  }
+}
+
+export const createMessageHandlers = (
+  args:
+    & Omit<TerminalMessageHandlers, "terminal">
+    & { readonly terminal: Terminal }
+): TerminalMessageHandlers => args
+
+const failBeforeAttach = (
+  args: TerminalSocketConnectArgs,
+  terminalLine: string,
+  uiMessage: string
+): void => {
+  args.lifecycle.terminalEnded = true
+  clearReconnectTimer(args.lifecycle)
+  args.terminal.writeln(`\r\n${terminalLine}`)
+  args.setStatus("error")
+  args.notifyMessage(uiMessage)
+  requestSessionClose(args.session.closePath)
+}
+
+const scheduleReconnect = (args: TerminalSocketConnectArgs): void => {
+  if (args.lifecycle.disposed || args.lifecycle.terminalEnded) {
+    return
+  }
+  const startedAt = args.lifecycle.reconnectStartedAtMs ?? Date.now()
+  args.lifecycle.reconnectStartedAtMs = startedAt
+  if (Date.now() - startedAt >= terminalReconnectGraceMs) {
+    failBeforeAttach(args, "[terminal reconnect failed]", "Terminal reconnect failed.")
+    return
+  }
+  if (args.lifecycle.reconnectAttempt === 0) {
+    args.terminal.writeln("\r\n[terminal connection lost; reconnecting]")
+    args.notifyMessage("Terminal connection lost. Reconnecting...")
+  }
+  args.setStatus("reconnecting")
+  const delayMs = resolveTerminalReconnectDelay(args.lifecycle.reconnectAttempt)
+  args.lifecycle.reconnectAttempt += 1
+  clearReconnectTimer(args.lifecycle)
+  args.lifecycle.reconnectTimer = setTimeout(args.reconnect, delayMs)
+}
+
+const handleSocketClose = (
+  args: TerminalSocketConnectArgs,
+  closedSocket: WebSocket
+): void => {
+  if (args.socketRef.current !== closedSocket) {
+    return
+  }
+  args.socketRef.current = null
+  if (args.lifecycle.disposed || args.lifecycle.terminalEnded) {
+    return
+  }
+  if (!args.lifecycle.attachedOnce) {
+    failBeforeAttach(args, "[websocket closed before attach]", "Terminal websocket closed before attach.")
+    return
+  }
+  scheduleReconnect(args)
+}
+const handleSocketError = (
+  args: TerminalSocketConnectArgs,
+  failedSocket: WebSocket
+): void => {
+  if (args.socketRef.current !== failedSocket || args.lifecycle.attachedOnce) {
+    return
+  }
+  failBeforeAttach(args, "[websocket error]", "Terminal websocket error.")
+}
+export const connectTerminalSocket = (args: TerminalSocketConnectArgs): void => {
+  if (args.lifecycle.disposed || args.lifecycle.terminalEnded) {
+    return
+  }
+  const socket = createTerminalSocket(args.session, args.terminal)
+  args.socketRef.current = socket
+  attachTerminalSocketListeners({
+    lifecycle: args.lifecycle,
+    onClose: (closedSocket) => {
+      handleSocketClose(args, closedSocket)
+    },
+    onError: (failedSocket) => {
+      handleSocketError(args, failedSocket)
+    },
+    onMessage: (payload) => {
+      handleTerminalServerMessage(args.handlers, payload)
+    },
+    onOpen: args.sendResize,
+    socket
+  })
+}

--- a/packages/app/src/web/terminal-panel-runtime-types.ts
+++ b/packages/app/src/web/terminal-panel-runtime-types.ts
@@ -1,0 +1,72 @@
+import type { Terminal } from "xterm"
+import type { FitAddon } from "xterm-addon-fit"
+
+import type { ActiveTerminalSession } from "./terminal.js"
+
+export type TerminalStatus = "attached" | "connecting" | "error" | "exited" | "reconnecting"
+
+export type TerminalConnectionState = { closing: boolean; opened: boolean }
+
+export type TerminalRuntime = { readonly fitAddon: FitAddon; readonly terminal: Terminal }
+
+export type TerminalLifecycleState = {
+  attachedOnce: boolean
+  disposed: boolean
+  readyNotified: boolean
+  reconnectAttempt: number
+  reconnectStartedAtMs: number | null
+  reconnectTimer: ReturnType<typeof setTimeout> | null
+  terminalEnded: boolean
+}
+
+export type TerminalSocketRef = { current: WebSocket | null }
+
+export type TerminalMessageHandlers = {
+  readonly connectionRef: { current: TerminalConnectionState }
+  readonly lifecycle: TerminalLifecycleState
+  readonly notifyMessage: (message: string) => void
+  readonly session: ActiveTerminalSession
+  readonly setStatus: (status: TerminalStatus) => void
+  readonly terminal: Terminal
+}
+
+export type TerminalCleanupArgs = {
+  readonly connectionRef: { current: TerminalConnectionState }
+  readonly lifecycle: TerminalLifecycleState
+  readonly notifyMessage: (message: string) => void
+  readonly removeInput: () => void
+  readonly removeResize: () => void
+  readonly resizeObserver: ResizeObserver | null
+  readonly session: ActiveTerminalSession
+  readonly socketRef: TerminalSocketRef
+  readonly terminal: Terminal
+}
+
+export type TerminalLifecycleArgs = {
+  readonly connectionRef: { current: TerminalConnectionState }
+  readonly hostRef: { readonly current: HTMLDivElement | null }
+  readonly notifyMessage: (message: string) => void
+  readonly session: ActiveTerminalSession
+  readonly setStatus: (status: TerminalStatus) => void
+}
+
+export type TerminalSocketListenerArgs = {
+  readonly lifecycle: TerminalLifecycleState
+  readonly onClose: (socket: WebSocket) => void
+  readonly onError: (socket: WebSocket) => void
+  readonly onMessage: (payload: string) => void
+  readonly onOpen: () => void
+  readonly socket: WebSocket
+}
+
+export type TerminalSocketConnectArgs = {
+  readonly handlers: TerminalMessageHandlers
+  readonly lifecycle: TerminalLifecycleState
+  readonly notifyMessage: (message: string) => void
+  readonly reconnect: () => void
+  readonly sendResize: () => void
+  readonly session: ActiveTerminalSession
+  readonly setStatus: (status: TerminalStatus) => void
+  readonly socketRef: TerminalSocketRef
+  readonly terminal: Terminal
+}

--- a/packages/app/src/web/terminal-panel-runtime.ts
+++ b/packages/app/src/web/terminal-panel-runtime.ts
@@ -6,14 +6,29 @@ import { FitAddon } from "xterm-addon-fit"
 import { deleteTerminalSessionByPath } from "./api.js"
 import type { ActiveTerminalSession } from "./terminal.js"
 import { parseTerminalServerMessage, resolveTerminalWebSocketUrl } from "./terminal.js"
+import { resolveTerminalReconnectDelay, terminalReconnectGraceMs } from "./terminal-reconnect.js"
 
-export type TerminalStatus = "attached" | "connecting" | "error" | "exited"
+export type TerminalStatus = "attached" | "connecting" | "error" | "exited" | "reconnecting"
 
-export type TerminalConnectionState = { opened: boolean }
+export type TerminalConnectionState = { closing: boolean; opened: boolean }
 
 type TerminalRuntime = { readonly fitAddon: FitAddon; readonly terminal: Terminal }
 
+type TerminalLifecycleState = {
+  attachedOnce: boolean
+  disposed: boolean
+  readyNotified: boolean
+  reconnectAttempt: number
+  reconnectStartedAtMs: number | null
+  reconnectTimer: ReturnType<typeof setTimeout> | null
+  terminalEnded: boolean
+}
+
+type TerminalSocketRef = { current: WebSocket | null }
+
 type TerminalMessageHandlers = {
+  readonly connectionRef: { current: TerminalConnectionState }
+  readonly lifecycle: TerminalLifecycleState
   readonly notifyMessage: (message: string) => void
   readonly session: ActiveTerminalSession
   readonly setStatus: (status: TerminalStatus) => void
@@ -21,10 +36,14 @@ type TerminalMessageHandlers = {
 }
 
 type TerminalCleanupArgs = {
+  readonly connectionRef: { current: TerminalConnectionState }
+  readonly lifecycle: TerminalLifecycleState
+  readonly notifyMessage: (message: string) => void
   readonly removeInput: () => void
   readonly removeResize: () => void
   readonly resizeObserver: ResizeObserver | null
-  readonly socket: WebSocket
+  readonly session: ActiveTerminalSession
+  readonly socketRef: TerminalSocketRef
   readonly terminal: Terminal
 }
 
@@ -37,34 +56,33 @@ type TerminalLifecycleArgs = {
 }
 
 type TerminalSocketListenerArgs = {
-  readonly connectionRef: { current: TerminalConnectionState }
-  readonly onClose: () => void
-  readonly onError: () => void
+  readonly lifecycle: TerminalLifecycleState
+  readonly onClose: (socket: WebSocket) => void
+  readonly onError: (socket: WebSocket) => void
   readonly onMessage: (payload: string) => void
   readonly onOpen: () => void
   readonly socket: WebSocket
 }
 
-type TerminalSocketFailureHandlerArgs = {
-  readonly notifyMessage: (message: string) => void
-  readonly setStatus: (status: TerminalStatus) => void
-  readonly terminal: Terminal
-  readonly terminalLine: string
-  readonly uiMessage: string
-}
-
-type TerminalSessionSocketArgs = {
-  readonly connectionRef: { current: TerminalConnectionState }
-  readonly handlers: TerminalMessageHandlers
-  readonly notifyMessage: (message: string) => void
-  readonly sendResize: () => void
-  readonly setStatus: (status: TerminalStatus) => void
-  readonly socket: WebSocket
-  readonly terminal: Terminal
-}
-
 const requestSessionClose = (closePath: string): void => {
   void Effect.runPromise(deleteTerminalSessionByPath(closePath).pipe(Effect.either, Effect.asVoid))
+}
+
+const createLifecycleState = (): TerminalLifecycleState => ({
+  attachedOnce: false,
+  disposed: false,
+  readyNotified: false,
+  reconnectAttempt: 0,
+  reconnectStartedAtMs: null,
+  reconnectTimer: null,
+  terminalEnded: false
+})
+
+const clearReconnectTimer = (lifecycle: TerminalLifecycleState): void => {
+  if (lifecycle.reconnectTimer !== null) {
+    clearTimeout(lifecycle.reconnectTimer)
+    lifecycle.reconnectTimer = null
+  }
 }
 
 const createTerminalRuntime = (host: HTMLDivElement): TerminalRuntime => {
@@ -93,11 +111,16 @@ const createTerminalSocket = (
 
 const sendTerminalResize = (
   fitAddon: FitAddon,
-  socket: WebSocket,
+  socketRef: TerminalSocketRef,
   terminal: Terminal
 ): void => {
-  fitAddon.fit()
-  if (socket.readyState !== WebSocket.OPEN) {
+  try {
+    fitAddon.fit()
+  } catch {
+    return
+  }
+  const socket = socketRef.current
+  if (socket === null || socket.readyState !== WebSocket.OPEN) {
     return
   }
   socket.send(JSON.stringify({
@@ -121,14 +144,33 @@ const observeTerminalResize = (
 
 const attachTerminalInput = (
   terminal: Terminal,
-  socket: WebSocket
+  socketRef: TerminalSocketRef
 ) =>
   terminal.onData((data) => {
-    if (socket.readyState !== WebSocket.OPEN) {
+    const socket = socketRef.current
+    if (socket === null || socket.readyState !== WebSocket.OPEN) {
       return
     }
     socket.send(JSON.stringify({ data, type: "input" }))
   })
+
+const notifyTerminalReady = (
+  handlers: TerminalMessageHandlers
+): void => {
+  handlers.lifecycle.attachedOnce = true
+  handlers.connectionRef.current.opened = true
+  handlers.lifecycle.reconnectAttempt = 0
+  handlers.lifecycle.reconnectStartedAtMs = null
+  clearReconnectTimer(handlers.lifecycle)
+  handlers.setStatus("attached")
+  if (handlers.lifecycle.readyNotified) {
+    handlers.notifyMessage("Terminal reconnected.")
+    return
+  }
+  handlers.lifecycle.readyNotified = true
+  handlers.notifyMessage(handlers.session.readyMessage)
+  handlers.session.onReady?.()
+}
 
 const handleTerminalServerMessage = (
   handlers: TerminalMessageHandlers,
@@ -136,15 +178,15 @@ const handleTerminalServerMessage = (
 ): void => {
   const message = parseTerminalServerMessage(payload)
   if (message === null) {
+    handlers.lifecycle.terminalEnded = true
+    clearReconnectTimer(handlers.lifecycle)
     handlers.terminal.writeln("\r\n[terminal protocol error]")
     handlers.setStatus("error")
     handlers.notifyMessage("Terminal protocol error.")
     return
   }
   if (message.type === "ready") {
-    handlers.setStatus("attached")
-    handlers.notifyMessage(handlers.session.readyMessage)
-    handlers.session.onReady?.()
+    notifyTerminalReady(handlers)
     return
   }
   if (message.type === "output") {
@@ -152,11 +194,15 @@ const handleTerminalServerMessage = (
     return
   }
   if (message.type === "error") {
+    handlers.lifecycle.terminalEnded = true
+    clearReconnectTimer(handlers.lifecycle)
     handlers.terminal.writeln(`\r\n[error] ${message.message}`)
     handlers.setStatus("error")
     handlers.notifyMessage(message.message)
     return
   }
+  handlers.lifecycle.terminalEnded = true
+  clearReconnectTimer(handlers.lifecycle)
   handlers.terminal.writeln("\r\n[session ended]")
   handlers.setStatus("exited")
   handlers.notifyMessage(handlers.session.exitMessage)
@@ -164,94 +210,126 @@ const handleTerminalServerMessage = (
 }
 
 const attachTerminalSocketListeners = (
-  { connectionRef, onClose, onError, onMessage, onOpen, socket }: TerminalSocketListenerArgs
+  { lifecycle, onClose, onError, onMessage, onOpen, socket }: TerminalSocketListenerArgs
 ): void => {
-  socket.addEventListener("open", () => {
-    connectionRef.current.opened = true
-    onOpen()
-  })
+  socket.addEventListener("open", onOpen)
   socket.addEventListener("message", (event) => {
     onMessage(typeof event.data === "string" ? event.data : "")
   })
   socket.addEventListener("close", () => {
-    if (!connectionRef.current.opened) {
-      onClose()
+    onClose(socket)
+  })
+  socket.addEventListener("error", () => {
+    if (!lifecycle.disposed) {
+      onError(socket)
     }
   })
-  socket.addEventListener("error", onError)
+}
+
+const closeSocket = (socket: WebSocket | null): void => {
+  if (socket === null || socket.readyState === WebSocket.CLOSED) {
+    return
+  }
+  try {
+    socket.close()
+  } catch {
+    return
+  }
 }
 
 const cleanupTerminalResources = (
-  { removeInput, removeResize, resizeObserver, socket, terminal }: TerminalCleanupArgs
+  {
+    connectionRef,
+    lifecycle,
+    notifyMessage,
+    removeInput,
+    removeResize,
+    resizeObserver,
+    session,
+    socketRef,
+    terminal
+  }: TerminalCleanupArgs
 ): void => {
+  lifecycle.disposed = true
+  clearReconnectTimer(lifecycle)
   removeInput()
   resizeObserver?.disconnect()
   removeResize()
-  if (socket.readyState === WebSocket.OPEN) {
-    socket.send(JSON.stringify({ type: "close" }))
-  }
-  socket.close()
+  closeSocket(socketRef.current)
+  socketRef.current = null
   terminal.dispose()
-}
-
-const createMessageHandlers = (
-  notifyMessage: (message: string) => void,
-  session: ActiveTerminalSession,
-  setStatus: (status: TerminalStatus) => void,
-  terminal: Terminal
-): TerminalMessageHandlers => ({
-  notifyMessage,
-  session,
-  setStatus,
-  terminal
-})
-
-const createSocketFailureHandler = (
-  { notifyMessage, setStatus, terminal, terminalLine, uiMessage }: TerminalSocketFailureHandlerArgs
-) =>
-(): void => {
-  terminal.writeln(`\r\n${terminalLine}`)
-  setStatus("error")
-  notifyMessage(uiMessage)
-}
-
-const maybeDeletePendingSession = (
-  connectionRef: { current: TerminalConnectionState },
-  notifyMessage: (message: string) => void,
-  session: ActiveTerminalSession
-): void => {
-  if (!connectionRef.current.opened) {
+  if (!connectionRef.current.opened && !connectionRef.current.closing) {
     requestSessionClose(session.closePath)
     notifyMessage(session.pendingDeleteMessage)
     session.onExit?.()
   }
 }
 
-const attachTerminalSessionSocket = (
-  { connectionRef, handlers, notifyMessage, sendResize, setStatus, socket, terminal }: TerminalSessionSocketArgs
+const createMessageHandlers = (
+  connectionRef: { current: TerminalConnectionState },
+  lifecycle: TerminalLifecycleState,
+  notifyMessage: (message: string) => void,
+  session: ActiveTerminalSession,
+  setStatus: (status: TerminalStatus) => void,
+  terminal: Terminal
+): TerminalMessageHandlers => ({
+  connectionRef,
+  lifecycle,
+  notifyMessage,
+  session,
+  setStatus,
+  terminal
+})
+
+const failBeforeAttach = (
+  lifecycle: TerminalLifecycleState,
+  notifyMessage: (message: string) => void,
+  session: ActiveTerminalSession,
+  setStatus: (status: TerminalStatus) => void,
+  terminal: Terminal,
+  terminalLine: string,
+  uiMessage: string
 ): void => {
-  attachTerminalSocketListeners({
-    connectionRef,
-    onClose: createSocketFailureHandler({
-      notifyMessage,
-      setStatus,
-      terminal,
-      terminalLine: "[websocket closed before attach]",
-      uiMessage: "Terminal websocket closed before attach."
-    }),
-    onError: createSocketFailureHandler({
-      notifyMessage,
-      setStatus,
-      terminal,
-      terminalLine: "[websocket error]",
-      uiMessage: "Terminal websocket error."
-    }),
-    onMessage: (payload) => {
-      handleTerminalServerMessage(handlers, payload)
-    },
-    onOpen: sendResize,
-    socket
-  })
+  lifecycle.terminalEnded = true
+  clearReconnectTimer(lifecycle)
+  terminal.writeln(`\r\n${terminalLine}`)
+  setStatus("error")
+  notifyMessage(uiMessage)
+  requestSessionClose(session.closePath)
+}
+
+const scheduleReconnect = (
+  connectSocket: () => void,
+  lifecycle: TerminalLifecycleState,
+  notifyMessage: (message: string) => void,
+  session: ActiveTerminalSession,
+  setStatus: (status: TerminalStatus) => void,
+  terminal: Terminal
+): void => {
+  if (lifecycle.disposed || lifecycle.terminalEnded) {
+    return
+  }
+  const startedAt = lifecycle.reconnectStartedAtMs ?? Date.now()
+  lifecycle.reconnectStartedAtMs = startedAt
+  const elapsedMs = Date.now() - startedAt
+  if (elapsedMs >= terminalReconnectGraceMs) {
+    lifecycle.terminalEnded = true
+    clearReconnectTimer(lifecycle)
+    terminal.writeln("\r\n[terminal reconnect failed]")
+    setStatus("error")
+    notifyMessage("Terminal reconnect failed.")
+    requestSessionClose(session.closePath)
+    return
+  }
+  if (lifecycle.reconnectAttempt === 0) {
+    terminal.writeln("\r\n[terminal connection lost; reconnecting]")
+    notifyMessage("Terminal connection lost. Reconnecting...")
+  }
+  setStatus("reconnecting")
+  const delayMs = resolveTerminalReconnectDelay(lifecycle.reconnectAttempt)
+  lifecycle.reconnectAttempt += 1
+  clearReconnectTimer(lifecycle)
+  lifecycle.reconnectTimer = setTimeout(connectSocket, delayMs)
 }
 
 const mountTerminalSession = (
@@ -262,34 +340,84 @@ const mountTerminalSession = (
     return undefined
   }
 
-  connectionRef.current = { opened: false }
+  connectionRef.current = { closing: false, opened: false }
+  const lifecycle = createLifecycleState()
+  const socketRef: TerminalSocketRef = { current: null }
   const { fitAddon, terminal } = createTerminalRuntime(host)
-  const socket = createTerminalSocket(session, terminal)
   const sendResize = () => {
-    sendTerminalResize(fitAddon, socket, terminal)
+    sendTerminalResize(fitAddon, socketRef, terminal)
   }
   const resizeObserver = observeTerminalResize(host, sendResize)
-  const inputDisposable = attachTerminalInput(terminal, socket)
+  const inputDisposable = attachTerminalInput(terminal, socketRef)
   const handlers = createMessageHandlers(
+    connectionRef,
+    lifecycle,
     notifyMessage,
     session,
     setStatus,
     terminal
   )
 
+  const connectSocket = () => {
+    if (lifecycle.disposed || lifecycle.terminalEnded) {
+      return
+    }
+    const socket = createTerminalSocket(session, terminal)
+    socketRef.current = socket
+    attachTerminalSocketListeners({
+      lifecycle,
+      onClose: (closedSocket) => {
+        if (socketRef.current !== closedSocket) {
+          return
+        }
+        socketRef.current = null
+        if (lifecycle.disposed || lifecycle.terminalEnded) {
+          return
+        }
+        if (!lifecycle.attachedOnce) {
+          failBeforeAttach(
+            lifecycle,
+            notifyMessage,
+            session,
+            setStatus,
+            terminal,
+            "[websocket closed before attach]",
+            "Terminal websocket closed before attach."
+          )
+          return
+        }
+        scheduleReconnect(connectSocket, lifecycle, notifyMessage, session, setStatus, terminal)
+      },
+      onError: (failedSocket) => {
+        if (socketRef.current !== failedSocket || lifecycle.attachedOnce) {
+          return
+        }
+        failBeforeAttach(
+          lifecycle,
+          notifyMessage,
+          session,
+          setStatus,
+          terminal,
+          "[websocket error]",
+          "Terminal websocket error."
+        )
+      },
+      onMessage: (payload) => {
+        handleTerminalServerMessage(handlers, payload)
+      },
+      onOpen: sendResize,
+      socket
+    })
+  }
+
   globalThis.addEventListener("resize", sendResize)
-  attachTerminalSessionSocket({
-    connectionRef,
-    handlers,
-    notifyMessage,
-    sendResize,
-    setStatus,
-    socket,
-    terminal
-  })
+  connectSocket()
 
   return () => {
     cleanupTerminalResources({
+      connectionRef,
+      lifecycle,
+      notifyMessage,
       removeInput: () => {
         inputDisposable.dispose()
       },
@@ -297,10 +425,10 @@ const mountTerminalSession = (
         globalThis.removeEventListener("resize", sendResize)
       },
       resizeObserver,
-      socket,
+      session,
+      socketRef,
       terminal
     })
-    maybeDeletePendingSession(connectionRef, notifyMessage, session)
   }
 }
 
@@ -315,5 +443,5 @@ export const useTerminalSessionLifecycle = (
       session,
       setStatus
     })
-  }, [connectionRef, hostRef, session, setStatus])
+  }, [connectionRef, hostRef, notifyMessage, session, setStatus])
 }

--- a/packages/app/src/web/terminal-panel-runtime.ts
+++ b/packages/app/src/web/terminal-panel-runtime.ts
@@ -1,335 +1,49 @@
-import { Effect } from "effect"
 import { useEffect } from "react"
-import { Terminal } from "xterm"
-import { FitAddon } from "xterm-addon-fit"
 
-import { deleteTerminalSessionByPath } from "./api.js"
-import type { ActiveTerminalSession } from "./terminal.js"
-import { parseTerminalServerMessage, resolveTerminalWebSocketUrl } from "./terminal.js"
-import { resolveTerminalReconnectDelay, terminalReconnectGraceMs } from "./terminal-reconnect.js"
+import {
+  attachTerminalInput,
+  cleanupTerminalResources,
+  connectTerminalSocket,
+  createLifecycleState,
+  createMessageHandlers,
+  createTerminalRuntime,
+  observeTerminalResize,
+  sendTerminalResize
+} from "./terminal-panel-runtime-core.js"
+import type {
+  TerminalLifecycleArgs,
+  TerminalSocketConnectArgs,
+  TerminalSocketRef
+} from "./terminal-panel-runtime-types.js"
 
-export type TerminalStatus = "attached" | "connecting" | "error" | "exited" | "reconnecting"
-
-export type TerminalConnectionState = { closing: boolean; opened: boolean }
-
-type TerminalRuntime = { readonly fitAddon: FitAddon; readonly terminal: Terminal }
-
-type TerminalLifecycleState = {
-  attachedOnce: boolean
-  disposed: boolean
-  readyNotified: boolean
-  reconnectAttempt: number
-  reconnectStartedAtMs: number | null
-  reconnectTimer: ReturnType<typeof setTimeout> | null
-  terminalEnded: boolean
+type TerminalCleanupFactoryArgs = {
+  readonly cleanupArgs: Omit<Parameters<typeof cleanupTerminalResources>[0], "removeInput" | "removeResize">
+  readonly inputDisposable: { readonly dispose: () => void }
+  readonly sendResize: () => void
 }
 
-type TerminalSocketRef = { current: WebSocket | null }
-
-type TerminalMessageHandlers = {
-  readonly connectionRef: { current: TerminalConnectionState }
-  readonly lifecycle: TerminalLifecycleState
-  readonly notifyMessage: (message: string) => void
-  readonly session: ActiveTerminalSession
-  readonly setStatus: (status: TerminalStatus) => void
-  readonly terminal: Terminal
-}
-
-type TerminalCleanupArgs = {
-  readonly connectionRef: { current: TerminalConnectionState }
-  readonly lifecycle: TerminalLifecycleState
-  readonly notifyMessage: (message: string) => void
-  readonly removeInput: () => void
-  readonly removeResize: () => void
-  readonly resizeObserver: ResizeObserver | null
-  readonly session: ActiveTerminalSession
-  readonly socketRef: TerminalSocketRef
-  readonly terminal: Terminal
-}
-
-type TerminalLifecycleArgs = {
-  readonly connectionRef: { current: TerminalConnectionState }
-  readonly hostRef: { readonly current: HTMLDivElement | null }
-  readonly notifyMessage: (message: string) => void
-  readonly session: ActiveTerminalSession
-  readonly setStatus: (status: TerminalStatus) => void
-}
-
-type TerminalSocketListenerArgs = {
-  readonly lifecycle: TerminalLifecycleState
-  readonly onClose: (socket: WebSocket) => void
-  readonly onError: (socket: WebSocket) => void
-  readonly onMessage: (payload: string) => void
-  readonly onOpen: () => void
-  readonly socket: WebSocket
-}
-
-const requestSessionClose = (closePath: string): void => {
-  void Effect.runPromise(deleteTerminalSessionByPath(closePath).pipe(Effect.either, Effect.asVoid))
-}
-
-const createLifecycleState = (): TerminalLifecycleState => ({
-  attachedOnce: false,
-  disposed: false,
-  readyNotified: false,
-  reconnectAttempt: 0,
-  reconnectStartedAtMs: null,
-  reconnectTimer: null,
-  terminalEnded: false
-})
-
-const clearReconnectTimer = (lifecycle: TerminalLifecycleState): void => {
-  if (lifecycle.reconnectTimer !== null) {
-    clearTimeout(lifecycle.reconnectTimer)
-    lifecycle.reconnectTimer = null
-  }
-}
-
-const createTerminalRuntime = (host: HTMLDivElement): TerminalRuntime => {
-  const terminal = new Terminal({
-    convertEol: false,
-    cursorBlink: true,
-    fontFamily: "'IBM Plex Mono', 'SFMono-Regular', monospace",
-    fontSize: 14,
-    theme: {
-      background: "#080a0d",
-      foreground: "#f4f7fb"
-    }
-  })
-  const fitAddon = new FitAddon()
-  terminal.loadAddon(fitAddon)
-  terminal.open(host)
-  fitAddon.fit()
-  terminal.focus()
-  return { fitAddon, terminal }
-}
-
-const createTerminalSocket = (
-  session: ActiveTerminalSession,
-  terminal: Terminal
-): WebSocket => new WebSocket(resolveTerminalWebSocketUrl(session.websocketPath, terminal.cols, terminal.rows))
-
-const sendTerminalResize = (
-  fitAddon: FitAddon,
-  socketRef: TerminalSocketRef,
-  terminal: Terminal
-): void => {
-  try {
-    fitAddon.fit()
-  } catch {
-    return
-  }
-  const socket = socketRef.current
-  if (socket === null || socket.readyState !== WebSocket.OPEN) {
-    return
-  }
-  socket.send(JSON.stringify({
-    cols: terminal.cols,
-    rows: terminal.rows,
-    type: "resize"
-  }))
-}
-
-const observeTerminalResize = (
-  host: HTMLDivElement,
-  onResize: () => void
-): ResizeObserver | null => {
-  if (typeof ResizeObserver !== "function") {
-    return null
-  }
-  const resizeObserver = new ResizeObserver(onResize)
-  resizeObserver.observe(host)
-  return resizeObserver
-}
-
-const attachTerminalInput = (
-  terminal: Terminal,
-  socketRef: TerminalSocketRef
-) =>
-  terminal.onData((data) => {
-    const socket = socketRef.current
-    if (socket === null || socket.readyState !== WebSocket.OPEN) {
-      return
-    }
-    socket.send(JSON.stringify({ data, type: "input" }))
-  })
-
-const notifyTerminalReady = (
-  handlers: TerminalMessageHandlers
-): void => {
-  handlers.lifecycle.attachedOnce = true
-  handlers.connectionRef.current.opened = true
-  handlers.lifecycle.reconnectAttempt = 0
-  handlers.lifecycle.reconnectStartedAtMs = null
-  clearReconnectTimer(handlers.lifecycle)
-  handlers.setStatus("attached")
-  if (handlers.lifecycle.readyNotified) {
-    handlers.notifyMessage("Terminal reconnected.")
-    return
-  }
-  handlers.lifecycle.readyNotified = true
-  handlers.notifyMessage(handlers.session.readyMessage)
-  handlers.session.onReady?.()
-}
-
-const handleTerminalServerMessage = (
-  handlers: TerminalMessageHandlers,
-  payload: string
-): void => {
-  const message = parseTerminalServerMessage(payload)
-  if (message === null) {
-    handlers.lifecycle.terminalEnded = true
-    clearReconnectTimer(handlers.lifecycle)
-    handlers.terminal.writeln("\r\n[terminal protocol error]")
-    handlers.setStatus("error")
-    handlers.notifyMessage("Terminal protocol error.")
-    return
-  }
-  if (message.type === "ready") {
-    notifyTerminalReady(handlers)
-    return
-  }
-  if (message.type === "output") {
-    handlers.terminal.write(message.data)
-    return
-  }
-  if (message.type === "error") {
-    handlers.lifecycle.terminalEnded = true
-    clearReconnectTimer(handlers.lifecycle)
-    handlers.terminal.writeln(`\r\n[error] ${message.message}`)
-    handlers.setStatus("error")
-    handlers.notifyMessage(message.message)
-    return
-  }
-  handlers.lifecycle.terminalEnded = true
-  clearReconnectTimer(handlers.lifecycle)
-  handlers.terminal.writeln("\r\n[session ended]")
-  handlers.setStatus("exited")
-  handlers.notifyMessage(handlers.session.exitMessage)
-  handlers.session.onExit?.()
-}
-
-const attachTerminalSocketListeners = (
-  { lifecycle, onClose, onError, onMessage, onOpen, socket }: TerminalSocketListenerArgs
-): void => {
-  socket.addEventListener("open", onOpen)
-  socket.addEventListener("message", (event) => {
-    onMessage(typeof event.data === "string" ? event.data : "")
-  })
-  socket.addEventListener("close", () => {
-    onClose(socket)
-  })
-  socket.addEventListener("error", () => {
-    if (!lifecycle.disposed) {
-      onError(socket)
+const createTerminalCleanup = (
+  { cleanupArgs, inputDisposable, sendResize }: TerminalCleanupFactoryArgs
+): () => void =>
+(): void => {
+  cleanupTerminalResources({
+    ...cleanupArgs,
+    removeInput: () => {
+      inputDisposable.dispose()
+    },
+    removeResize: () => {
+      globalThis.removeEventListener("resize", sendResize)
     }
   })
 }
 
-const closeSocket = (socket: WebSocket | null): void => {
-  if (socket === null || socket.readyState === WebSocket.CLOSED) {
-    return
+const createConnectSocket = (
+  args: Omit<TerminalSocketConnectArgs, "reconnect">
+): () => void => {
+  const connectSocket = () => {
+    connectTerminalSocket({ ...args, reconnect: connectSocket })
   }
-  try {
-    socket.close()
-  } catch {
-    return
-  }
-}
-
-const cleanupTerminalResources = (
-  {
-    connectionRef,
-    lifecycle,
-    notifyMessage,
-    removeInput,
-    removeResize,
-    resizeObserver,
-    session,
-    socketRef,
-    terminal
-  }: TerminalCleanupArgs
-): void => {
-  lifecycle.disposed = true
-  clearReconnectTimer(lifecycle)
-  removeInput()
-  resizeObserver?.disconnect()
-  removeResize()
-  closeSocket(socketRef.current)
-  socketRef.current = null
-  terminal.dispose()
-  if (!connectionRef.current.opened && !connectionRef.current.closing) {
-    requestSessionClose(session.closePath)
-    notifyMessage(session.pendingDeleteMessage)
-    session.onExit?.()
-  }
-}
-
-const createMessageHandlers = (
-  connectionRef: { current: TerminalConnectionState },
-  lifecycle: TerminalLifecycleState,
-  notifyMessage: (message: string) => void,
-  session: ActiveTerminalSession,
-  setStatus: (status: TerminalStatus) => void,
-  terminal: Terminal
-): TerminalMessageHandlers => ({
-  connectionRef,
-  lifecycle,
-  notifyMessage,
-  session,
-  setStatus,
-  terminal
-})
-
-const failBeforeAttach = (
-  lifecycle: TerminalLifecycleState,
-  notifyMessage: (message: string) => void,
-  session: ActiveTerminalSession,
-  setStatus: (status: TerminalStatus) => void,
-  terminal: Terminal,
-  terminalLine: string,
-  uiMessage: string
-): void => {
-  lifecycle.terminalEnded = true
-  clearReconnectTimer(lifecycle)
-  terminal.writeln(`\r\n${terminalLine}`)
-  setStatus("error")
-  notifyMessage(uiMessage)
-  requestSessionClose(session.closePath)
-}
-
-const scheduleReconnect = (
-  connectSocket: () => void,
-  lifecycle: TerminalLifecycleState,
-  notifyMessage: (message: string) => void,
-  session: ActiveTerminalSession,
-  setStatus: (status: TerminalStatus) => void,
-  terminal: Terminal
-): void => {
-  if (lifecycle.disposed || lifecycle.terminalEnded) {
-    return
-  }
-  const startedAt = lifecycle.reconnectStartedAtMs ?? Date.now()
-  lifecycle.reconnectStartedAtMs = startedAt
-  const elapsedMs = Date.now() - startedAt
-  if (elapsedMs >= terminalReconnectGraceMs) {
-    lifecycle.terminalEnded = true
-    clearReconnectTimer(lifecycle)
-    terminal.writeln("\r\n[terminal reconnect failed]")
-    setStatus("error")
-    notifyMessage("Terminal reconnect failed.")
-    requestSessionClose(session.closePath)
-    return
-  }
-  if (lifecycle.reconnectAttempt === 0) {
-    terminal.writeln("\r\n[terminal connection lost; reconnecting]")
-    notifyMessage("Terminal connection lost. Reconnecting...")
-  }
-  setStatus("reconnecting")
-  const delayMs = resolveTerminalReconnectDelay(lifecycle.reconnectAttempt)
-  lifecycle.reconnectAttempt += 1
-  clearReconnectTimer(lifecycle)
-  lifecycle.reconnectTimer = setTimeout(connectSocket, delayMs)
+  return connectSocket
 }
 
 const mountTerminalSession = (
@@ -349,87 +63,41 @@ const mountTerminalSession = (
   }
   const resizeObserver = observeTerminalResize(host, sendResize)
   const inputDisposable = attachTerminalInput(terminal, socketRef)
-  const handlers = createMessageHandlers(
+  const handlers = createMessageHandlers({
     connectionRef,
     lifecycle,
     notifyMessage,
     session,
     setStatus,
     terminal
-  )
-
-  const connectSocket = () => {
-    if (lifecycle.disposed || lifecycle.terminalEnded) {
-      return
-    }
-    const socket = createTerminalSocket(session, terminal)
-    socketRef.current = socket
-    attachTerminalSocketListeners({
-      lifecycle,
-      onClose: (closedSocket) => {
-        if (socketRef.current !== closedSocket) {
-          return
-        }
-        socketRef.current = null
-        if (lifecycle.disposed || lifecycle.terminalEnded) {
-          return
-        }
-        if (!lifecycle.attachedOnce) {
-          failBeforeAttach(
-            lifecycle,
-            notifyMessage,
-            session,
-            setStatus,
-            terminal,
-            "[websocket closed before attach]",
-            "Terminal websocket closed before attach."
-          )
-          return
-        }
-        scheduleReconnect(connectSocket, lifecycle, notifyMessage, session, setStatus, terminal)
-      },
-      onError: (failedSocket) => {
-        if (socketRef.current !== failedSocket || lifecycle.attachedOnce) {
-          return
-        }
-        failBeforeAttach(
-          lifecycle,
-          notifyMessage,
-          session,
-          setStatus,
-          terminal,
-          "[websocket error]",
-          "Terminal websocket error."
-        )
-      },
-      onMessage: (payload) => {
-        handleTerminalServerMessage(handlers, payload)
-      },
-      onOpen: sendResize,
-      socket
-    })
-  }
+  })
+  const connectSocket = createConnectSocket({
+    handlers,
+    lifecycle,
+    notifyMessage,
+    sendResize,
+    session,
+    setStatus,
+    socketRef,
+    terminal
+  })
 
   globalThis.addEventListener("resize", sendResize)
   connectSocket()
 
-  return () => {
-    cleanupTerminalResources({
+  return createTerminalCleanup({
+    cleanupArgs: {
       connectionRef,
       lifecycle,
       notifyMessage,
-      removeInput: () => {
-        inputDisposable.dispose()
-      },
-      removeResize: () => {
-        globalThis.removeEventListener("resize", sendResize)
-      },
       resizeObserver,
       session,
       socketRef,
       terminal
-    })
-  }
+    },
+    inputDisposable,
+    sendResize
+  })
 }
 
 export const useTerminalSessionLifecycle = (
@@ -445,3 +113,5 @@ export const useTerminalSessionLifecycle = (
     })
   }, [connectionRef, hostRef, notifyMessage, session, setStatus])
 }
+
+export { type TerminalConnectionState, type TerminalStatus } from "./terminal-panel-runtime-types.js"

--- a/packages/app/src/web/terminal-reconnect.ts
+++ b/packages/app/src/web/terminal-reconnect.ts
@@ -1,7 +1,7 @@
 export const terminalReconnectGraceMs = 60_000
 
 const reconnectBaseDelayMs = 500
-const reconnectMaxDelayMs = 3_000
+const reconnectMaxDelayMs = 3000
 
 export const resolveTerminalReconnectDelay = (attempt: number): number =>
   Math.min(reconnectBaseDelayMs * (2 ** Math.max(0, attempt)), reconnectMaxDelayMs)

--- a/packages/app/src/web/terminal-reconnect.ts
+++ b/packages/app/src/web/terminal-reconnect.ts
@@ -1,0 +1,7 @@
+export const terminalReconnectGraceMs = 60_000
+
+const reconnectBaseDelayMs = 500
+const reconnectMaxDelayMs = 3_000
+
+export const resolveTerminalReconnectDelay = (attempt: number): number =>
+  Math.min(reconnectBaseDelayMs * (2 ** Math.max(0, attempt)), reconnectMaxDelayMs)

--- a/packages/app/tests/docker-git/app-dashboard-state.test.ts
+++ b/packages/app/tests/docker-git/app-dashboard-state.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "@effect/vitest"
+
+import type { DashboardData } from "../../src/web/api.js"
+import { type DashboardState, mergeDashboardRefreshState } from "../../src/web/app-dashboard-state.js"
+
+const dashboard: DashboardData = {
+  apiBaseUrl: "/api",
+  health: {
+    cwd: "/home/dev",
+    ok: true,
+    projectsRoot: "/home/dev/workspaces",
+    revision: "rev"
+  },
+  projects: []
+}
+
+describe("web dashboard state", () => {
+  it("keeps the ready screen mounted when a background refresh fails", () => {
+    const ready: DashboardState = {
+      _tag: "Ready",
+      dashboard,
+      refreshedAtMs: 10
+    }
+    const error: DashboardState = {
+      _tag: "Error",
+      apiBaseUrl: "/api",
+      message: "temporary tunnel failure"
+    }
+
+    expect(mergeDashboardRefreshState(ready, error)).toBe(ready)
+  })
+
+  it("still surfaces initial loading failures", () => {
+    const loading: DashboardState = {
+      _tag: "Loading",
+      apiBaseUrl: "/api"
+    }
+    const error: DashboardState = {
+      _tag: "Error",
+      apiBaseUrl: "/api",
+      message: "api unavailable"
+    }
+
+    expect(mergeDashboardRefreshState(loading, error)).toBe(error)
+  })
+})

--- a/packages/app/tests/docker-git/terminal.test.ts
+++ b/packages/app/tests/docker-git/terminal.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest"
 import { afterEach, beforeEach, vi } from "vitest"
 
+import { resolveTerminalReconnectDelay } from "../../src/web/terminal-reconnect.js"
 import { parseTerminalServerMessage, resolveTerminalWebSocketUrl } from "../../src/web/terminal.js"
 import type { TerminalServerMessage } from "../../src/web/terminal.js"
 
@@ -65,5 +66,15 @@ describe("browser terminal helpers", () => {
 
   it("rejects malformed terminal messages", () => {
     expect(parseTerminalServerMessage("{\"type\":\"output\",\"data\":1}")).toBeNull()
+  })
+
+  it("caps reconnect backoff inside the server reconnect grace window", () => {
+    expect([
+      resolveTerminalReconnectDelay(-1),
+      resolveTerminalReconnectDelay(0),
+      resolveTerminalReconnectDelay(1),
+      resolveTerminalReconnectDelay(2),
+      resolveTerminalReconnectDelay(3)
+    ]).toEqual([500, 500, 1000, 2000, 3000])
   })
 })

--- a/packages/app/vite.web.config.ts
+++ b/packages/app/vite.web.config.ts
@@ -15,6 +15,7 @@ const noStoreHeaders = {
   "Cache-Control": "no-store, no-cache, must-revalidate, max-age=0",
   Pragma: "no-cache"
 }
+const webSocketHeartbeatIntervalMs = 25_000
 
 const createProxy = (apiTarget: string) => ({
   "/b": {
@@ -60,6 +61,31 @@ const proxyForwardHeaders = (request: IncomingMessage): Record<string, string> =
   }
 }
 
+const attachWebSocketHeartbeat = (socket: WebSocket): void => {
+  let alive = true
+  const interval = setInterval(() => {
+    if (socket.readyState !== WebSocket.OPEN) {
+      return
+    }
+    if (!alive) {
+      socket.terminate()
+      return
+    }
+    alive = false
+    socket.ping()
+  }, webSocketHeartbeatIntervalMs)
+
+  socket.on("pong", () => {
+    alive = true
+  })
+  socket.on("close", () => {
+    clearInterval(interval)
+  })
+  socket.on("error", () => {
+    clearInterval(interval)
+  })
+}
+
 const bridgeWebSockets = (clientSocket: WebSocket, upstream: WebSocket): void => {
   const pending: Array<{ readonly data: RawData; readonly isBinary: boolean }> = []
   const sendWhenOpen = (socket: WebSocket, data: RawData, isBinary: boolean): void => {
@@ -67,6 +93,8 @@ const bridgeWebSockets = (clientSocket: WebSocket, upstream: WebSocket): void =>
       socket.send(data, { binary: isBinary })
     }
   }
+  attachWebSocketHeartbeat(clientSocket)
+  attachWebSocketHeartbeat(upstream)
   const flushPending = (): void => {
     for (const message of pending.splice(0)) {
       sendWhenOpen(upstream, message.data, message.isBinary)

--- a/packages/lib/src/usecases/projects-ssh.ts
+++ b/packages/lib/src/usecases/projects-ssh.ts
@@ -54,6 +54,10 @@ const buildSshArgs = (item: ProjectItem): ReadonlyArray<string> => {
     "StrictHostKeyChecking=no",
     "-o",
     "UserKnownHostsFile=/dev/null",
+    "-o",
+    "ServerAliveInterval=30",
+    "-o",
+    "ServerAliveCountMax=3",
     "-p",
     String(port),
     `${item.sshUser}@${host}`

--- a/packages/lib/tests/usecases/projects-ssh.test.ts
+++ b/packages/lib/tests/usecases/projects-ssh.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "@effect/vitest"
+
+import type { ProjectItem } from "../../src/usecases/projects-core.js"
+import { prepareProjectSsh } from "../../src/usecases/projects-ssh.js"
+
+const projectItem: ProjectItem = {
+  authorizedKeysExists: true,
+  authorizedKeysPath: "/tmp/project/.ssh/authorized_keys",
+  codexAuthPath: "/tmp/auth.json",
+  codexHome: "/tmp/codex",
+  containerName: "project-container",
+  displayName: "org/repo",
+  envGlobalPath: "/tmp/.env",
+  envProjectPath: "/tmp/project/.env",
+  projectDir: "/tmp/project",
+  repoRef: "main",
+  repoUrl: "https://example.com/org/repo.git",
+  serviceName: "app",
+  sshCommand: "ssh -p 2222 dev@localhost",
+  sshKeyPath: "/tmp/key",
+  sshPort: 2222,
+  sshUser: "dev",
+  targetDir: "/workspace"
+}
+
+describe("project ssh preparation", () => {
+  it("adds ssh keepalive options for interactive sessions", () => {
+    const prepared = prepareProjectSsh(projectItem)
+
+    expect(prepared.args).toContain("ServerAliveInterval=30")
+    expect(prepared.args).toContain("ServerAliveCountMax=3")
+    expect(prepared.args).toEqual([
+      "-i",
+      "/tmp/key",
+      "-tt",
+      "-Y",
+      "-o",
+      "LogLevel=ERROR",
+      "-o",
+      "StrictHostKeyChecking=no",
+      "-o",
+      "UserKnownHostsFile=/dev/null",
+      "-o",
+      "ServerAliveInterval=30",
+      "-o",
+      "ServerAliveCountMax=3",
+      "-p",
+      "2222",
+      "dev@localhost"
+    ])
+  })
+})


### PR DESCRIPTION
## Summary

Harden the web SSH terminal against transient WebSocket and tunnel drops.

## What Changed

- Keep terminal PTYs alive for a 60 second reconnect grace period instead of killing the session on every WebSocket close.
- Reuse the existing PTY on reconnect for both project SSH terminals and auth terminal sessions.
- Add WebSocket ping/pong heartbeat handling in the API and in both dev and production web proxy bridges.
- Add frontend reconnect state, reconnect backoff, and status messaging for dropped terminal sockets.
- Keep explicit `Close terminal` behavior as an actual server-side session delete.
- Preserve the Ready dashboard UI on transient background refresh failures so the terminal is not unmounted.
- Add SSH keepalive options to interactive project SSH sessions.
- Add tests for dashboard refresh hardening, reconnect backoff, and SSH keepalive args.

## Root Cause

A transient tunnel or WebSocket close was treated as terminal session teardown. The API killed the PTY immediately, while the browser runtime did not reconnect after an already-attached socket closed. A background dashboard refresh failure could also replace the Ready screen with Error and unmount the terminal.

## Validation

- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/api typecheck`
- `bun run --cwd packages/lib typecheck`
- `bun run --cwd packages/app test`
- `bun run --cwd packages/api test`
- `bun run --cwd packages/lib test`
- `bun run --cwd packages/app build:web`
- `git diff --check`

Note: `build:web` completed with the existing Vite warnings about deprecated `optimizeDeps.esbuildOptions` and large client chunk size.
