### PR TITLE
fix(browser): restart web stack on rerun

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,14 @@ bun run web:dev
 
 Открой `http://127.0.0.1:4174/`.
 
+Одна команда для controller + web frontend:
+
+```bash
+bun run docker-git -- browser
+```
+
+Если controller или web frontend уже запущены, команда спросит про restart. В non-interactive запуске restart выполняется автоматически.
+
 Preview собранного frontend:
 
 ```bash

--- a/packages/app/src/docker-git/browser-frontend.ts
+++ b/packages/app/src/docker-git/browser-frontend.ts
@@ -1,9 +1,14 @@
 import type * as CommandExecutor from "@effect/platform/CommandExecutor"
 import type { PlatformError } from "@effect/platform/Error"
-import { Effect } from "effect"
+import { Effect, pipe } from "effect"
 
-import { resolveApiBaseUrl } from "./controller.js"
-import { runCommandExitCodeStreaming } from "./frontend-lib/shell/command-runner.js"
+import { controllerExists } from "./controller-docker.js"
+import { type ControllerRuntime, ensureControllerReady, resolveApiBaseUrl, restartController } from "./controller.js"
+import {
+  runCommandCapture,
+  runCommandExitCode,
+  runCommandExitCodeStreaming
+} from "./frontend-lib/shell/command-runner.js"
 import type { ControllerBootstrapError } from "./host-errors.js"
 
 const browserFrontendError = (message: string): ControllerBootstrapError => ({
@@ -25,6 +30,11 @@ const webHost = (): string => process.env["DOCKER_GIT_WEB_HOST"]?.trim() || "127
 
 const webPort = (): string => process.env["DOCKER_GIT_WEB_PORT"]?.trim() || "4174"
 
+type BrowserFrontendRuntimeState = {
+  readonly controllerRunning: boolean
+  readonly webPids: ReadonlyArray<string>
+}
+
 const browserEnv = (apiBaseUrl: string): Readonly<Record<string, string>> => ({
   ...copyProcessEnv(),
   DOCKER_GIT_API_URL: apiBaseUrl,
@@ -41,6 +51,146 @@ const runStreaming = (
     command: "bun",
     cwd: process.cwd(),
     env
+  })
+
+const parsePids = (output: string): ReadonlyArray<string> =>
+  output
+    .split(/\s+/u)
+    .map((pid) => pid.trim())
+    .filter((pid) => /^\d+$/u.test(pid))
+
+const findWebServerPids = (): Effect.Effect<ReadonlyArray<string>, never, CommandExecutor.CommandExecutor> => {
+  const script = [
+    "port=\"$1\"",
+    "if command -v lsof >/dev/null 2>&1; then",
+    "  lsof -nP -tiTCP:\"$port\" -sTCP:LISTEN 2>/dev/null || true",
+    "  exit 0",
+    "fi",
+    "if command -v fuser >/dev/null 2>&1; then",
+    String.raw`  fuser "$port/tcp" 2>/dev/null | tr ' ' '\n' || true`,
+    "fi"
+  ].join("\n")
+
+  return runCommandCapture(
+    {
+      cwd: process.cwd(),
+      command: "sh",
+      args: ["-c", script, "sh", webPort()]
+    },
+    [0],
+    () => browserFrontendError("Failed to inspect docker-git browser frontend port.")
+  ).pipe(
+    Effect.map((output) => parsePids(output)),
+    Effect.orElseSucceed((): ReadonlyArray<string> => [])
+  )
+}
+
+const stopWebServerPids = (
+  pids: ReadonlyArray<string>
+): Effect.Effect<void, ControllerBootstrapError | PlatformError, CommandExecutor.CommandExecutor> => {
+  if (pids.length === 0) {
+    return Effect.void
+  }
+
+  const script = [
+    "kill \"$@\" 2>/dev/null || true",
+    "sleep 1",
+    "kill -9 \"$@\" 2>/dev/null || true"
+  ].join("\n")
+
+  return runCommandExitCode({
+    cwd: process.cwd(),
+    command: "sh",
+    args: ["-c", script, "sh", ...pids]
+  }).pipe(
+    Effect.flatMap((exitCode) =>
+      exitCode === 0
+        ? Effect.void
+        : Effect.fail(browserFrontendError(`Failed to stop browser frontend pids: ${pids.join(", ")}`))
+    )
+  )
+}
+
+const readBrowserFrontendRuntimeState = (): Effect.Effect<
+  BrowserFrontendRuntimeState,
+  never,
+  ControllerRuntime
+> =>
+  Effect.all({
+    controllerRunning: controllerExists().pipe(Effect.orElseSucceed(() => false)),
+    webPids: findWebServerPids()
+  })
+
+const renderRunningSummary = (state: BrowserFrontendRuntimeState): string =>
+  [
+    state.controllerRunning ? "API controller is already running" : "",
+    state.webPids.length > 0 ? `browser frontend is listening on port ${webPort()}` : ""
+  ].filter((line) => line.length > 0).join("; ")
+
+const hasRunningBrowserStack = (state: BrowserFrontendRuntimeState): boolean =>
+  state.controllerRunning || state.webPids.length > 0
+
+const normalizePromptAnswer = (answer: string): boolean => {
+  const normalized = answer.trim().toLowerCase()
+  return normalized.length === 0 || normalized === "y" || normalized === "yes" || normalized === "д" ||
+    normalized === "да"
+}
+
+const promptRestart = (state: BrowserFrontendRuntimeState): Effect.Effect<boolean> => {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return Effect.succeed(true)
+  }
+
+  return Effect.async((resume) => {
+    const onData = (chunk: Buffer) => {
+      process.stdin.off("data", onData)
+      resume(Effect.succeed(normalizePromptAnswer(chunk.toString("utf8"))))
+    }
+
+    process.stdout.write(`${renderRunningSummary(state)}. Restart API and web frontend? [Y/n] `)
+    process.stdin.resume()
+    process.stdin.once("data", onData)
+
+    return Effect.sync(() => {
+      process.stdin.off("data", onData)
+    })
+  })
+}
+
+const shouldRestartBrowserStack = (
+  state: BrowserFrontendRuntimeState
+): Effect.Effect<boolean> => hasRunningBrowserStack(state) ? promptRestart(state) : Effect.succeed(false)
+
+const stopCurrentWebServer = (): Effect.Effect<
+  void,
+  ControllerBootstrapError | PlatformError,
+  CommandExecutor.CommandExecutor
+> =>
+  pipe(
+    findWebServerPids(),
+    Effect.tap((pids) =>
+      pids.length === 0 ? Effect.void : Effect.log(`Stopping existing browser frontend pids: ${pids.join(", ")}`)
+    ),
+    Effect.flatMap((pids) => stopWebServerPids(pids))
+  )
+
+const prepareBrowserStack = (): Effect.Effect<
+  boolean,
+  ControllerBootstrapError | PlatformError,
+  ControllerRuntime
+> =>
+  Effect.gen(function*(_) {
+    const runtimeState = yield* _(readBrowserFrontendRuntimeState())
+    const restart = yield* _(shouldRestartBrowserStack(runtimeState))
+    if (!restart) {
+      yield* _(ensureControllerReady())
+      return runtimeState.webPids.length === 0
+    }
+
+    yield* _(Effect.log("Restarting docker-git API controller."))
+    yield* _(restartController())
+    yield* _(stopCurrentWebServer())
+    return true
   })
 
 const ensureSuccess = (
@@ -71,3 +221,26 @@ export const runBrowserFrontend: Effect.Effect<
   const serveExitCode = yield* _(runStreaming(["run", "--cwd", "packages/app", "serve:web"], env))
   yield* _(ensureSuccess(serveExitCode, "Browser frontend server"))
 })
+
+// CHANGE: make `docker-git browser` idempotent for local development
+// WHY: repeated invocations should deploy current controller code and replace the previous web process
+// QUOTE(ТЗ): "если её вызвать заново то перезапустит и web и api"
+// REF: user-request-2026-04-21-browser-restart
+// SOURCE: n/a
+// FORMAT THEOREM: ∀run: existing(api ∨ web) ∧ confirm(run) → restarted(api) ∧ restarted(web)
+// PURITY: SHELL
+// EFFECT: Effect<void, ControllerBootstrapError | PlatformError, CommandExecutor>
+// INVARIANT: a confirmed rerun force-recreates the controller before serving the new frontend
+// COMPLEXITY: O(processes + compose)
+export const runBrowserFrontendCommand: Effect.Effect<
+  void,
+  ControllerBootstrapError | PlatformError,
+  ControllerRuntime
+> = pipe(
+  prepareBrowserStack(),
+  Effect.flatMap((shouldStartWeb) =>
+    shouldStartWeb
+      ? runBrowserFrontend
+      : Effect.log(`docker-git browser frontend is already running at http://${webHost()}:${webPort()}/`)
+  )
+)

