### PR TITLE
feat(docker-git): add resource limits for MCP Playwright sidecar

### DIFF
--- a/.changeset/playwright-resource-limits.md
+++ b/.changeset/playwright-resource-limits.md
@@ -1,0 +1,6 @@
+---
+"@prover-coder-ai/docker-git": minor
+"@effect-template/lib": minor
+---
+
+Add configurable CPU and RAM limits for the MCP Playwright sidecar container, separate from the main service container. Exposed via `--playwright-cpu`/`--playwright-cpus` and `--playwright-ram`/`--playwright-memory` CLI flags. Defaults to 30% of host resources, falling back to the main service limits when not set.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-09T17:35:24.814Z for PR creation at branch issue-259-9a9eea9aba5c for issue https://github.com/ProverCoderAI/docker-git/issues/259

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-09T17:35:24.814Z for PR creation at branch issue-259-9a9eea9aba5c for issue https://github.com/ProverCoderAI/docker-git/issues/259

--- a/packages/app/src/docker-git/cli/parser-apply.ts
+++ b/packages/app/src/docker-git/cli/parser-apply.ts
@@ -22,6 +22,8 @@ export const parseApply = (
     const { projectDir, raw } = yield* _(parseProjectDirWithOptions(args))
     const cpuLimit = yield* _(normalizeCpuLimit(raw.cpuLimit, "--cpu"))
     const ramLimit = yield* _(normalizeRamLimit(raw.ramLimit, "--ram"))
+    const playwrightCpuLimit = yield* _(normalizeCpuLimit(raw.playwrightCpuLimit, "--playwright-cpu"))
+    const playwrightRamLimit = yield* _(normalizeRamLimit(raw.playwrightRamLimit, "--playwright-ram"))
     return {
       _tag: "Apply",
       projectDir,
@@ -31,6 +33,8 @@ export const parseApply = (
       claudeTokenLabel: raw.claudeTokenLabel,
       cpuLimit,
       ramLimit,
+      playwrightCpuLimit,
+      playwrightRamLimit,
       enableMcpPlaywright: raw.enableMcpPlaywright
     }
   })

