### PR TITLE
fix(app): process first CLI TUI input

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-12T09:49:03.648Z for PR creation at branch issue-274-1f6a9d48fe85 for issue https://github.com/ProverCoderAI/docker-git/issues/274

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-12T09:49:03.648Z for PR creation at branch issue-274-1f6a9d48fe85 for issue https://github.com/ProverCoderAI/docker-git/issues/274

--- a/packages/app/src/docker-git/menu-input-handler.ts
+++ b/packages/app/src/docker-git/menu-input-handler.ts
@@ -34,25 +34,11 @@ const activateInput = (
   }
 
   const normalized = input.trim()
-
-  if (normalized.length > 1) {
+  const hasMenuInput = normalized.length > 0 || input.length > 0
+  const hasMenuActionKey = key.upArrow || key.downArrow || key.return
+  if (hasMenuInput || hasMenuActionKey) {
     context.setInputStage("active")
     return { activated: true, allowProcessing: true }
-  }
-
-  if (key.upArrow || key.downArrow || key.return) {
-    context.setInputStage("active")
-    return { activated: true, allowProcessing: false }
-  }
-
-  if (normalized.length === 1) {
-    context.setInputStage("active")
-    return { activated: true, allowProcessing: false }
-  }
-
-  if (input.length > 0) {
-    context.setInputStage("active")
-    return { activated: true, allowProcessing: false }
   }
 
   return { activated: false, allowProcessing: false }

--- a/packages/app/src/docker-git/menu-state.ts
+++ b/packages/app/src/docker-git/menu-state.ts
@@ -32,6 +32,16 @@ export type MenuSnapshotStore = {
   current: MenuSnapshot
 }
 
+// CHANGE: make a fresh CLI TUI process the first user key after readiness gates
+// WHY: ready/ignoreUntil already filters bootstrap noise; skipping valid input breaks menu liveness
+// QUOTE(ISSUE): "Почему-то CLI TUI не работает"
+// REF: issue-274
+// SOURCE: n/a
+// FORMAT THEOREM: forall key in ValidMenuInput: ready(menu) -> processed(key)
+// PURITY: CORE
+// EFFECT: n/a
+// INVARIANT: initial snapshot has no synthetic skipped user inputs
+// COMPLEXITY: O(1)
 export const defaultMenuSnapshot = (): MenuSnapshot => ({
   activeDir: null,
   runningDockerGitContainers: 0,
@@ -39,9 +49,9 @@ export const defaultMenuSnapshot = (): MenuSnapshot => ({
   busy: false,
   message: null,
   view: { _tag: "Menu" },
-  inputStage: "cold",
+  inputStage: "active",
   ready: false,
-  skipInputs: 2,
+  skipInputs: 0,
   sshActive: false,
   startupLoaded: false
 })

--- a/packages/app/src/docker-git/menu-state.ts
+++ b/packages/app/src/docker-git/menu-state.ts
@@ -34,7 +34,7 @@ export type MenuSnapshotStore = {
 
 // CHANGE: make a fresh CLI TUI process the first user key after readiness gates
 // WHY: ready/ignoreUntil already filters bootstrap noise; skipping valid input breaks menu liveness
-// QUOTE(ISSUE): "Почему-то CLI TUI не работает"
+// QUOTE(ТЗ): "Почему-то CLI TUI не работает"
 // REF: issue-274
 // SOURCE: n/a
 // FORMAT THEOREM: forall key in ValidMenuInput: ready(menu) -> processed(key)

--- a/packages/app/tests/docker-git/menu-input-handler.test.ts
+++ b/packages/app/tests/docker-git/menu-input-handler.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from "vitest"
 
 import { handleUserInput } from "../../src/docker-git/menu-input-handler.js"
 import type { MenuInputContext } from "../../src/docker-git/menu-input-handler.js"
+import { defaultMenuSnapshot } from "../../src/docker-git/menu-state.js"
 
 const makeContext = (inputStage: "cold" | "active"): MenuInputContext & {
   readonly runnerRunEffect: ReturnType<typeof vi.fn>
@@ -47,15 +48,15 @@ const makeContext = (inputStage: "cold" | "active"): MenuInputContext & {
 }
 
 describe("menu-input-handler", () => {
-  it("swallows the first single-character alias on cold start", () => {
+  it("handles the first single-character alias on cold start", () => {
     const context = makeContext("cold")
 
     handleUserInput("s", {}, context)
 
     expect(context.setInputStageMock).toHaveBeenCalledWith("active")
-    expect(context.runnerRunEffect).not.toHaveBeenCalled()
+    expect(context.runnerRunEffect).toHaveBeenCalledTimes(1)
+    expect(context.setSkipInputsMock).toHaveBeenCalledTimes(1)
     expect(context.setViewMock).not.toHaveBeenCalled()
-    expect(context.setMessageMock).not.toHaveBeenCalled()
   })
 
   it("allows the same alias once input is already active", () => {
@@ -65,5 +66,12 @@ describe("menu-input-handler", () => {
 
     expect(context.runnerRunEffect).toHaveBeenCalledTimes(1)
     expect(context.setSkipInputsMock).toHaveBeenCalledTimes(1)
+  })
+
+  it("starts a fresh TUI snapshot without synthetic skipped inputs", () => {
+    const snapshot = defaultMenuSnapshot()
+
+    expect(snapshot.inputStage).toBe("active")
+    expect(snapshot.skipInputs).toBe(0)
   })
 })


### PR DESCRIPTION
## Summary

Fixes ProverCoderAI/docker-git#274: the CLI TUI could appear ready while the first real user inputs were still ignored.

## Root cause

A fresh menu snapshot started with `inputStage: "cold"` and `skipInputs: 2`. After the readiness/time gate had already finished, the Gridland input boundary could still consume two valid user key events, and the pure menu input handler also intentionally dropped the first single-character alias, arrow, or Enter event while moving from `cold` to `active`.

That violates the TUI liveness invariant: once the rendered menu is ready and not busy, a valid user key should be processed without requiring dummy keypresses.

## Fix

- Fresh CLI TUI snapshots now start with `inputStage: "active"` and `skipInputs: 0`.
- The cold-stage input handler no longer drops semantic menu inputs; it activates and processes the first valid key in the same transition.
- Existing post-interactive SSH/session handoff protection remains intact via `restoreMenuAfterInteractiveEffect(... skipInputs: 2)`.
- Removed the placeholder `.gitkeep` that was only used to bootstrap this PR branch.

## Mathematical guarantees

- Invariant: `forall key in ValidMenuInput: ready(menu) and not busy(menu) and not sshActive(menu) -> processed(key)`.
- CORE/SHELL boundary: bootstrap noise filtering remains in the Gridland shell gate (`ready` / `ignoreUntil`), while the pure input routing layer no longer discards valid domain events.
- SOURCE: n/a.

## Tests

- [x] `bunx vitest run packages/app/tests/docker-git/menu-input-handler.test.ts`
- [x] `bun run --cwd packages/app lint:tests`
- [x] `bun run --cwd packages/app lint`
- [x] `bun run --cwd packages/app lint:effect`
- [x] `bun run --cwd packages/app typecheck`
- [x] `bun run check`

Environment note: `bun run --cwd packages/app test` and full direct `bunx vitest run` were attempted locally, but this runner terminated them with SIGTERM before a Vitest assertion failure was emitted. The focused regression test and static/type checks above passed; CI should run the complete matrix on the pushed SHA.