--- a/packages/app/src/docker-git/controller.ts
+++ b/packages/app/src/docker-git/controller.ts
@@ -290,3 +290,16 @@ export const ensureControllerReady = (): Effect.Effect<void, ControllerBootstrap
     }
     yield* _(startAndRememberController(bootstrapContext))
   })
+
+export const restartController = (): Effect.Effect<void, ControllerBootstrapError, ControllerRuntime> =>
+  Effect.gen(function*(_) {
+    yield* _(failIfRemoteDockerWithoutApiUrl())
+    const explicitApiBaseUrl = resolveExplicitApiBaseUrl()
+    if (explicitApiBaseUrl !== undefined) {
+      yield* _(ensureControllerReady())
+      return
+    }
+
+    const bootstrapContext = yield* _(loadControllerBootstrapContext())
+    yield* _(startAndRememberController({ ...bootstrapContext, forceRecreateController: true }))
+  })

--- a/packages/app/src/docker-git/program.ts
+++ b/packages/app/src/docker-git/program.ts
@@ -25,7 +25,7 @@ import {
   renderProjectSummaryLine,
   syncState
 } from "./api-client.js"
-import { runBrowserFrontend } from "./browser-frontend.js"
+import { runBrowserFrontendCommand } from "./browser-frontend.js"
 import { readCommand } from "./cli/read-command.js"
 import { usageText } from "./cli/usage.js"
 import { type ControllerRuntime, ensureControllerReady } from "./controller.js"