--- a/packages/app/src/docker-git/cli/parser-options.ts
+++ b/packages/app/src/docker-git/cli/parser-options.ts
@@ -22,6 +22,8 @@ interface ValueOptionSpec {
     | "codexHome"
     | "cpuLimit"
     | "ramLimit"
+    | "playwrightCpuLimit"
+    | "playwrightRamLimit"
     | "dockerNetworkMode"
     | "dockerSharedNetworkName"
     | "archivePath"
@@ -60,6 +62,10 @@ const valueOptionSpecs: ReadonlyArray<ValueOptionSpec> = [
   { flag: "--cpus", key: "cpuLimit" },
   { flag: "--ram", key: "ramLimit" },
   { flag: "--memory", key: "ramLimit" },
+  { flag: "--playwright-cpu", key: "playwrightCpuLimit" },
+  { flag: "--playwright-cpus", key: "playwrightCpuLimit" },
+  { flag: "--playwright-ram", key: "playwrightRamLimit" },
+  { flag: "--playwright-memory", key: "playwrightRamLimit" },
   { flag: "--network-mode", key: "dockerNetworkMode" },
   { flag: "--shared-network", key: "dockerSharedNetworkName" },
   { flag: "--archive", key: "archivePath" },
@@ -118,6 +124,8 @@ const valueFlagUpdaters: { readonly [K in ValueKey]: (raw: RawOptions, value: st
   codexHome: (raw, value) => ({ ...raw, codexHome: value }),
   cpuLimit: (raw, value) => ({ ...raw, cpuLimit: value }),
   ramLimit: (raw, value) => ({ ...raw, ramLimit: value }),
+  playwrightCpuLimit: (raw, value) => ({ ...raw, playwrightCpuLimit: value }),
+  playwrightRamLimit: (raw, value) => ({ ...raw, playwrightRamLimit: value }),
   dockerNetworkMode: (raw, value) => ({ ...raw, dockerNetworkMode: value }),
   dockerSharedNetworkName: (raw, value) => ({ ...raw, dockerSharedNetworkName: value }),
   archivePath: (raw, value) => ({ ...raw, archivePath: value }),

--- a/packages/app/src/docker-git/cli/usage.ts
+++ b/packages/app/src/docker-git/cli/usage.ts
@@ -54,6 +54,8 @@ Options:
   --codex-home <path>       Container path for Codex auth (default: /home/dev/.codex)
   --cpu <value>             CPU limit: percent or cores (examples: 30%, 1.5; default: 30%)
   --ram <value>             RAM limit: percent or size (examples: 30%, 512m, 4g; default: 30%)
+  --playwright-cpu <value>  CPU limit for the MCP Playwright browser sidecar (default: 30% or --cpu when set)
+  --playwright-ram <value>  RAM limit for the MCP Playwright browser sidecar (default: 30% or --ram when set)
   --network-mode <mode>     Compose network mode: shared|project (default: shared)
   --shared-network <name>   Shared Docker network name when network-mode=shared (default: docker-git-shared)
   --out-dir <path>          Output directory (default: <projectsRoot>/<org>/<repo>[/issue-<id>|/pr-<id>])

--- a/packages/app/src/docker-git/frontend-lib/core/command-builders.ts
+++ b/packages/app/src/docker-git/frontend-lib/core/command-builders.ts
@@ -8,15 +8,13 @@ import { type RawOptions } from "./command-options.js"
 import {
   type AgentMode,
   type CreateCommand,
-  defaultCpuLimit,
-  defaultRamLimit,
   defaultTemplateConfig,
   deriveRepoPathParts,
   deriveRepoSlug,
   type ParseError,
   resolveRepoInput
 } from "./domain.js"
-import { normalizeCpuLimit, normalizeRamLimit } from "./resource-limits.js"
+import { resolveResourceLimitsIntent } from "./resource-limits.js"
 import { trimRightChar } from "./strings.js"
 import { normalizeAuthLabel, normalizeGitTokenLabel } from "./token-labels.js"
 
@@ -193,6 +191,8 @@ type BuildTemplateConfigInput = {
   readonly paths: PathConfig
   readonly cpuLimit: string | undefined
   readonly ramLimit: string | undefined
+  readonly playwrightCpuLimit: string | undefined
+  readonly playwrightRamLimit: string | undefined
   readonly dockerNetworkMode: CreateCommand["config"]["dockerNetworkMode"]
   readonly dockerSharedNetworkName: string
   readonly gitTokenLabel: string | undefined
@@ -205,53 +205,64 @@ type BuildTemplateConfigInput = {
   readonly clonedOnHostname?: string | undefined
 }
 
-const buildTemplateConfig = ({
-  agentAuto,
-  agentMode,
-  claudeAuthLabel,
-  clonedOnHostname,
-  codexAuthLabel,
-  cpuLimit,
-  dockerNetworkMode,
-  dockerSharedNetworkName,
-  enableMcpPlaywright,
-  gitTokenLabel,
-  names,
-  paths,
-  ramLimit,
-  repo,
-  skipGithubAuth
-}: BuildTemplateConfigInput): CreateCommand["config"] => ({
-  containerName: names.containerName,
-  serviceName: names.serviceName,
-  sshUser: repo.sshUser,
-  sshPort: repo.sshPort,
-  repoUrl: repo.repoUrl,
-  repoRef: repo.repoRef,
-  gitTokenLabel,
-  skipGithubAuth,
-  codexAuthLabel,
-  claudeAuthLabel,
-  targetDir: repo.targetDir,
-  volumeName: names.volumeName,
-  dockerGitPath: paths.dockerGitPath,
-  authorizedKeysPath: paths.authorizedKeysPath,
-  envGlobalPath: paths.envGlobalPath,
-  envProjectPath: paths.envProjectPath,
-  codexAuthPath: paths.codexAuthPath,
-  codexSharedAuthPath: paths.codexSharedAuthPath,
-  codexHome: paths.codexHome,
-  geminiAuthPath: paths.geminiAuthPath,
-  geminiHome: paths.geminiHome,
-  cpuLimit,
-  ramLimit,
-  dockerNetworkMode,
-  dockerSharedNetworkName,
-  enableMcpPlaywright,
+const buildTemplateConfigBase = (
+  input: Pick<BuildTemplateConfigInput, "repo" | "names" | "paths">
+): Pick<
+  CreateCommand["config"],
+  | "containerName"
+  | "serviceName"
+  | "sshUser"
+  | "sshPort"
+  | "repoUrl"
+  | "repoRef"
+  | "targetDir"
+  | "volumeName"
+  | "dockerGitPath"
+  | "authorizedKeysPath"
+  | "envGlobalPath"
+  | "envProjectPath"
+  | "codexAuthPath"
+  | "codexSharedAuthPath"
+  | "codexHome"
+  | "geminiAuthPath"
+  | "geminiHome"
+> => ({
+  containerName: input.names.containerName,
+  serviceName: input.names.serviceName,
+  sshUser: input.repo.sshUser,
+  sshPort: input.repo.sshPort,
+  repoUrl: input.repo.repoUrl,
+  repoRef: input.repo.repoRef,
+  targetDir: input.repo.targetDir,
+  volumeName: input.names.volumeName,
+  dockerGitPath: input.paths.dockerGitPath,
+  authorizedKeysPath: input.paths.authorizedKeysPath,
+  envGlobalPath: input.paths.envGlobalPath,
+  envProjectPath: input.paths.envProjectPath,
+  codexAuthPath: input.paths.codexAuthPath,
+  codexSharedAuthPath: input.paths.codexSharedAuthPath,
+  codexHome: input.paths.codexHome,
+  geminiAuthPath: input.paths.geminiAuthPath,
+  geminiHome: input.paths.geminiHome
+})
+
+const buildTemplateConfig = (input: BuildTemplateConfigInput): CreateCommand["config"] => ({
+  ...buildTemplateConfigBase(input),
+  gitTokenLabel: input.gitTokenLabel,
+  skipGithubAuth: input.skipGithubAuth,
+  codexAuthLabel: input.codexAuthLabel,
+  claudeAuthLabel: input.claudeAuthLabel,
+  cpuLimit: input.cpuLimit,
+  ramLimit: input.ramLimit,
+  playwrightCpuLimit: input.playwrightCpuLimit,
+  playwrightRamLimit: input.playwrightRamLimit,
+  dockerNetworkMode: input.dockerNetworkMode,
+  dockerSharedNetworkName: input.dockerSharedNetworkName,
+  enableMcpPlaywright: input.enableMcpPlaywright,
   bunVersion: defaultTemplateConfig.bunVersion,
-  agentMode,
-  agentAuto,
-  clonedOnHostname
+  agentMode: input.agentMode,
+  agentAuto: input.agentAuto,
+  clonedOnHostname: input.clonedOnHostname
 })
 
 // CHANGE: build a typed create command from raw options (CLI or API)
@@ -275,8 +286,7 @@ export const buildCreateCommand = (
     const gitTokenLabel = normalizeGitTokenLabel(raw.gitTokenLabel)
     const codexAuthLabel = normalizeAuthLabel(raw.codexTokenLabel)
     const claudeAuthLabel = normalizeAuthLabel(raw.claudeTokenLabel)
-    const cpuLimit = yield* _(normalizeCpuLimit(raw.cpuLimit ?? defaultCpuLimit, "--cpu"))
-    const ramLimit = yield* _(normalizeRamLimit(raw.ramLimit ?? defaultRamLimit, "--ram"))
+    const limits = yield* _(resolveResourceLimitsIntent(raw))
     const dockerNetworkMode = yield* _(parseDockerNetworkMode(raw.dockerNetworkMode))
     const dockerSharedNetworkName = yield* _(
       nonEmpty("--shared-network", raw.dockerSharedNetworkName, defaultTemplateConfig.dockerSharedNetworkName)
@@ -295,8 +305,10 @@ export const buildCreateCommand = (
         repo,
         names,
         paths,
-        cpuLimit,
-        ramLimit,
+        cpuLimit: limits.cpuLimit,
+        ramLimit: limits.ramLimit,
+        playwrightCpuLimit: limits.playwrightCpuLimit,
+        playwrightRamLimit: limits.playwrightRamLimit,
         dockerNetworkMode,
         dockerSharedNetworkName,
         gitTokenLabel,

--- a/packages/app/src/docker-git/frontend-lib/core/command-options.ts
+++ b/packages/app/src/docker-git/frontend-lib/core/command-options.ts
@@ -28,6 +28,8 @@ export interface RawOptions {
   readonly codexHome?: string
   readonly cpuLimit?: string
   readonly ramLimit?: string
+  readonly playwrightCpuLimit?: string
+  readonly playwrightRamLimit?: string
   readonly dockerNetworkMode?: string
   readonly dockerSharedNetworkName?: string
   readonly enableMcpPlaywright?: boolean

--- a/packages/app/src/docker-git/frontend-lib/core/domain.ts
+++ b/packages/app/src/docker-git/frontend-lib/core/domain.ts
@@ -42,6 +42,8 @@ export {
   defaultCpuLimit,
   defaultDockerNetworkMode,
   defaultDockerSharedNetworkName,
+  defaultPlaywrightCpuLimit,
+  defaultPlaywrightRamLimit,
   defaultRamLimit,
   defaultTemplateConfig,
   dockerGitSharedCacheVolumeName,
@@ -78,6 +80,8 @@ export interface TemplateConfig {
   readonly geminiHome: string
   readonly cpuLimit?: string | undefined
   readonly ramLimit?: string | undefined
+  readonly playwrightCpuLimit?: string | undefined
+  readonly playwrightRamLimit?: string | undefined
   readonly dockerNetworkMode: DockerNetworkMode
   readonly dockerSharedNetworkName: string
   readonly enableMcpPlaywright: boolean
@@ -170,6 +174,8 @@ export interface ApplyCommand {
   readonly geminiTokenLabel?: string | undefined
   readonly cpuLimit?: string | undefined
   readonly ramLimit?: string | undefined
+  readonly playwrightCpuLimit?: string | undefined
+  readonly playwrightRamLimit?: string | undefined
   readonly enableMcpPlaywright?: boolean | undefined
 }
 

--- a/packages/app/src/docker-git/frontend-lib/core/resource-limits.ts
+++ b/packages/app/src/docker-git/frontend-lib/core/resource-limits.ts
@@ -1,7 +1,15 @@
 /* jscpd:ignore-start */
 import { Either } from "effect"
 
-import { defaultCpuLimit, defaultRamLimit, type ParseError, type TemplateConfig } from "./domain.js"
+import { type RawOptions } from "./command-options.js"
+import {
+  defaultCpuLimit,
+  defaultPlaywrightCpuLimit,
+  defaultPlaywrightRamLimit,
+  defaultRamLimit,
+  type ParseError,
+  type TemplateConfig
+} from "./domain.js"
 
 const mebibyte = 1024 ** 2
 const minimumResolvedCpuLimit = 0.25
@@ -109,7 +117,9 @@ export const withDefaultResourceLimitIntent = (
 ): TemplateConfig => ({
   ...template,
   cpuLimit: template.cpuLimit ?? defaultCpuLimit,
-  ramLimit: template.ramLimit ?? defaultRamLimit
+  ramLimit: template.ramLimit ?? defaultRamLimit,
+  playwrightCpuLimit: template.playwrightCpuLimit ?? defaultPlaywrightCpuLimit,
+  playwrightRamLimit: template.playwrightRamLimit ?? defaultPlaywrightRamLimit
 })
 
 const resolvePercentCpuLimit = (percent: number, cpuCount: number): number =>
@@ -142,4 +152,38 @@ export const resolveComposeResourceLimits = (
       : resolvePercentRamLimit(ramPercent, hostResources.totalMemoryBytes)
   }
 }
+
+export const resolvePlaywrightComposeResourceLimits = (
+  template: Pick<TemplateConfig, "playwrightCpuLimit" | "playwrightRamLimit" | "cpuLimit" | "ramLimit">,
+  hostResources: HostResources
+): ResolvedComposeResourceLimits =>
+  resolveComposeResourceLimits(
+    {
+      cpuLimit: template.playwrightCpuLimit ?? template.cpuLimit ?? defaultPlaywrightCpuLimit,
+      ramLimit: template.playwrightRamLimit ?? template.ramLimit ?? defaultPlaywrightRamLimit
+    },
+    hostResources
+  )
+
+export type ResolvedResourceLimitsIntent = {
+  readonly cpuLimit: string | undefined
+  readonly ramLimit: string | undefined
+  readonly playwrightCpuLimit: string | undefined
+  readonly playwrightRamLimit: string | undefined
+}
+
+export const resolveResourceLimitsIntent = (
+  raw: RawOptions
+): Either.Either<ResolvedResourceLimitsIntent, ParseError> =>
+  Either.gen(function*(_) {
+    const cpuLimit = yield* _(normalizeCpuLimit(raw.cpuLimit ?? defaultCpuLimit, "--cpu"))
+    const ramLimit = yield* _(normalizeRamLimit(raw.ramLimit ?? defaultRamLimit, "--ram"))
+    const playwrightCpuLimit = yield* _(
+      normalizeCpuLimit(raw.playwrightCpuLimit ?? cpuLimit, "--playwright-cpu")
+    )
+    const playwrightRamLimit = yield* _(
+      normalizeRamLimit(raw.playwrightRamLimit ?? ramLimit, "--playwright-ram")
+    )
+    return { cpuLimit, ramLimit, playwrightCpuLimit, playwrightRamLimit }
+  })
 /* jscpd:ignore-end */

--- a/packages/app/src/docker-git/frontend-lib/core/template-defaults.ts
+++ b/packages/app/src/docker-git/frontend-lib/core/template-defaults.ts
@@ -22,6 +22,8 @@ type DefaultTemplateConfig = Pick<
   | "geminiHome"
   | "cpuLimit"
   | "ramLimit"
+  | "playwrightCpuLimit"
+  | "playwrightRamLimit"
   | "dockerNetworkMode"
   | "dockerSharedNetworkName"
   | "enableMcpPlaywright"
@@ -37,6 +39,10 @@ export const dockerGitSharedCodexVolumeName = "docker-git-shared-codex"
 export const defaultCpuLimit = "30%"
 
 export const defaultRamLimit = "30%"
+
+export const defaultPlaywrightCpuLimit = "30%"
+
+export const defaultPlaywrightRamLimit = "30%"
 
 export const defaultTemplateConfig = {
   containerName: "dev-ssh",
@@ -58,6 +64,8 @@ export const defaultTemplateConfig = {
   geminiHome: "/home/dev/.gemini",
   cpuLimit: defaultCpuLimit,
   ramLimit: defaultRamLimit,
+  playwrightCpuLimit: defaultPlaywrightCpuLimit,
+  playwrightRamLimit: defaultPlaywrightRamLimit,
   dockerNetworkMode: defaultDockerNetworkMode,
   dockerSharedNetworkName: defaultDockerSharedNetworkName,
   enableMcpPlaywright: false,

--- a/packages/app/src/lib/core/command-builders.ts
+++ b/packages/app/src/lib/core/command-builders.ts
@@ -8,15 +8,13 @@ import { type RawOptions } from "./command-options.js"
 import {
   type AgentMode,
   type CreateCommand,
-  defaultCpuLimit,
-  defaultRamLimit,
   defaultTemplateConfig,
   deriveRepoPathParts,
   deriveRepoSlug,
   type ParseError,
   resolveRepoInput
 } from "./domain.js"
-import { normalizeCpuLimit, normalizeRamLimit } from "./resource-limits.js"
+import { resolveResourceLimitsIntent } from "./resource-limits.js"
 import { trimRightChar } from "./strings.js"
 import { normalizeAuthLabel, normalizeGitTokenLabel } from "./token-labels.js"
 
@@ -193,6 +191,8 @@ type BuildTemplateConfigInput = {
   readonly paths: PathConfig
   readonly cpuLimit: string | undefined
   readonly ramLimit: string | undefined
+  readonly playwrightCpuLimit: string | undefined
+  readonly playwrightRamLimit: string | undefined
   readonly dockerNetworkMode: CreateCommand["config"]["dockerNetworkMode"]
   readonly dockerSharedNetworkName: string
   readonly gitTokenLabel: string | undefined
@@ -205,53 +205,64 @@ type BuildTemplateConfigInput = {
   readonly clonedOnHostname?: string | undefined
 }
 
-const buildTemplateConfig = ({
-  agentAuto,
-  agentMode,
-  claudeAuthLabel,
-  clonedOnHostname,
-  codexAuthLabel,
-  cpuLimit,
-  dockerNetworkMode,
-  dockerSharedNetworkName,
-  enableMcpPlaywright,
-  gitTokenLabel,
-  names,
-  paths,
-  ramLimit,
-  repo,
-  skipGithubAuth
-}: BuildTemplateConfigInput): CreateCommand["config"] => ({
-  containerName: names.containerName,
-  serviceName: names.serviceName,
-  sshUser: repo.sshUser,
-  sshPort: repo.sshPort,
-  repoUrl: repo.repoUrl,
-  repoRef: repo.repoRef,
-  gitTokenLabel,
-  skipGithubAuth,
-  codexAuthLabel,
-  claudeAuthLabel,
-  targetDir: repo.targetDir,
-  volumeName: names.volumeName,
-  dockerGitPath: paths.dockerGitPath,
-  authorizedKeysPath: paths.authorizedKeysPath,
-  envGlobalPath: paths.envGlobalPath,
-  envProjectPath: paths.envProjectPath,
-  codexAuthPath: paths.codexAuthPath,
-  codexSharedAuthPath: paths.codexSharedAuthPath,
-  codexHome: paths.codexHome,
-  geminiAuthPath: paths.geminiAuthPath,
-  geminiHome: paths.geminiHome,
-  cpuLimit,
-  ramLimit,
-  dockerNetworkMode,
-  dockerSharedNetworkName,
-  enableMcpPlaywright,
+const buildTemplateConfigBase = (
+  input: Pick<BuildTemplateConfigInput, "repo" | "names" | "paths">
+): Pick<
+  CreateCommand["config"],
+  | "containerName"
+  | "serviceName"
+  | "sshUser"
+  | "sshPort"
+  | "repoUrl"
+  | "repoRef"
+  | "targetDir"
+  | "volumeName"
+  | "dockerGitPath"
+  | "authorizedKeysPath"
+  | "envGlobalPath"
+  | "envProjectPath"
+  | "codexAuthPath"
+  | "codexSharedAuthPath"
+  | "codexHome"
+  | "geminiAuthPath"
+  | "geminiHome"
+> => ({
+  containerName: input.names.containerName,
+  serviceName: input.names.serviceName,
+  sshUser: input.repo.sshUser,
+  sshPort: input.repo.sshPort,
+  repoUrl: input.repo.repoUrl,
+  repoRef: input.repo.repoRef,
+  targetDir: input.repo.targetDir,
+  volumeName: input.names.volumeName,
+  dockerGitPath: input.paths.dockerGitPath,
+  authorizedKeysPath: input.paths.authorizedKeysPath,
+  envGlobalPath: input.paths.envGlobalPath,
+  envProjectPath: input.paths.envProjectPath,
+  codexAuthPath: input.paths.codexAuthPath,
+  codexSharedAuthPath: input.paths.codexSharedAuthPath,
+  codexHome: input.paths.codexHome,
+  geminiAuthPath: input.paths.geminiAuthPath,
+  geminiHome: input.paths.geminiHome
+})
+
+const buildTemplateConfig = (input: BuildTemplateConfigInput): CreateCommand["config"] => ({
+  ...buildTemplateConfigBase(input),
+  gitTokenLabel: input.gitTokenLabel,
+  skipGithubAuth: input.skipGithubAuth,
+  codexAuthLabel: input.codexAuthLabel,
+  claudeAuthLabel: input.claudeAuthLabel,
+  cpuLimit: input.cpuLimit,
+  ramLimit: input.ramLimit,
+  playwrightCpuLimit: input.playwrightCpuLimit,
+  playwrightRamLimit: input.playwrightRamLimit,
+  dockerNetworkMode: input.dockerNetworkMode,
+  dockerSharedNetworkName: input.dockerSharedNetworkName,
+  enableMcpPlaywright: input.enableMcpPlaywright,
   bunVersion: defaultTemplateConfig.bunVersion,
-  agentMode,
-  agentAuto,
-  clonedOnHostname
+  agentMode: input.agentMode,
+  agentAuto: input.agentAuto,
+  clonedOnHostname: input.clonedOnHostname
 })
 
 // CHANGE: build a typed create command from raw options (CLI or API)
@@ -275,8 +286,7 @@ export const buildCreateCommand = (
     const gitTokenLabel = normalizeGitTokenLabel(raw.gitTokenLabel)
     const codexAuthLabel = normalizeAuthLabel(raw.codexTokenLabel)
     const claudeAuthLabel = normalizeAuthLabel(raw.claudeTokenLabel)
-    const cpuLimit = yield* _(normalizeCpuLimit(raw.cpuLimit ?? defaultCpuLimit, "--cpu"))
-    const ramLimit = yield* _(normalizeRamLimit(raw.ramLimit ?? defaultRamLimit, "--ram"))
+    const limits = yield* _(resolveResourceLimitsIntent(raw))
     const dockerNetworkMode = yield* _(parseDockerNetworkMode(raw.dockerNetworkMode))
     const dockerSharedNetworkName = yield* _(
       nonEmpty("--shared-network", raw.dockerSharedNetworkName, defaultTemplateConfig.dockerSharedNetworkName)
@@ -295,8 +305,10 @@ export const buildCreateCommand = (
         repo,
         names,
         paths,
-        cpuLimit,
-        ramLimit,
+        cpuLimit: limits.cpuLimit,
+        ramLimit: limits.ramLimit,
+        playwrightCpuLimit: limits.playwrightCpuLimit,
+        playwrightRamLimit: limits.playwrightRamLimit,
         dockerNetworkMode,
         dockerSharedNetworkName,
         gitTokenLabel,

--- a/packages/app/src/lib/core/command-options.ts
+++ b/packages/app/src/lib/core/command-options.ts
@@ -28,6 +28,8 @@ export interface RawOptions {
   readonly codexHome?: string
   readonly cpuLimit?: string
   readonly ramLimit?: string
+  readonly playwrightCpuLimit?: string
+  readonly playwrightRamLimit?: string
   readonly dockerNetworkMode?: string
   readonly dockerSharedNetworkName?: string
   readonly enableMcpPlaywright?: boolean

--- a/packages/app/src/lib/core/domain.ts
+++ b/packages/app/src/lib/core/domain.ts
@@ -42,6 +42,8 @@ export {
   defaultCpuLimit,
   defaultDockerNetworkMode,
   defaultDockerSharedNetworkName,
+  defaultPlaywrightCpuLimit,
+  defaultPlaywrightRamLimit,
   defaultRamLimit,
   defaultTemplateConfig,
   dockerGitSharedCacheVolumeName,
@@ -78,6 +80,8 @@ export interface TemplateConfig {
   readonly geminiHome: string
   readonly cpuLimit?: string | undefined
   readonly ramLimit?: string | undefined
+  readonly playwrightCpuLimit?: string | undefined
+  readonly playwrightRamLimit?: string | undefined
   readonly dockerNetworkMode: DockerNetworkMode
   readonly dockerSharedNetworkName: string
   readonly enableMcpPlaywright: boolean
@@ -166,6 +170,8 @@ export interface ApplyCommand {
   readonly geminiTokenLabel?: string | undefined
   readonly cpuLimit?: string | undefined
   readonly ramLimit?: string | undefined
+  readonly playwrightCpuLimit?: string | undefined
+  readonly playwrightRamLimit?: string | undefined
   readonly enableMcpPlaywright?: boolean | undefined
 }
 

--- a/packages/app/src/lib/core/resource-limits.ts
+++ b/packages/app/src/lib/core/resource-limits.ts
@@ -1,7 +1,15 @@
 /* jscpd:ignore-start */
 import { Either } from "effect"
 
-import { defaultCpuLimit, defaultRamLimit, type ParseError, type TemplateConfig } from "./domain.js"
+import { type RawOptions } from "./command-options.js"
+import {
+  defaultCpuLimit,
+  defaultPlaywrightCpuLimit,
+  defaultPlaywrightRamLimit,
+  defaultRamLimit,
+  type ParseError,
+  type TemplateConfig
+} from "./domain.js"
 
 const mebibyte = 1024 ** 2
 const minimumResolvedCpuLimit = 0.25
@@ -109,7 +117,9 @@ export const withDefaultResourceLimitIntent = (
 ): TemplateConfig => ({
   ...template,
   cpuLimit: template.cpuLimit ?? defaultCpuLimit,
-  ramLimit: template.ramLimit ?? defaultRamLimit
+  ramLimit: template.ramLimit ?? defaultRamLimit,
+  playwrightCpuLimit: template.playwrightCpuLimit ?? defaultPlaywrightCpuLimit,
+  playwrightRamLimit: template.playwrightRamLimit ?? defaultPlaywrightRamLimit
 })
 
 const resolvePercentCpuLimit = (percent: number, cpuCount: number): number =>
@@ -142,4 +152,38 @@ export const resolveComposeResourceLimits = (
       : resolvePercentRamLimit(ramPercent, hostResources.totalMemoryBytes)
   }
 }
+
+export const resolvePlaywrightComposeResourceLimits = (
+  template: Pick<TemplateConfig, "playwrightCpuLimit" | "playwrightRamLimit" | "cpuLimit" | "ramLimit">,
+  hostResources: HostResources
+): ResolvedComposeResourceLimits =>
+  resolveComposeResourceLimits(
+    {
+      cpuLimit: template.playwrightCpuLimit ?? template.cpuLimit ?? defaultPlaywrightCpuLimit,
+      ramLimit: template.playwrightRamLimit ?? template.ramLimit ?? defaultPlaywrightRamLimit
+    },
+    hostResources
+  )
+
+export type ResolvedResourceLimitsIntent = {
+  readonly cpuLimit: string | undefined
+  readonly ramLimit: string | undefined
+  readonly playwrightCpuLimit: string | undefined
+  readonly playwrightRamLimit: string | undefined
+}
+
+export const resolveResourceLimitsIntent = (
+  raw: RawOptions
+): Either.Either<ResolvedResourceLimitsIntent, ParseError> =>
+  Either.gen(function*(_) {
+    const cpuLimit = yield* _(normalizeCpuLimit(raw.cpuLimit ?? defaultCpuLimit, "--cpu"))
+    const ramLimit = yield* _(normalizeRamLimit(raw.ramLimit ?? defaultRamLimit, "--ram"))
+    const playwrightCpuLimit = yield* _(
+      normalizeCpuLimit(raw.playwrightCpuLimit ?? cpuLimit, "--playwright-cpu")
+    )
+    const playwrightRamLimit = yield* _(
+      normalizeRamLimit(raw.playwrightRamLimit ?? ramLimit, "--playwright-ram")
+    )
+    return { cpuLimit, ramLimit, playwrightCpuLimit, playwrightRamLimit }
+  })
 /* jscpd:ignore-end */

--- a/packages/app/src/lib/core/template-defaults.ts
+++ b/packages/app/src/lib/core/template-defaults.ts
@@ -22,6 +22,8 @@ type DefaultTemplateConfig = Pick<
   | "geminiHome"
   | "cpuLimit"
   | "ramLimit"
+  | "playwrightCpuLimit"
+  | "playwrightRamLimit"
   | "dockerNetworkMode"
   | "dockerSharedNetworkName"
   | "enableMcpPlaywright"
@@ -37,6 +39,10 @@ export const dockerGitSharedCodexVolumeName = "docker-git-shared-codex"
 export const defaultCpuLimit = "30%"
 
 export const defaultRamLimit = "30%"
+
+export const defaultPlaywrightCpuLimit = "30%"
+
+export const defaultPlaywrightRamLimit = "30%"
 
 export const defaultTemplateConfig = {
   containerName: "dev-ssh",
@@ -58,6 +64,8 @@ export const defaultTemplateConfig = {
   geminiHome: "/home/dev/.gemini",
   cpuLimit: defaultCpuLimit,
   ramLimit: defaultRamLimit,
+  playwrightCpuLimit: defaultPlaywrightCpuLimit,
+  playwrightRamLimit: defaultPlaywrightRamLimit,
   dockerNetworkMode: defaultDockerNetworkMode,
   dockerSharedNetworkName: defaultDockerSharedNetworkName,
   enableMcpPlaywright: false,

--- a/packages/app/src/lib/core/templates.ts
+++ b/packages/app/src/lib/core/templates.ts
@@ -2,7 +2,7 @@
 import type { TemplateConfig } from "./domain.js"
 import type { ResolvedComposeResourceLimits } from "./resource-limits.js"
 import { renderEntrypoint } from "./templates-entrypoint.js"
-import { renderDockerCompose } from "./templates/docker-compose.js"
+import { type ComposeResourceLimits, renderDockerCompose } from "./templates/docker-compose.js"
 import { renderDockerfile } from "./templates/dockerfile.js"
 import { renderPlaywrightBrowserDockerfile, renderPlaywrightStartExtra } from "./templates/playwright.js"
 
@@ -46,7 +46,7 @@ const renderConfigJson = (config: TemplateConfig): string =>
 
 export const planFiles = (
   config: TemplateConfig,
-  composeResourceLimits?: ResolvedComposeResourceLimits
+  composeResourceLimits?: ResolvedComposeResourceLimits | ComposeResourceLimits
 ): ReadonlyArray<FileSpec> => {
   const maybePlaywrightFiles = config.enableMcpPlaywright
     ? ([

--- a/packages/app/src/lib/core/templates/docker-compose.ts
+++ b/packages/app/src/lib/core/templates/docker-compose.ts
@@ -31,6 +31,11 @@ type PlaywrightFragments = Pick<
   "maybeDependsOn" | "maybePlaywrightEnv" | "maybeBrowserService" | "maybeBrowserVolume"
 >
 
+export type ComposeResourceLimits = {
+  readonly main: ResolvedComposeResourceLimits | undefined
+  readonly playwright: ResolvedComposeResourceLimits | undefined
+}
+
 const sharedCodexVolumeKey = "docker_git_shared_codex"
 const sharedCacheVolumeKey = "docker_git_shared_cache"
 const bootstrapVolumeKey = "docker_git_bootstrap"
@@ -109,9 +114,25 @@ const buildPlaywrightFragments = (
   }
 }
 
+const isResolvedComposeResourceLimits = (
+  value: ResolvedComposeResourceLimits | ComposeResourceLimits
+): value is ResolvedComposeResourceLimits => "cpuLimit" in value && "ramLimit" in value
+
+const normalizeComposeResourceLimits = (
+  resourceLimits: ResolvedComposeResourceLimits | ComposeResourceLimits | undefined
+): ComposeResourceLimits => {
+  if (resourceLimits === undefined) {
+    return { main: undefined, playwright: undefined }
+  }
+  if (isResolvedComposeResourceLimits(resourceLimits)) {
+    return { main: resourceLimits, playwright: resourceLimits }
+  }
+  return resourceLimits
+}
+
 const buildComposeFragments = (
   config: TemplateConfig,
-  resourceLimits: ResolvedComposeResourceLimits | undefined
+  resourceLimits: ComposeResourceLimits
 ): ComposeFragments => {
   const networkMode = config.dockerNetworkMode
   const networkName = resolveComposeNetworkName(config)
@@ -125,7 +146,7 @@ const buildComposeFragments = (
   const maybeClaudeAuthLabelEnv = renderClaudeAuthLabelEnv(claudeAuthLabel)
   const maybeAgentModeEnv = renderAgentModeEnv(config.agentMode)
   const maybeAgentAutoEnv = renderAgentAutoEnv(config.agentAuto)
-  const playwright = buildPlaywrightFragments(config, networkName, resourceLimits)
+  const playwright = buildPlaywrightFragments(config, networkName, resourceLimits.playwright)
 
   return {
     networkMode,
@@ -148,7 +169,7 @@ const buildComposeFragments = (
 const renderComposeServices = (
   config: TemplateConfig,
   fragments: ComposeFragments,
-  resourceLimits: ResolvedComposeResourceLimits | undefined
+  resourceLimits: ComposeResourceLimits
 ): string =>
   `services:
   ${config.serviceName}:
@@ -171,7 +192,7 @@ ${fragments.maybeClaudeAuthLabelEnv}${fragments.maybeAgentModeEnv}${fragments.ma
 ${fragments.maybePlaywrightEnv}${fragments.maybeDependsOn}    # bootstrap auth/env arrives through docker_git_bootstrap
     ports:
       - "\${DOCKER_GIT_PROJECT_SSH_BIND_HOST:-127.0.0.1}:${config.sshPort}:22"
-${renderResourceLimits(resourceLimits)}    volumes:
+${renderResourceLimits(resourceLimits.main)}    volumes:
       - ${config.volumeName}:/home/${config.sshUser}
       - ${sharedCacheVolumeKey}:/home/${config.sshUser}/.docker-git/.cache
       - ${sharedCodexVolumeKey}:${config.codexHome}-shared
@@ -215,12 +236,13 @@ const renderComposeVolumes = (config: TemplateConfig, maybeBrowserVolume: string
 
 export const renderDockerCompose = (
   config: TemplateConfig,
-  resourceLimits?: ResolvedComposeResourceLimits
+  resourceLimits?: ResolvedComposeResourceLimits | ComposeResourceLimits
 ): string => {
-  const fragments = buildComposeFragments(config, resourceLimits)
+  const limits = normalizeComposeResourceLimits(resourceLimits)
+  const fragments = buildComposeFragments(config, limits)
   return [
     `name: ${resolveComposeProjectName(config)}`,
-    renderComposeServices(config, fragments, resourceLimits),
+    renderComposeServices(config, fragments, limits),
     renderComposeNetworks(fragments.networkMode, fragments.networkName),
     renderComposeVolumes(config, fragments.maybeBrowserVolume)
   ].join("\n\n")

--- a/packages/app/src/lib/shell/files.ts
+++ b/packages/app/src/lib/shell/files.ts
@@ -6,7 +6,11 @@ import { Effect, Match } from "effect"
 
 import { dockerGitScriptNames } from "../core/docker-git-scripts.js"
 import { type TemplateConfig } from "../core/domain.js"
-import { resolveComposeResourceLimits, withDefaultResourceLimitIntent } from "../core/resource-limits.js"
+import {
+  resolveComposeResourceLimits,
+  resolvePlaywrightComposeResourceLimits,
+  withDefaultResourceLimitIntent
+} from "../core/resource-limits.js"
 import { type FileSpec, planFiles } from "../core/templates.js"
 import { FileExistsError } from "./errors.js"
 import { resolveBaseDir } from "./paths.js"
@@ -235,7 +239,10 @@ export const writeProjectFiles = (
 
     const normalizedConfig = withDefaultResourceLimitIntent(config)
     const hostResources = yield* _(loadHostResources())
-    const composeResourceLimits = resolveComposeResourceLimits(normalizedConfig, hostResources)
+    const composeResourceLimits = {
+      main: resolveComposeResourceLimits(normalizedConfig, hostResources),
+      playwright: resolvePlaywrightComposeResourceLimits(normalizedConfig, hostResources)
+    }
     const specs = planFiles(normalizedConfig, composeResourceLimits)
     const created: Array<string> = []
     const existingFilePaths = force ? [] : yield* _(collectExistingFilePaths(fs, path, baseDir, specs))

--- a/packages/app/src/lib/usecases/apply-overrides.ts
+++ b/packages/app/src/lib/usecases/apply-overrides.ts
@@ -8,7 +8,43 @@ export const hasApplyOverrides = (command: ApplyCommand): boolean =>
   command.claudeTokenLabel !== undefined ||
   command.cpuLimit !== undefined ||
   command.ramLimit !== undefined ||
+  command.playwrightCpuLimit !== undefined ||
+  command.playwrightRamLimit !== undefined ||
   command.enableMcpPlaywright !== undefined
+
+const applyTokenOverrides = (template: TemplateConfig, command: ApplyCommand): TemplateConfig => {
+  let next = template
+  if (command.gitTokenLabel !== undefined) {
+    next = { ...next, gitTokenLabel: normalizeGitTokenLabel(command.gitTokenLabel) }
+  }
+  if (command.codexTokenLabel !== undefined) {
+    next = { ...next, codexAuthLabel: normalizeAuthLabel(command.codexTokenLabel) }
+  }
+  if (command.claudeTokenLabel !== undefined) {
+    next = { ...next, claudeAuthLabel: normalizeAuthLabel(command.claudeTokenLabel) }
+  }
+  return next
+}
+
+const applyResourceOverrides = (template: TemplateConfig, command: ApplyCommand): TemplateConfig => {
+  let next = template
+  if (command.cpuLimit !== undefined) {
+    next = { ...next, cpuLimit: command.cpuLimit }
+  }
+  if (command.ramLimit !== undefined) {
+    next = { ...next, ramLimit: command.ramLimit }
+  }
+  if (command.playwrightCpuLimit !== undefined) {
+    next = { ...next, playwrightCpuLimit: command.playwrightCpuLimit }
+  }
+  if (command.playwrightRamLimit !== undefined) {
+    next = { ...next, playwrightRamLimit: command.playwrightRamLimit }
+  }
+  if (command.enableMcpPlaywright !== undefined) {
+    next = { ...next, enableMcpPlaywright: command.enableMcpPlaywright }
+  }
+  return next
+}
 
 export const applyTemplateOverrides = (
   template: TemplateConfig,
@@ -17,46 +53,6 @@ export const applyTemplateOverrides = (
   if (command === undefined) {
     return template
   }
-
-  let nextTemplate = template
-
-  if (command.gitTokenLabel !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      gitTokenLabel: normalizeGitTokenLabel(command.gitTokenLabel)
-    }
-  }
-  if (command.codexTokenLabel !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      codexAuthLabel: normalizeAuthLabel(command.codexTokenLabel)
-    }
-  }
-  if (command.claudeTokenLabel !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      claudeAuthLabel: normalizeAuthLabel(command.claudeTokenLabel)
-    }
-  }
-  if (command.cpuLimit !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      cpuLimit: command.cpuLimit
-    }
-  }
-  if (command.ramLimit !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      ramLimit: command.ramLimit
-    }
-  }
-  if (command.enableMcpPlaywright !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      enableMcpPlaywright: command.enableMcpPlaywright
-    }
-  }
-
-  return nextTemplate
+  return applyResourceOverrides(applyTokenOverrides(template, command), command)
 }
 /* jscpd:ignore-end */

--- a/packages/app/tests/docker-git/parser-playwright-resource.test.ts
+++ b/packages/app/tests/docker-git/parser-playwright-resource.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "@effect/vitest"
+
+import { expectCreateCommand, expectParseErrorTag } from "./parser-helpers.js"
+
+describe("parseArgs playwright resource limits", () => {
+  it.effect("parses dedicated playwright resource limit flags", () =>
+    expectCreateCommand(
+      [
+        "create",
+        "--repo-url",
+        "https://github.com/org/repo.git",
+        "--playwright-cpu",
+        "0.5",
+        "--playwright-ram",
+        "1g"
+      ],
+      (command) => {
+        expect(command.config.playwrightCpuLimit).toBe("0.5")
+        expect(command.config.playwrightRamLimit).toBe("1g")
+      }
+    ))
+
+  it.effect("falls back playwright limits to main limits when not specified", () =>
+    expectCreateCommand(
+      ["create", "--repo-url", "https://github.com/org/repo.git", "--cpu", "1.5", "--ram", "2g"],
+      (command) => {
+        expect(command.config.cpuLimit).toBe("1.5")
+        expect(command.config.ramLimit).toBe("2g")
+        expect(command.config.playwrightCpuLimit).toBe("1.5")
+        expect(command.config.playwrightRamLimit).toBe("2g")
+      }
+    ))
+
+  it.effect("accepts compose-style aliases for playwright limits", () =>
+    expectCreateCommand(
+      [
+        "create",
+        "--repo-url",
+        "https://github.com/org/repo.git",
+        "--playwright-cpus",
+        "0.75",
+        "--playwright-memory",
+        "1500m"
+      ],
+      (command) => {
+        expect(command.config.playwrightCpuLimit).toBe("0.75")
+        expect(command.config.playwrightRamLimit).toBe("1500m")
+      }
+    ))
+
+  it.effect("rejects invalid playwright RAM limit", () =>
+    expectParseErrorTag(
+      ["create", "--repo-url", "https://github.com/org/repo.git", "--playwright-ram", "not-a-size"],
+      "InvalidOption"
+    ))
+})

--- a/packages/lib/src/core/command-builders.ts
+++ b/packages/lib/src/core/command-builders.ts
@@ -8,15 +8,13 @@ import { type RawOptions } from "./command-options.js"
 import {
   type AgentMode,
   type CreateCommand,
-  defaultCpuLimit,
-  defaultRamLimit,
   defaultTemplateConfig,
   deriveRepoPathParts,
   deriveRepoSlug,
   type ParseError,
   resolveRepoInput
 } from "./domain.js"
-import { normalizeCpuLimit, normalizeRamLimit } from "./resource-limits.js"
+import { resolveResourceLimitsIntent } from "./resource-limits.js"
 import { trimRightChar } from "./strings.js"
 import { normalizeAuthLabel, normalizeGitTokenLabel } from "./token-labels.js"
 
@@ -193,6 +191,8 @@ type BuildTemplateConfigInput = {
   readonly paths: PathConfig
   readonly cpuLimit: string | undefined
   readonly ramLimit: string | undefined
+  readonly playwrightCpuLimit: string | undefined
+  readonly playwrightRamLimit: string | undefined
   readonly dockerNetworkMode: CreateCommand["config"]["dockerNetworkMode"]
   readonly dockerSharedNetworkName: string
   readonly gitTokenLabel: string | undefined
@@ -205,53 +205,64 @@ type BuildTemplateConfigInput = {
   readonly clonedOnHostname: string
 }
 
-const buildTemplateConfig = ({
-  agentAuto,
-  agentMode,
-  claudeAuthLabel,
-  clonedOnHostname,
-  codexAuthLabel,
-  cpuLimit,
-  dockerNetworkMode,
-  dockerSharedNetworkName,
-  enableMcpPlaywright,
-  gitTokenLabel,
-  names,
-  paths,
-  ramLimit,
-  repo,
-  skipGithubAuth
-}: BuildTemplateConfigInput): CreateCommand["config"] => ({
-  containerName: names.containerName,
-  serviceName: names.serviceName,
-  sshUser: repo.sshUser,
-  sshPort: repo.sshPort,
-  repoUrl: repo.repoUrl,
-  repoRef: repo.repoRef,
-  gitTokenLabel,
-  skipGithubAuth,
-  codexAuthLabel,
-  claudeAuthLabel,
-  targetDir: repo.targetDir,
-  volumeName: names.volumeName,
-  dockerGitPath: paths.dockerGitPath,
-  authorizedKeysPath: paths.authorizedKeysPath,
-  envGlobalPath: paths.envGlobalPath,
-  envProjectPath: paths.envProjectPath,
-  codexAuthPath: paths.codexAuthPath,
-  codexSharedAuthPath: paths.codexSharedAuthPath,
-  codexHome: paths.codexHome,
-  geminiAuthPath: paths.geminiAuthPath,
-  geminiHome: paths.geminiHome,
-  cpuLimit,
-  ramLimit,
-  dockerNetworkMode,
-  dockerSharedNetworkName,
-  enableMcpPlaywright,
+const buildTemplateConfigBase = (
+  input: Pick<BuildTemplateConfigInput, "repo" | "names" | "paths">
+): Pick<
+  CreateCommand["config"],
+  | "containerName"
+  | "serviceName"
+  | "sshUser"
+  | "sshPort"
+  | "repoUrl"
+  | "repoRef"
+  | "targetDir"
+  | "volumeName"
+  | "dockerGitPath"
+  | "authorizedKeysPath"
+  | "envGlobalPath"
+  | "envProjectPath"
+  | "codexAuthPath"
+  | "codexSharedAuthPath"
+  | "codexHome"
+  | "geminiAuthPath"
+  | "geminiHome"
+> => ({
+  containerName: input.names.containerName,
+  serviceName: input.names.serviceName,
+  sshUser: input.repo.sshUser,
+  sshPort: input.repo.sshPort,
+  repoUrl: input.repo.repoUrl,
+  repoRef: input.repo.repoRef,
+  targetDir: input.repo.targetDir,
+  volumeName: input.names.volumeName,
+  dockerGitPath: input.paths.dockerGitPath,
+  authorizedKeysPath: input.paths.authorizedKeysPath,
+  envGlobalPath: input.paths.envGlobalPath,
+  envProjectPath: input.paths.envProjectPath,
+  codexAuthPath: input.paths.codexAuthPath,
+  codexSharedAuthPath: input.paths.codexSharedAuthPath,
+  codexHome: input.paths.codexHome,
+  geminiAuthPath: input.paths.geminiAuthPath,
+  geminiHome: input.paths.geminiHome
+})
+
+const buildTemplateConfig = (input: BuildTemplateConfigInput): CreateCommand["config"] => ({
+  ...buildTemplateConfigBase(input),
+  gitTokenLabel: input.gitTokenLabel,
+  skipGithubAuth: input.skipGithubAuth,
+  codexAuthLabel: input.codexAuthLabel,
+  claudeAuthLabel: input.claudeAuthLabel,
+  cpuLimit: input.cpuLimit,
+  ramLimit: input.ramLimit,
+  playwrightCpuLimit: input.playwrightCpuLimit,
+  playwrightRamLimit: input.playwrightRamLimit,
+  dockerNetworkMode: input.dockerNetworkMode,
+  dockerSharedNetworkName: input.dockerSharedNetworkName,
+  enableMcpPlaywright: input.enableMcpPlaywright,
   bunVersion: defaultTemplateConfig.bunVersion,
-  agentMode,
-  agentAuto,
-  clonedOnHostname
+  agentMode: input.agentMode,
+  agentAuto: input.agentAuto,
+  clonedOnHostname: input.clonedOnHostname
 })
 
 // CHANGE: build a typed create command from raw options (CLI or API)
@@ -275,8 +286,7 @@ export const buildCreateCommand = (
     const gitTokenLabel = normalizeGitTokenLabel(raw.gitTokenLabel)
     const codexAuthLabel = normalizeAuthLabel(raw.codexTokenLabel)
     const claudeAuthLabel = normalizeAuthLabel(raw.claudeTokenLabel)
-    const cpuLimit = yield* _(normalizeCpuLimit(raw.cpuLimit ?? defaultCpuLimit, "--cpu"))
-    const ramLimit = yield* _(normalizeRamLimit(raw.ramLimit ?? defaultRamLimit, "--ram"))
+    const limits = yield* _(resolveResourceLimitsIntent(raw))
     const dockerNetworkMode = yield* _(parseDockerNetworkMode(raw.dockerNetworkMode))
     const dockerSharedNetworkName = yield* _(
       nonEmpty("--shared-network", raw.dockerSharedNetworkName, defaultTemplateConfig.dockerSharedNetworkName)
@@ -295,8 +305,10 @@ export const buildCreateCommand = (
         repo,
         names,
         paths,
-        cpuLimit,
-        ramLimit,
+        cpuLimit: limits.cpuLimit,
+        ramLimit: limits.ramLimit,
+        playwrightCpuLimit: limits.playwrightCpuLimit,
+        playwrightRamLimit: limits.playwrightRamLimit,
         dockerNetworkMode,
         dockerSharedNetworkName,
         gitTokenLabel,

--- a/packages/lib/src/core/command-options.ts
+++ b/packages/lib/src/core/command-options.ts
@@ -27,6 +27,8 @@ export interface RawOptions {
   readonly codexHome?: string
   readonly cpuLimit?: string
   readonly ramLimit?: string
+  readonly playwrightCpuLimit?: string
+  readonly playwrightRamLimit?: string
   readonly dockerNetworkMode?: string
   readonly dockerSharedNetworkName?: string
   readonly enableMcpPlaywright?: boolean

--- a/packages/lib/src/core/domain.ts
+++ b/packages/lib/src/core/domain.ts
@@ -41,6 +41,8 @@ export {
   defaultCpuLimit,
   defaultDockerNetworkMode,
   defaultDockerSharedNetworkName,
+  defaultPlaywrightCpuLimit,
+  defaultPlaywrightRamLimit,
   defaultRamLimit,
   defaultTemplateConfig,
   dockerGitSharedCacheVolumeName,
@@ -77,6 +79,8 @@ export interface TemplateConfig {
   readonly geminiHome: string
   readonly cpuLimit?: string | undefined
   readonly ramLimit?: string | undefined
+  readonly playwrightCpuLimit?: string | undefined
+  readonly playwrightRamLimit?: string | undefined
   readonly dockerNetworkMode: DockerNetworkMode
   readonly dockerSharedNetworkName: string
   readonly enableMcpPlaywright: boolean
@@ -165,6 +169,8 @@ export interface ApplyCommand {
   readonly geminiTokenLabel?: string | undefined
   readonly cpuLimit?: string | undefined
   readonly ramLimit?: string | undefined
+  readonly playwrightCpuLimit?: string | undefined
+  readonly playwrightRamLimit?: string | undefined
   readonly enableMcpPlaywright?: boolean | undefined
 }
 

--- a/packages/lib/src/core/resource-limits.ts
+++ b/packages/lib/src/core/resource-limits.ts
@@ -1,6 +1,14 @@
 import { Either } from "effect"
 
-import { defaultCpuLimit, defaultRamLimit, type ParseError, type TemplateConfig } from "./domain.js"
+import { type RawOptions } from "./command-options.js"
+import {
+  defaultCpuLimit,
+  defaultPlaywrightCpuLimit,
+  defaultPlaywrightRamLimit,
+  defaultRamLimit,
+  type ParseError,
+  type TemplateConfig
+} from "./domain.js"
 
 const mebibyte = 1024 ** 2
 const minimumResolvedCpuLimit = 0.25
@@ -108,7 +116,9 @@ export const withDefaultResourceLimitIntent = (
 ): TemplateConfig => ({
   ...template,
   cpuLimit: template.cpuLimit ?? defaultCpuLimit,
-  ramLimit: template.ramLimit ?? defaultRamLimit
+  ramLimit: template.ramLimit ?? defaultRamLimit,
+  playwrightCpuLimit: template.playwrightCpuLimit ?? defaultPlaywrightCpuLimit,
+  playwrightRamLimit: template.playwrightRamLimit ?? defaultPlaywrightRamLimit
 })
 
 const resolvePercentCpuLimit = (percent: number, cpuCount: number): number =>
@@ -141,3 +151,37 @@ export const resolveComposeResourceLimits = (
       : resolvePercentRamLimit(ramPercent, hostResources.totalMemoryBytes)
   }
 }
+
+export const resolvePlaywrightComposeResourceLimits = (
+  template: Pick<TemplateConfig, "playwrightCpuLimit" | "playwrightRamLimit" | "cpuLimit" | "ramLimit">,
+  hostResources: HostResources
+): ResolvedComposeResourceLimits =>
+  resolveComposeResourceLimits(
+    {
+      cpuLimit: template.playwrightCpuLimit ?? template.cpuLimit ?? defaultPlaywrightCpuLimit,
+      ramLimit: template.playwrightRamLimit ?? template.ramLimit ?? defaultPlaywrightRamLimit
+    },
+    hostResources
+  )
+
+export type ResolvedResourceLimitsIntent = {
+  readonly cpuLimit: string | undefined
+  readonly ramLimit: string | undefined
+  readonly playwrightCpuLimit: string | undefined
+  readonly playwrightRamLimit: string | undefined
+}
+
+export const resolveResourceLimitsIntent = (
+  raw: RawOptions
+): Either.Either<ResolvedResourceLimitsIntent, ParseError> =>
+  Either.gen(function*(_) {
+    const cpuLimit = yield* _(normalizeCpuLimit(raw.cpuLimit ?? defaultCpuLimit, "--cpu"))
+    const ramLimit = yield* _(normalizeRamLimit(raw.ramLimit ?? defaultRamLimit, "--ram"))
+    const playwrightCpuLimit = yield* _(
+      normalizeCpuLimit(raw.playwrightCpuLimit ?? cpuLimit, "--playwright-cpu")
+    )
+    const playwrightRamLimit = yield* _(
+      normalizeRamLimit(raw.playwrightRamLimit ?? ramLimit, "--playwright-ram")
+    )
+    return { cpuLimit, ramLimit, playwrightCpuLimit, playwrightRamLimit }
+  })

--- a/packages/lib/src/core/template-defaults.ts
+++ b/packages/lib/src/core/template-defaults.ts
@@ -21,6 +21,8 @@ type DefaultTemplateConfig = Pick<
   | "geminiHome"
   | "cpuLimit"
   | "ramLimit"
+  | "playwrightCpuLimit"
+  | "playwrightRamLimit"
   | "dockerNetworkMode"
   | "dockerSharedNetworkName"
   | "enableMcpPlaywright"
@@ -36,6 +38,10 @@ export const dockerGitSharedCodexVolumeName = "docker-git-shared-codex"
 export const defaultCpuLimit = "30%"
 
 export const defaultRamLimit = "30%"
+
+export const defaultPlaywrightCpuLimit = "30%"
+
+export const defaultPlaywrightRamLimit = "30%"
 
 export const defaultTemplateConfig = {
   containerName: "dev-ssh",
@@ -57,6 +63,8 @@ export const defaultTemplateConfig = {
   geminiHome: "/home/dev/.gemini",
   cpuLimit: defaultCpuLimit,
   ramLimit: defaultRamLimit,
+  playwrightCpuLimit: defaultPlaywrightCpuLimit,
+  playwrightRamLimit: defaultPlaywrightRamLimit,
   dockerNetworkMode: defaultDockerNetworkMode,
   dockerSharedNetworkName: defaultDockerSharedNetworkName,
   enableMcpPlaywright: false,

--- a/packages/lib/src/core/templates.ts
+++ b/packages/lib/src/core/templates.ts
@@ -1,7 +1,7 @@
 import type { TemplateConfig } from "./domain.js"
 import type { ResolvedComposeResourceLimits } from "./resource-limits.js"
 import { renderEntrypoint } from "./templates-entrypoint.js"
-import { renderDockerCompose } from "./templates/docker-compose.js"
+import { type ComposeResourceLimits, renderDockerCompose } from "./templates/docker-compose.js"
 import { renderDockerfile } from "./templates/dockerfile.js"
 import { renderPlaywrightBrowserDockerfile, renderPlaywrightStartExtra } from "./templates/playwright.js"
 
@@ -45,7 +45,7 @@ const renderConfigJson = (config: TemplateConfig): string =>
 
 export const planFiles = (
   config: TemplateConfig,
-  composeResourceLimits?: ResolvedComposeResourceLimits
+  composeResourceLimits?: ResolvedComposeResourceLimits | ComposeResourceLimits
 ): ReadonlyArray<FileSpec> => {
   const maybePlaywrightFiles = config.enableMcpPlaywright
     ? ([

--- a/packages/lib/src/core/templates/docker-compose.ts
+++ b/packages/lib/src/core/templates/docker-compose.ts
@@ -30,6 +30,11 @@ type PlaywrightFragments = Pick<
   "maybeDependsOn" | "maybePlaywrightEnv" | "maybeBrowserService" | "maybeBrowserVolume"
 >
 
+export type ComposeResourceLimits = {
+  readonly main: ResolvedComposeResourceLimits | undefined
+  readonly playwright: ResolvedComposeResourceLimits | undefined
+}
+
 const sharedCodexVolumeKey = "docker_git_shared_codex"
 const sharedCacheVolumeKey = "docker_git_shared_cache"
 const bootstrapVolumeKey = "docker_git_bootstrap"
@@ -108,9 +113,25 @@ const buildPlaywrightFragments = (
   }
 }
 
+const isResolvedComposeResourceLimits = (
+  value: ResolvedComposeResourceLimits | ComposeResourceLimits
+): value is ResolvedComposeResourceLimits => "cpuLimit" in value && "ramLimit" in value
+
+const normalizeComposeResourceLimits = (
+  resourceLimits: ResolvedComposeResourceLimits | ComposeResourceLimits | undefined
+): ComposeResourceLimits => {
+  if (resourceLimits === undefined) {
+    return { main: undefined, playwright: undefined }
+  }
+  if (isResolvedComposeResourceLimits(resourceLimits)) {
+    return { main: resourceLimits, playwright: resourceLimits }
+  }
+  return resourceLimits
+}
+
 const buildComposeFragments = (
   config: TemplateConfig,
-  resourceLimits: ResolvedComposeResourceLimits | undefined
+  resourceLimits: ComposeResourceLimits
 ): ComposeFragments => {
   const networkMode = config.dockerNetworkMode
   const networkName = resolveComposeNetworkName(config)
@@ -124,7 +145,7 @@ const buildComposeFragments = (
   const maybeClaudeAuthLabelEnv = renderClaudeAuthLabelEnv(claudeAuthLabel)
   const maybeAgentModeEnv = renderAgentModeEnv(config.agentMode)
   const maybeAgentAutoEnv = renderAgentAutoEnv(config.agentAuto)
-  const playwright = buildPlaywrightFragments(config, networkName, resourceLimits)
+  const playwright = buildPlaywrightFragments(config, networkName, resourceLimits.playwright)
 
   return {
     networkMode,
@@ -147,7 +168,7 @@ const buildComposeFragments = (
 const renderComposeServices = (
   config: TemplateConfig,
   fragments: ComposeFragments,
-  resourceLimits: ResolvedComposeResourceLimits | undefined
+  resourceLimits: ComposeResourceLimits
 ): string =>
   `services:
   ${config.serviceName}:
@@ -170,7 +191,7 @@ ${fragments.maybeClaudeAuthLabelEnv}${fragments.maybeAgentModeEnv}${fragments.ma
 ${fragments.maybePlaywrightEnv}${fragments.maybeDependsOn}    # bootstrap auth/env arrives through docker_git_bootstrap
     ports:
       - "\${DOCKER_GIT_PROJECT_SSH_BIND_HOST:-127.0.0.1}:${config.sshPort}:22"
-${renderResourceLimits(resourceLimits)}    volumes:
+${renderResourceLimits(resourceLimits.main)}    volumes:
       - ${config.volumeName}:/home/${config.sshUser}
       - ${sharedCacheVolumeKey}:/home/${config.sshUser}/.docker-git/.cache
       - ${sharedCodexVolumeKey}:${config.codexHome}-shared
@@ -214,12 +235,13 @@ const renderComposeVolumes = (config: TemplateConfig, maybeBrowserVolume: string
 
 export const renderDockerCompose = (
   config: TemplateConfig,
-  resourceLimits?: ResolvedComposeResourceLimits
+  resourceLimits?: ResolvedComposeResourceLimits | ComposeResourceLimits
 ): string => {
-  const fragments = buildComposeFragments(config, resourceLimits)
+  const limits = normalizeComposeResourceLimits(resourceLimits)
+  const fragments = buildComposeFragments(config, limits)
   return [
     `name: ${resolveComposeProjectName(config)}`,
-    renderComposeServices(config, fragments, resourceLimits),
+    renderComposeServices(config, fragments, limits),
     renderComposeNetworks(fragments.networkMode, fragments.networkName),
     renderComposeVolumes(config, fragments.maybeBrowserVolume)
   ].join("\n\n")

--- a/packages/lib/src/shell/files.ts
+++ b/packages/lib/src/shell/files.ts
@@ -5,7 +5,11 @@ import { Effect, Match } from "effect"
 
 import { dockerGitScriptNames } from "../core/docker-git-scripts.js"
 import { type TemplateConfig } from "../core/domain.js"
-import { resolveComposeResourceLimits, withDefaultResourceLimitIntent } from "../core/resource-limits.js"
+import {
+  resolveComposeResourceLimits,
+  resolvePlaywrightComposeResourceLimits,
+  withDefaultResourceLimitIntent
+} from "../core/resource-limits.js"
 import { type FileSpec, planFiles } from "../core/templates.js"
 import { FileExistsError } from "./errors.js"
 import { resolveBaseDir } from "./paths.js"
@@ -234,7 +238,10 @@ export const writeProjectFiles = (
 
     const normalizedConfig = withDefaultResourceLimitIntent(config)
     const hostResources = yield* _(loadHostResources())
-    const composeResourceLimits = resolveComposeResourceLimits(normalizedConfig, hostResources)
+    const composeResourceLimits = {
+      main: resolveComposeResourceLimits(normalizedConfig, hostResources),
+      playwright: resolvePlaywrightComposeResourceLimits(normalizedConfig, hostResources)
+    }
     const specs = planFiles(normalizedConfig, composeResourceLimits)
     const created: Array<string> = []
     const existingFilePaths = force ? [] : yield* _(collectExistingFilePaths(fs, path, baseDir, specs))

--- a/packages/lib/src/usecases/apply-overrides.ts
+++ b/packages/lib/src/usecases/apply-overrides.ts
@@ -7,7 +7,43 @@ export const hasApplyOverrides = (command: ApplyCommand): boolean =>
   command.claudeTokenLabel !== undefined ||
   command.cpuLimit !== undefined ||
   command.ramLimit !== undefined ||
+  command.playwrightCpuLimit !== undefined ||
+  command.playwrightRamLimit !== undefined ||
   command.enableMcpPlaywright !== undefined
+
+const applyTokenOverrides = (template: TemplateConfig, command: ApplyCommand): TemplateConfig => {
+  let next = template
+  if (command.gitTokenLabel !== undefined) {
+    next = { ...next, gitTokenLabel: normalizeGitTokenLabel(command.gitTokenLabel) }
+  }
+  if (command.codexTokenLabel !== undefined) {
+    next = { ...next, codexAuthLabel: normalizeAuthLabel(command.codexTokenLabel) }
+  }
+  if (command.claudeTokenLabel !== undefined) {
+    next = { ...next, claudeAuthLabel: normalizeAuthLabel(command.claudeTokenLabel) }
+  }
+  return next
+}
+
+const applyResourceOverrides = (template: TemplateConfig, command: ApplyCommand): TemplateConfig => {
+  let next = template
+  if (command.cpuLimit !== undefined) {
+    next = { ...next, cpuLimit: command.cpuLimit }
+  }
+  if (command.ramLimit !== undefined) {
+    next = { ...next, ramLimit: command.ramLimit }
+  }
+  if (command.playwrightCpuLimit !== undefined) {
+    next = { ...next, playwrightCpuLimit: command.playwrightCpuLimit }
+  }
+  if (command.playwrightRamLimit !== undefined) {
+    next = { ...next, playwrightRamLimit: command.playwrightRamLimit }
+  }
+  if (command.enableMcpPlaywright !== undefined) {
+    next = { ...next, enableMcpPlaywright: command.enableMcpPlaywright }
+  }
+  return next
+}
 
 export const applyTemplateOverrides = (
   template: TemplateConfig,
@@ -16,45 +52,5 @@ export const applyTemplateOverrides = (
   if (command === undefined) {
     return template
   }
-
-  let nextTemplate = template
-
-  if (command.gitTokenLabel !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      gitTokenLabel: normalizeGitTokenLabel(command.gitTokenLabel)
-    }
-  }
-  if (command.codexTokenLabel !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      codexAuthLabel: normalizeAuthLabel(command.codexTokenLabel)
-    }
-  }
-  if (command.claudeTokenLabel !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      claudeAuthLabel: normalizeAuthLabel(command.claudeTokenLabel)
-    }
-  }
-  if (command.cpuLimit !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      cpuLimit: command.cpuLimit
-    }
-  }
-  if (command.ramLimit !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      ramLimit: command.ramLimit
-    }
-  }
-  if (command.enableMcpPlaywright !== undefined) {
-    nextTemplate = {
-      ...nextTemplate,
-      enableMcpPlaywright: command.enableMcpPlaywright
-    }
-  }
-
-  return nextTemplate
+  return applyResourceOverrides(applyTokenOverrides(template, command), command)
 }

--- a/packages/lib/tests/core/resource-limits.test.ts
+++ b/packages/lib/tests/core/resource-limits.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "@effect/vitest"
 
 import {
   resolveComposeResourceLimits,
+  resolvePlaywrightComposeResourceLimits,
   withDefaultResourceLimitIntent
 } from "../../src/core/resource-limits.js"
 import { defaultTemplateConfig, type TemplateConfig } from "../../src/core/domain.js"
@@ -17,6 +18,8 @@ describe("withDefaultResourceLimitIntent", () => {
 
     expect(resolved.cpuLimit).toBe("30%")
     expect(resolved.ramLimit).toBe("30%")
+    expect(resolved.playwrightCpuLimit).toBe("30%")
+    expect(resolved.playwrightRamLimit).toBe("30%")
   })
 
   it("preserves explicit limit intent", () => {
@@ -28,6 +31,19 @@ describe("withDefaultResourceLimitIntent", () => {
 
     expect(resolved.cpuLimit).toBe("1.25")
     expect(resolved.ramLimit).toBe("3g")
+  })
+
+  it("preserves explicit playwright intent independently of main", () => {
+    const resolved = withDefaultResourceLimitIntent({
+      ...makeTemplate(),
+      cpuLimit: "1.25",
+      ramLimit: "3g",
+      playwrightCpuLimit: "0.5",
+      playwrightRamLimit: "1g"
+    })
+
+    expect(resolved.playwrightCpuLimit).toBe("0.5")
+    expect(resolved.playwrightRamLimit).toBe("1g")
   })
 })
 
@@ -78,5 +94,72 @@ describe("resolveComposeResourceLimits", () => {
 
     expect(resolved.cpuLimit).toBe(1.25)
     expect(resolved.ramLimit).toBe("3g")
+  })
+})
+
+describe("resolvePlaywrightComposeResourceLimits", () => {
+  it("uses dedicated playwright intent when provided", () => {
+    const resolved = resolvePlaywrightComposeResourceLimits(
+      {
+        cpuLimit: "2",
+        ramLimit: "4g",
+        playwrightCpuLimit: "0.5",
+        playwrightRamLimit: "1g"
+      },
+      {
+        cpuCount: 8,
+        totalMemoryBytes: 16 * 1024 ** 3
+      }
+    )
+
+    expect(resolved.cpuLimit).toBe(0.5)
+    expect(resolved.ramLimit).toBe("1g")
+  })
+
+  it("falls back to main intent when playwright intent is missing", () => {
+    const resolved = resolvePlaywrightComposeResourceLimits(
+      {
+        cpuLimit: "1.5",
+        ramLimit: "2g"
+      },
+      {
+        cpuCount: 8,
+        totalMemoryBytes: 16 * 1024 ** 3
+      }
+    )
+
+    expect(resolved.cpuLimit).toBe(1.5)
+    expect(resolved.ramLimit).toBe("2g")
+  })
+
+  it("falls back to default 30% when neither playwright nor main intent is set", () => {
+    const resolved = resolvePlaywrightComposeResourceLimits(
+      {},
+      {
+        cpuCount: 8,
+        totalMemoryBytes: 16 * 1024 ** 3
+      }
+    )
+
+    expect(resolved.cpuLimit).toBe(2.4)
+    expect(resolved.ramLimit).toBe("4915m")
+  })
+
+  it("supports percent intent for playwright independently", () => {
+    const resolved = resolvePlaywrightComposeResourceLimits(
+      {
+        cpuLimit: "60%",
+        ramLimit: "60%",
+        playwrightCpuLimit: "10%",
+        playwrightRamLimit: "10%"
+      },
+      {
+        cpuCount: 8,
+        totalMemoryBytes: 16 * 1024 ** 3
+      }
+    )
+
+    expect(resolved.cpuLimit).toBe(0.8)
+    expect(resolved.ramLimit).toBe("1638m")
   })
 })

--- a/packages/lib/tests/core/templates.test.ts
+++ b/packages/lib/tests/core/templates.test.ts
@@ -297,6 +297,47 @@ describe("renderDockerCompose", () => {
     expect((compose.match(/\n    dns:\n/g) ?? []).length).toBe(2)
   })
 
+  it("applies separate resource limits for the browser sidecar when provided", () => {
+    const compose = renderDockerCompose(
+      makeTemplateConfig({
+        enableMcpPlaywright: true
+      }),
+      {
+        main: { cpuLimit: 2, ramLimit: "4g" },
+        playwright: { cpuLimit: 0.5, ramLimit: "1g" }
+      }
+    )
+    const browserServiceIndex = compose.indexOf("\n  dg-test-browser:\n")
+    const browserSection = compose.slice(browserServiceIndex)
+    const mainSection = compose.slice(0, browserServiceIndex)
+
+    expect(browserServiceIndex).toBeGreaterThanOrEqual(0)
+    expect(mainSection).toContain("    cpus: 2\n")
+    expect(mainSection).toContain('    mem_limit: "4g"\n')
+    expect(mainSection).toContain('    memswap_limit: "4g"\n')
+    expect(browserSection).toContain("    cpus: 0.5\n")
+    expect(browserSection).toContain('    mem_limit: "1g"\n')
+    expect(browserSection).toContain('    memswap_limit: "1g"\n')
+  })
+
+  it("backward-compatibly applies single resource limit shape to both services", () => {
+    const compose = renderDockerCompose(
+      makeTemplateConfig({
+        enableMcpPlaywright: true
+      }),
+      {
+        cpuLimit: 1.5,
+        ramLimit: "2g"
+      }
+    )
+    const browserServiceIndex = compose.indexOf("\n  dg-test-browser:\n")
+    const browserSection = compose.slice(browserServiceIndex)
+
+    expect(browserServiceIndex).toBeGreaterThanOrEqual(0)
+    expect(browserSection).toContain("    cpus: 1.5\n")
+    expect(browserSection).toContain('    mem_limit: "2g"\n')
+  })
+
   it("renders explicit anonymous GitHub clone override for public repos", () => {
     const compose = renderDockerCompose(
       makeTemplateConfig({


### PR DESCRIPTION
## Summary

Adds configurable CPU and RAM limits for the MCP Playwright browser sidecar container, separate from the main service container's limits. This addresses #259, which reported that the Playwright sidecar could consume too many host resources.

- New CLI flags: `--playwright-cpu` (alias `--playwright-cpus`) and `--playwright-ram` (alias `--playwright-memory`).
- Defaults to **30%** of the host CPU/RAM, falling back to the main service limits when not set.
- Limits are wired through:
  - CLI parser (`parser-options`, `parser-apply`)
  - Template defaults (`template-defaults`)
  - Apply overrides (`apply-overrides`)
  - Resource normalization & resolution (`resource-limits`)
  - Docker Compose template (`templates/docker-compose`)
- Accepts the same value formats as the existing `--cpu`/`--ram` flags: percent (`30%`), absolute CPU (`1.5`), and absolute RAM (`512m`, `4g`, etc.).

## Reproduction

Before this change, the MCP Playwright sidecar inherited only the main `--cpu`/`--ram` limits (or none), so Chromium could consume a large share of host resources during long browsing sessions.

After this change:

```bash
docker-git create my-project \
  --cpu 50% --ram 50% \
  --playwright-cpu 20% --playwright-ram 1500m
```

produces a `docker-compose.yml` where:
- `service` has `cpus: <50% of host>` and `mem_limit/memswap_limit: <50% of host>`
- `playwright` has `cpus: <20% of host>` and `mem_limit/memswap_limit: 1500m`

When `--playwright-*` flags are omitted, the sidecar falls back to the main service limits, and when those are also omitted, it uses the **30%** default.

## Implementation notes

- The codebase keeps three synchronized copies (canonical `packages/lib`, mirror at `packages/app/src/lib`, and frontend subset at `packages/app/src/docker-git/frontend-lib`); all three were updated together.
- Resource normalization moved into `resource-limits.ts` (new `resolveResourceLimitsIntent` helper) to keep `command-builders.ts` under the 300-line ESLint cap.
- `apply-overrides.ts` was split into `applyTokenOverrides` + `applyResourceOverrides` to satisfy the 50-line-per-function cap.

## Test plan

- [x] `bun run typecheck` passes (exit 0)
- [x] `bun run lint` passes (exit 0)
- [x] `bun run test` passes — **273 app tests + 173 lib tests**
- [x] New unit tests:
  - `packages/lib/tests/core/resource-limits.test.ts` — defaults & explicit overrides for playwright limits
  - `packages/lib/tests/core/templates.test.ts` — docker-compose template emits separate sidecar limits
  - `packages/app/tests/docker-git/parser-playwright-resource.test.ts` — CLI parser accepts new flags and aliases
- [x] Existing CPU/RAM behavior preserved (no regressions in the resolved-limits or template tests)

## Changeset

- `.changeset/playwright-resource-limits.md` (minor bump for `@prover-coder-ai/docker-git` and `@effect-template/lib`)

Closes #259