### PR TITLE
fix: configure changeset github changelog

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -3,7 +3,7 @@
   "changelog": [
     "@changesets/changelog-github",
     {
-      "repo": "<PLACEHOLDER>"
+      "repo": "ProverCoderAI/docker-git"
     }
   ],
   "commit": false,


### PR DESCRIPTION
Fixes the Release workflow failure in changeset versioning by replacing the placeholder changelog repo with ProverCoderAI/docker-git.