@@ -236,7 +236,7 @@ const dispatchOperationalCommand = (
 ): Effect.Effect<void, CliError, ControllerRuntime> =>
   Match.value(command).pipe(
     Match.when({ _tag: "Menu" }, () => withControllerReady(runMenu)),
-    Match.when({ _tag: "Browser" }, () => withControllerReady(runBrowserFrontend)),
+    Match.when({ _tag: "Browser" }, () => runBrowserFrontendCommand),
     Match.when({ _tag: "Create" }, handleCreateCommand),
     Match.when({ _tag: "Open" }, handleOpenCommand),
     Match.when({ _tag: "Status" }, handleStatusCommand),

--- a/packages/app/tests/docker-git/browser-frontend.test.ts
+++ b/packages/app/tests/docker-git/browser-frontend.test.ts
@@ -1,0 +1,123 @@
+import { NodeContext as BrowserFrontendTestNodeContext } from "@effect/platform-node"
+import { describe, expect, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { afterEach, beforeEach, vi } from "vitest"
+
+type CommandSpec = {
+  readonly args: ReadonlyArray<string>
+  readonly command: string
+  readonly cwd: string
+  readonly env?: Readonly<Record<string, string | undefined>>
+}
+
+const ensureControllerReadyMock = vi.hoisted(() => vi.fn<() => Effect.Effect<void>>())
+const restartControllerMock = vi.hoisted(() => vi.fn<() => Effect.Effect<void>>())
+const controllerExistsMock = vi.hoisted(() => vi.fn<() => Effect.Effect<boolean>>())
+const runCommandCaptureMock = vi.hoisted(() => vi.fn<(spec: CommandSpec) => Effect.Effect<string>>())
+const runCommandExitCodeMock = vi.hoisted(() => vi.fn<(spec: CommandSpec) => Effect.Effect<number>>())
+const runCommandExitCodeStreamingMock = vi.hoisted(() => vi.fn<(spec: CommandSpec) => Effect.Effect<number>>())
+
+vi.mock("../../src/docker-git/controller.js", () => ({
+  ensureControllerReady: ensureControllerReadyMock,
+  resolveApiBaseUrl: () => "http://127.0.0.1:3334",
+  restartController: restartControllerMock
+}))
+
+vi.mock("../../src/docker-git/controller-docker.js", () => ({
+  controllerExists: controllerExistsMock
+}))
+
+vi.mock("../../src/docker-git/frontend-lib/shell/command-runner.js", () => ({
+  runCommandCapture: runCommandCaptureMock,
+  runCommandExitCode: runCommandExitCodeMock,
+  runCommandExitCodeStreaming: runCommandExitCodeStreamingMock
+}))
+
+const originalStdinTty = process.stdin.isTTY
+const originalStdoutTty = process.stdout.isTTY
+
+const makeNonInteractive = (): void => {
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: false })
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: false })
+}
+
+const restoreTty = (): void => {
+  Object.defineProperty(process.stdin, "isTTY", { configurable: true, value: originalStdinTty })
+  Object.defineProperty(process.stdout, "isTTY", { configurable: true, value: originalStdoutTty })
+}
+
+const runBrowserCommandUnderTest = Effect.gen(function*(_) {
+  const { runBrowserFrontendCommand } = yield* _(
+    Effect.promise(() => import("../../src/docker-git/browser-frontend.js"))
+  )
+  yield* _(runBrowserFrontendCommand.pipe(Effect.provide(BrowserFrontendTestNodeContext.layer)))
+})
+
+describe("browser frontend command", () => {
+  beforeEach(() => {
+    vi.resetModules()
+    makeNonInteractive()
+    ensureControllerReadyMock.mockReset()
+    ensureControllerReadyMock.mockImplementation(() => Effect.void)
+    restartControllerMock.mockReset()
+    restartControllerMock.mockImplementation(() => Effect.void)
+    controllerExistsMock.mockReset()
+    controllerExistsMock.mockImplementation(() => Effect.succeed(false))
+    runCommandCaptureMock.mockReset()
+    runCommandCaptureMock.mockImplementation(() => Effect.succeed(""))
+    runCommandExitCodeMock.mockReset()
+    runCommandExitCodeMock.mockImplementation(() => Effect.succeed(0))
+    runCommandExitCodeStreamingMock.mockReset()
+    runCommandExitCodeStreamingMock.mockImplementation(() => Effect.succeed(0))
+  })
+
+  afterEach(() => {
+    restoreTty()
+    delete process.env["DOCKER_GIT_WEB_PORT"]
+    delete process.env["DOCKER_GIT_WEB_HOST"]
+  })
+
+  it.effect("starts controller and web when nothing is running", () =>
+    Effect.gen(function*(_) {
+      yield* _(runBrowserCommandUnderTest)
+
+      expect(ensureControllerReadyMock).toHaveBeenCalledTimes(1)
+      expect(restartControllerMock).not.toHaveBeenCalled()
+      expect(runCommandExitCodeMock).not.toHaveBeenCalled()
+      expect(runCommandExitCodeStreamingMock).toHaveBeenCalledTimes(2)
+    }))
+
+  it.effect("restarts controller and replaces the web process when rerun non-interactively", () =>
+    Effect.gen(function*(_) {
+      const events: Array<string> = []
+      controllerExistsMock.mockImplementation(() => Effect.succeed(true))
+      runCommandCaptureMock.mockImplementation(() => Effect.succeed("123\n"))
+      restartControllerMock.mockImplementation(() =>
+        Effect.sync(() => {
+          events.push("restart-controller")
+        })
+      )
+      runCommandExitCodeMock.mockImplementation((spec) =>
+        Effect.sync(() => {
+          events.push(`stop:${spec.args.join(" ")}`)
+          return 0
+        })
+      )
+      runCommandExitCodeStreamingMock.mockImplementation((spec) =>
+        Effect.sync(() => {
+          events.push(`stream:${spec.args.join(" ")}`)
+          return 0
+        })
+      )
+
+      yield* _(runBrowserCommandUnderTest)
+
+      expect(ensureControllerReadyMock).not.toHaveBeenCalled()
+      expect(events).toEqual([
+        "restart-controller",
+        "stop:-c kill \"$@\" 2>/dev/null || true\nsleep 1\nkill -9 \"$@\" 2>/dev/null || true sh 123",
+        "stream:run --cwd packages/app build:web",
+        "stream:run --cwd packages/app serve:web"
+      ])
+    }))
+})

