### PR TITLE
fix: pass github token to changeset version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -240,6 +240,8 @@ jobs:
       - name: Version packages
         if: steps.compare_npm.outputs.should_release != 'false' && github.actor != 'github-actions[bot]'
         shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
           bun run changeset-version


### PR DESCRIPTION
Fixes the Release workflow after changeset changelog setup by exposing GITHUB_TOKEN to the changeset version step. Without this, @changesets/changelog-github cannot read GitHub metadata and aborts versioning.