### PR TITLE
fix: make session sync cli self-contained

### DIFF
--- a/.changeset/fix-session-sync-entrypoint.md
+++ b/.changeset/fix-session-sync-entrypoint.md
@@ -1,0 +1,5 @@
+---
+"@prover-coder-ai/docker-git-session-sync": patch
+---
+
+Remove the unnecessary Effect platform runtime import from the CLI entrypoint so globally installed post-push session backups start without optional platform-node peer dependencies.

--- a/bun.lock
+++ b/bun.lock
@@ -37,7 +37,7 @@
     },
     "packages/app": {
       "name": "@prover-coder-ai/docker-git",
-      "version": "1.0.81",
+      "version": "1.0.82",
       "bin": {
         "docker-git": "dist/src/docker-git/main.js",
       },
@@ -106,13 +106,9 @@
     },
     "packages/docker-git-session-sync": {
       "name": "@prover-coder-ai/docker-git-session-sync",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "bin": {
         "docker-git-session-sync": "dist/docker-git-session-sync.js",
-      },
-      "dependencies": {
-        "@effect/platform-node": "^0.106.0",
-        "effect": "^3.21.0",
       },
       "devDependencies": {
         "@effect/vitest": "^0.29.0",

--- a/packages/docker-git-session-sync/package.json
+++ b/packages/docker-git-session-sync/package.json
@@ -36,10 +36,6 @@
   },
   "homepage": "https://github.com/ProverCoderAI/docker-git#readme",
   "packageManager": "bun@1.3.11",
-  "dependencies": {
-    "@effect/platform-node": "^0.106.0",
-    "effect": "^3.21.0"
-  },
   "devDependencies": {
     "@effect/vitest": "^0.29.0",
     "@types/node": "^24.12.0",

--- a/packages/docker-git-session-sync/src/main.ts
+++ b/packages/docker-git-session-sync/src/main.ts
@@ -1,19 +1,12 @@
-import { NodeRuntime } from "@effect/platform-node"
-import { Effect } from "effect"
-
 import { runCli } from "./cli.js"
 
-const program = Effect.sync(() => {
-  try {
-    const exitCode = runCli(process.argv.slice(2), process.cwd())
-    if (exitCode !== 0) {
-      process.exitCode = exitCode
-    }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error)
-    process.stderr.write(`${message}\n`)
-    process.exitCode = 1
+try {
+  const exitCode = runCli(process.argv.slice(2), process.cwd())
+  if (exitCode !== 0) {
+    process.exitCode = exitCode
   }
-})
-
-NodeRuntime.runMain(program)
+} catch (error) {
+  const message = error instanceof Error ? error.message : String(error)
+  process.stderr.write(`${message}\n`)
+  process.exitCode = 1
+}


### PR DESCRIPTION
## Summary
- remove the unnecessary Effect runtime import from docker-git-session-sync CLI entrypoint
- drop the now-unused runtime dependencies from the package
- add a patch changeset for publishing the fixed CLI

## Verification
- bun run --cwd packages/docker-git-session-sync build
- bun run --cwd packages/docker-git-session-sync typecheck
- bun run --cwd packages/docker-git-session-sync test
- bun run check:dist-deps-prune
- bun run check
- docker-git-session-sync --help
- /opt/docker-git/hooks/post-push (now reaches session-backup output instead of module import failure)