--- a/packages/app/tests/docker-git/program.test.ts
+++ b/packages/app/tests/docker-git/program.test.ts
@@ -6,7 +6,7 @@ import { beforeEach, vi } from "vitest"
 import type { Command } from "../../src/docker-git/frontend-lib/core/domain.js"
 
 const ensureControllerReadyMock = vi.hoisted(() => vi.fn(() => Effect.void))
-const runBrowserFrontendMock = vi.hoisted(() => vi.fn(() => Effect.void))
+const runBrowserFrontendCommandMock = vi.hoisted(() => vi.fn(() => Effect.void))
 const runMenuCallMock = vi.hoisted(() => vi.fn(() => {}))
 const readCommandMock = vi.hoisted(() => vi.fn<() => Command>())
 const codexLoginMock = vi.hoisted(() => vi.fn(() => Effect.void))
@@ -30,7 +30,7 @@ vi.mock("../../src/docker-git/controller.js", () => ({
 }))
 
 vi.mock("../../src/docker-git/browser-frontend.js", () => ({
-  runBrowserFrontend: Effect.flatMap(Effect.sync(() => runBrowserFrontendMock()), (effect) => effect)
+  runBrowserFrontendCommand: Effect.flatMap(Effect.sync(() => runBrowserFrontendCommandMock()), (effect) => effect)
 }))
 
 vi.mock("../../src/docker-git/api-client.js", () => ({
@@ -72,8 +72,8 @@ describe("program menu dispatch", () => {
   beforeEach(() => {
     ensureControllerReadyMock.mockReset()
     ensureControllerReadyMock.mockImplementation(() => Effect.void)
-    runBrowserFrontendMock.mockReset()
-    runBrowserFrontendMock.mockImplementation(() => Effect.void)
+    runBrowserFrontendCommandMock.mockReset()
+    runBrowserFrontendCommandMock.mockImplementation(() => Effect.void)
     runMenuCallMock.mockReset()
     readCommandMock.mockReset()
     readCommandMock.mockReturnValue(menuCommand)
@@ -94,13 +94,13 @@ describe("program menu dispatch", () => {
       expect(process.exitCode ?? 0).toBe(0)
     }))
 
-  it.effect("routes browser frontend through controller bootstrap", () =>
+  it.effect("routes browser frontend through the browser command runner", () =>
     Effect.gen(function*(_) {
       readCommandMock.mockReturnValue(browserCommand)
       yield* _(runProgram())
 
-      expect(ensureControllerReadyMock).toHaveBeenCalledTimes(1)
-      expect(runBrowserFrontendMock).toHaveBeenCalledTimes(1)
+      expect(ensureControllerReadyMock).not.toHaveBeenCalled()
+      expect(runBrowserFrontendCommandMock).toHaveBeenCalledTimes(1)
       expect(process.exitCode ?? 0).toBe(0)
     }))
 


### PR DESCRIPTION
## Summary
- make `docker-git browser` / `docker-git web` detect an already-running API controller or browser frontend
- prompt for restart in interactive terminals and restart automatically in non-interactive runs
- force-recreate the local API controller on confirmed restart, stop the old web process on the configured port, then build and serve the current frontend

## Mathematical guarantees
- Invariant: confirmed rerun of the browser command deploys the current controller code before serving the frontend.
- Invariant: at most one web frontend listener is intentionally left on `DOCKER_GIT_WEB_PORT` after confirmed restart.
- Invariant: declining restart preserves the existing web listener and does not start a competing server on the same port.

## Verification
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app lint`
- `bun run --cwd packages/app lint:tests`
- `bun run --cwd packages/app test`
- `bun run --cwd packages/app lint:effect`
- `bun run --cwd packages/app build`
