### PR TITLE
fix(ci): make controller GPU opt-in

### DIFF
--- a/docker-compose.api.gpu.yml
+++ b/docker-compose.api.gpu.yml
@@ -1,0 +1,3 @@
+services:
+  api:
+    gpus: all

--- a/docker-compose.api.yml
+++ b/docker-compose.api.yml
@@ -33,7 +33,6 @@ services:
     volumes:
       - docker_git_projects:${DOCKER_GIT_PROJECTS_ROOT:-/home/dev/.docker-git}
       - docker_git_docker_data:/var/lib/docker
-    gpus: all
     privileged: true
     cgroup: host
     init: true

--- a/docker-compose.gpu.yml
+++ b/docker-compose.gpu.yml
@@ -1,0 +1,3 @@
+services:
+  api:
+    gpus: all

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ services:
     volumes:
       - docker_git_projects:${DOCKER_GIT_PROJECTS_ROOT:-/home/dev/.docker-git}
       - docker_git_docker_data:/var/lib/docker
-    gpus: all
     privileged: true
     cgroup: host
     init: true

--- a/packages/app/src/docker-git/controller-compose.ts
+++ b/packages/app/src/docker-git/controller-compose.ts
@@ -1,0 +1,147 @@
+import type { PlatformError } from "@effect/platform/Error"
+import * as FileSystem from "@effect/platform/FileSystem"
+import * as Path from "@effect/platform/Path"
+import { Effect } from "effect"
+
+import { computeLocalControllerRevision, controllerRevisionEnvKey } from "./controller-revision.js"
+import { findExistingUpwards } from "./frontend-lib/usecases/path-helpers.js"
+import type { ControllerBootstrapError } from "./host-errors.js"
+
+export const controllerGpuModeEnvKey = "DOCKER_GIT_CONTROLLER_GPU"
+
+export type ControllerGpuMode = "none" | "all"
+
+export type ControllerComposeFiles = {
+  readonly composePath: string
+  readonly gpuOverlayPath: string | null
+}
+
+const controllerBootstrapError = (message: string): ControllerBootstrapError => ({
+  _tag: "ControllerBootstrapError",
+  message
+})
+
+export const parseControllerGpuMode = (raw?: string): ControllerGpuMode | null => {
+  const trimmed = raw?.trim() ?? ""
+  if (trimmed.length === 0 || trimmed === "none") {
+    return "none"
+  }
+  return trimmed === "all" ? "all" : null
+}
+
+export const controllerRevisionForMode = (
+  sourceRevision: string,
+  gpuMode: ControllerGpuMode
+): string => `${sourceRevision}-${gpuMode}`
+
+const loadControllerGpuMode = (): Effect.Effect<ControllerGpuMode, ControllerBootstrapError> => {
+  const raw = process.env[controllerGpuModeEnvKey]
+  const parsed = parseControllerGpuMode(raw)
+  if (parsed !== null) {
+    return Effect.succeed(parsed)
+  }
+  return Effect.fail(
+    controllerBootstrapError(
+      `${controllerGpuModeEnvKey} must be unset or one of: none, all. Received: ${raw ?? ""}`
+    )
+  )
+}
+
+const composeFilePath = (): Effect.Effect<string, PlatformError, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function*(_) {
+    const fs = yield* _(FileSystem.FileSystem)
+    const path = yield* _(Path.Path)
+    const found = yield* _(findExistingUpwards(fs, path, process.cwd(), "docker-compose.yml", 20))
+    return found ?? path.resolve(process.cwd(), "docker-compose.yml")
+  })
+
+const mapComposePathError = (error: PlatformError): ControllerBootstrapError =>
+  controllerBootstrapError(`Failed to resolve docker-compose.yml path.\nDetails: ${String(error)}`)
+
+const mapControllerRevisionError = (error: PlatformError): ControllerBootstrapError =>
+  controllerBootstrapError(`Failed to compute docker-git controller revision.\nDetails: ${String(error)}`)
+
+export const composeFilesForMode = (
+  composePath: string,
+  gpuOverlayPath: string | null
+): ReadonlyArray<string> =>
+  gpuOverlayPath === null
+    ? ["-f", composePath]
+    : ["-f", composePath, "-f", gpuOverlayPath]
+
+const requireGpuOverlayPath = (
+  composePath: string
+): Effect.Effect<string, ControllerBootstrapError, FileSystem.FileSystem | Path.Path> =>
+  Effect.gen(function*(_) {
+    const fs = yield* _(FileSystem.FileSystem)
+    const path = yield* _(Path.Path)
+    const gpuOverlayPath = path.join(path.dirname(composePath), "docker-compose.gpu.yml")
+    const exists = yield* _(fs.exists(gpuOverlayPath).pipe(Effect.mapError(mapComposePathError)))
+    return exists
+      ? gpuOverlayPath
+      : yield* _(
+        Effect.fail(
+          controllerBootstrapError(`${controllerGpuModeEnvKey}=all requires ${gpuOverlayPath}, but it was not found.`)
+        )
+      )
+  })
+
+const composeFilesForGpuMode = (
+  composePath: string,
+  gpuMode: ControllerGpuMode
+): Effect.Effect<ControllerComposeFiles, ControllerBootstrapError, FileSystem.FileSystem | Path.Path> =>
+  gpuMode === "none"
+    ? Effect.succeed({ composePath, gpuOverlayPath: null })
+    : requireGpuOverlayPath(composePath).pipe(
+      Effect.map((gpuOverlayPath) => ({ composePath, gpuOverlayPath }))
+    )
+
+type ComposePathAndGpuMode = {
+  readonly composePath: string
+  readonly gpuMode: ControllerGpuMode
+}
+
+const withComposePathAndGpuMode = <A>(
+  effect: (input: ComposePathAndGpuMode) => Effect.Effect<
+    A,
+    ControllerBootstrapError,
+    FileSystem.FileSystem | Path.Path
+  >
+): Effect.Effect<A, ControllerBootstrapError, FileSystem.FileSystem | Path.Path> =>
+  composeFilePath().pipe(
+    Effect.mapError(mapComposePathError),
+    Effect.flatMap((composePath) =>
+      loadControllerGpuMode().pipe(
+        Effect.flatMap((gpuMode) => effect({ composePath, gpuMode }))
+      )
+    )
+  )
+
+export const resolveControllerComposeFiles = (): Effect.Effect<
+  ControllerComposeFiles,
+  ControllerBootstrapError,
+  FileSystem.FileSystem | Path.Path
+> => withComposePathAndGpuMode(({ composePath, gpuMode }) => composeFilesForGpuMode(composePath, gpuMode))
+
+const computeControllerRevision = (
+  composePath: string,
+  gpuMode: ControllerGpuMode
+): Effect.Effect<string, ControllerBootstrapError, FileSystem.FileSystem | Path.Path> =>
+  computeLocalControllerRevision(composePath).pipe(
+    Effect.mapError(mapControllerRevisionError),
+    Effect.map((revision) => controllerRevisionForMode(revision, gpuMode))
+  )
+
+const persistControllerRevision = (revision: string): Effect.Effect<void> =>
+  Effect.sync(() => {
+    process.env[controllerRevisionEnvKey] = revision
+  })
+
+export const prepareControllerRevision = (): Effect.Effect<
+  string,
+  ControllerBootstrapError,
+  FileSystem.FileSystem | Path.Path
+> =>
+  withComposePathAndGpuMode(({ composePath, gpuMode }) => computeControllerRevision(composePath, gpuMode)).pipe(
+    Effect.tap((revision) => persistControllerRevision(revision))
+  )

--- a/packages/app/src/docker-git/controller-docker.ts
+++ b/packages/app/src/docker-git/controller-docker.ts
@@ -1,9 +1,9 @@
 import type * as CommandExecutor from "@effect/platform/CommandExecutor"
-import type { PlatformError } from "@effect/platform/Error"
-import * as FileSystem from "@effect/platform/FileSystem"
-import * as Path from "@effect/platform/Path"
+import type * as FileSystem from "@effect/platform/FileSystem"
+import type * as Path from "@effect/platform/Path"
 import { Effect } from "effect"
 
+import { composeFilesForMode, prepareControllerRevision, resolveControllerComposeFiles } from "./controller-compose.js"
 import {
   runCommandCapture,
   runCommandExitCode,
@@ -18,12 +18,10 @@ import {
   resolveConfiguredApiBaseUrl,
   uniqueStrings
 } from "./controller-reachability.js"
-import {
-  computeLocalControllerRevision,
-  controllerRevisionEnvKey,
-  parseControllerRevisionEnvOutput
-} from "./controller-revision.js"
+import { parseControllerRevisionEnvOutput } from "./controller-revision.js"
 import type { ControllerBootstrapError } from "./host-errors.js"
+
+export { controllerGpuModeEnvKey, controllerRevisionForMode, parseControllerGpuMode } from "./controller-compose.js"
 
 export type ControllerRuntime =
   | CommandExecutor.CommandExecutor
@@ -40,33 +38,6 @@ const controllerBootstrapError = (message: string): ControllerBootstrapError => 
   _tag: "ControllerBootstrapError",
   message
 })
-
-const composeFilePath = (): Effect.Effect<string, PlatformError, FileSystem.FileSystem | Path.Path> =>
-  Effect.gen(function*(_) {
-    const fs = yield* _(FileSystem.FileSystem)
-    const path = yield* _(Path.Path)
-    let current = process.cwd()
-
-    for (;;) {
-      const candidate = path.join(current, "docker-compose.yml")
-      const exists = yield* _(fs.exists(candidate))
-      if (exists) {
-        return candidate
-      }
-
-      const parent = path.dirname(current)
-      if (parent === current) {
-        return path.resolve(process.cwd(), "docker-compose.yml")
-      }
-      current = parent
-    }
-  })
-
-const mapComposePathError = (error: PlatformError): ControllerBootstrapError =>
-  controllerBootstrapError(`Failed to resolve docker-compose.yml path.\nDetails: ${String(error)}`)
-
-const mapControllerRevisionError = (error: PlatformError): ControllerBootstrapError =>
-  controllerBootstrapError(`Failed to compute docker-git controller revision.\nDetails: ${String(error)}`)
 
 const currentProcessEnv = (): Readonly<Record<string, string>> =>
   Object.fromEntries(
@@ -211,11 +182,10 @@ export const runCompose = (
 ): Effect.Effect<void, ControllerBootstrapError, ControllerRuntime> =>
   Effect.gen(function*(_) {
     const dockerCommand = yield* _(resolveDockerCommand())
-    const composePath = yield* _(composeFilePath().pipe(Effect.mapError(mapComposePathError)))
+    const composeFiles = yield* _(resolveControllerComposeFiles())
     const invocation = buildDockerInvocation(dockerCommand, [
       "compose",
-      "-f",
-      composePath,
+      ...composeFilesForMode(composeFiles.composePath, composeFiles.gpuOverlayPath),
       ...args
     ])
     const exitCode = yield* _(
@@ -269,18 +239,7 @@ export const inspectControllerRevision = (): Effect.Effect<
   )
 
 export const prepareLocalControllerRevision = (): Effect.Effect<string, ControllerBootstrapError, ControllerRuntime> =>
-  Effect.gen(function*(_) {
-    const composePath = yield* _(composeFilePath().pipe(Effect.mapError(mapComposePathError)))
-    const revision = yield* _(
-      computeLocalControllerRevision(composePath).pipe(Effect.mapError(mapControllerRevisionError))
-    )
-    yield* _(
-      Effect.sync(() => {
-        process.env[controllerRevisionEnvKey] = revision
-      })
-    )
-    return revision
-  })
+  prepareControllerRevision()
 
 export const inspectContainerNetworks = (
   containerName: string

--- a/packages/app/src/docker-git/controller-revision.ts
+++ b/packages/app/src/docker-git/controller-revision.ts
@@ -7,6 +7,7 @@ export const controllerRevisionEnvKey = "DOCKER_GIT_CONTROLLER_REV"
 
 const controllerRevisionInputs: ReadonlyArray<string> = [
   "docker-compose.yml",
+  "docker-compose.gpu.yml",
   "package.json",
   "bun.lock",
   "bunfig.toml",

--- a/packages/app/src/docker-git/frontend-lib/core/domain.ts
+++ b/packages/app/src/docker-git/frontend-lib/core/domain.ts
@@ -247,8 +247,7 @@ export type Command =
 export const isDockerNetworkMode = (value: string): value is DockerNetworkMode =>
   value === "shared" || value === "project"
 
-export const isGpuMode = (value: string): value is GpuMode =>
-  value === "none" || value === "all"
+export const isGpuMode = (value: string): value is GpuMode => value === "none" || value === "all"
 
 // CHANGE: derive compose network name from typed template config
 // WHY: keep network naming deterministic across template generation and runtime checks

--- a/packages/app/src/lib/core/domain.ts
+++ b/packages/app/src/lib/core/domain.ts
@@ -242,8 +242,7 @@ export type Command =
 export const isDockerNetworkMode = (value: string): value is DockerNetworkMode =>
   value === "shared" || value === "project"
 
-export const isGpuMode = (value: string): value is GpuMode =>
-  value === "none" || value === "all"
+export const isGpuMode = (value: string): value is GpuMode => value === "none" || value === "all"
 
 // CHANGE: derive compose network name from typed template config
 // WHY: keep network naming deterministic across template generation and runtime checks

--- a/packages/app/src/lib/core/templates/docker-compose.ts
+++ b/packages/app/src/lib/core/templates/docker-compose.ts
@@ -181,7 +181,9 @@ const renderComposeServices = (
     build: .
     container_name: ${config.containerName}
     restart: unless-stopped
-${renderGpu(config.gpu)}${renderEnvFiles(config)}    # runtime auth/env must be loaded into the container process, not only bootstrap scripts
+${renderGpu(config.gpu)}${
+    renderEnvFiles(config)
+  }    # runtime auth/env must be loaded into the container process, not only bootstrap scripts
     environment:
       REPO_URL: "${config.repoUrl}"
       REPO_REF: "${config.repoRef}"

--- a/packages/app/src/lib/usecases/apply-overrides.ts
+++ b/packages/app/src/lib/usecases/apply-overrides.ts
@@ -2,16 +2,20 @@
 import type { ApplyCommand, TemplateConfig } from "../core/domain.js"
 import { normalizeAuthLabel, normalizeGitTokenLabel } from "../core/token-labels.js"
 
+const applyOverrideKeys = [
+  "gitTokenLabel",
+  "codexTokenLabel",
+  "claudeTokenLabel",
+  "cpuLimit",
+  "ramLimit",
+  "playwrightCpuLimit",
+  "playwrightRamLimit",
+  "gpu",
+  "enableMcpPlaywright"
+] satisfies ReadonlyArray<keyof ApplyCommand>
+
 export const hasApplyOverrides = (command: ApplyCommand): boolean =>
-  command.gitTokenLabel !== undefined ||
-  command.codexTokenLabel !== undefined ||
-  command.claudeTokenLabel !== undefined ||
-  command.cpuLimit !== undefined ||
-  command.ramLimit !== undefined ||
-  command.playwrightCpuLimit !== undefined ||
-  command.playwrightRamLimit !== undefined ||
-  command.gpu !== undefined ||
-  command.enableMcpPlaywright !== undefined
+  applyOverrideKeys.some((key) => command[key] !== undefined)
 
 const applyTokenOverrides = (template: TemplateConfig, command: ApplyCommand): TemplateConfig => {
   let next = template

--- a/packages/app/src/web/app-ready-main-panels.tsx
+++ b/packages/app/src/web/app-ready-main-panels.tsx
@@ -42,6 +42,19 @@ const actionLabels: Record<MainPanelsProps["currentMenu"], string> = {
 
 const actionLabel = (menu: MainPanelsProps["currentMenu"]): string => actionLabels[menu]
 
+type ProjectActionBarProps = Pick<
+  MainPanelsProps,
+  | "currentMenu"
+  | "onApplyAllProjects"
+  | "onApplySelectedProject"
+  | "onRunCurrentMenuAction"
+  | "project"
+  | "projectBrowser"
+  | "selectedProjectSummary"
+>
+
+type ProjectGpuMode = NonNullable<MainPanelsProps["project"]>["gpu"]
+
 const screenTitle = (props: Pick<MainPanelsProps, "activeScreen" | "currentMenu">): string => {
   if (props.activeScreen.tag === "Create") {
     return "docker-git / Create"
@@ -80,29 +93,129 @@ const MainMenuRoute = (
   </ScreenFrame>
 )
 
-const ProjectActionBar = (
+const selectedProjectGpu = (
+  { project, selectedProjectSummary }: Pick<ProjectActionBarProps, "project" | "selectedProjectSummary">
+): ProjectGpuMode | null =>
+  selectedProjectSummary !== undefined && project !== null && project.id === selectedProjectSummary.id
+    ? project.gpu
+    : null
+
+type ActionButtonProps = {
+  readonly fg?: string | undefined
+  readonly label: string
+  readonly onClick: () => void
+}
+
+const ActionButton = ({ fg = "#78f0a3", label, onClick }: ActionButtonProps): JSX.Element => (
+  <Box onClick={onClick} width="auto">
+    <Text bold={true} fg={fg}>{label}</Text>
+  </Box>
+)
+
+const ProjectSelectionSummary = (
+  { currentMenu, project, selectedProjectSummary }: Pick<
+    ProjectActionBarProps,
+    "currentMenu" | "project" | "selectedProjectSummary"
+  >
+): JSX.Element => {
+  const selectedGpu = selectedProjectGpu({ project, selectedProjectSummary })
+  const showGpu = currentMenu === "Select" && selectedProjectSummary !== undefined
+
+  return (
+    <Box flexDirection="column" width="auto">
+      <Text fg="#aab7c4" wrap="truncate">
+        {selectedProjectSummary === undefined ? "No project selected." : selectedProjectSummary.displayName}
+      </Text>
+      {showGpu ? <Text fg="#8fa6c4">GPU: {selectedGpu ?? "unknown"}</Text> : null}
+    </Box>
+  )
+}
+
+const ProjectGpuControls = (
+  { onApplySelectedProject, selectedGpu }: Pick<ProjectActionBarProps, "onApplySelectedProject"> & {
+    readonly selectedGpu: ProjectGpuMode | null
+  }
+): JSX.Element => (
+  <>
+    <ActionButton
+      fg={selectedGpu === "all" ? "#56f39a" : "#78f0a3"}
+      label="GPU on"
+      onClick={() => {
+        onApplySelectedProject("all")
+      }}
+    />
+    <ActionButton
+      fg={selectedGpu === "none" ? "#ffd166" : "#ffb86b"}
+      label="GPU off"
+      onClick={() => {
+        onApplySelectedProject("none")
+      }}
+    />
+  </>
+)
+
+const SelectProjectControls = (
   {
     currentMenu,
     onApplyAllProjects,
     onApplySelectedProject,
+    selectedGpu,
+    selectedProjectSummary
+  }:
+    & Pick<
+      ProjectActionBarProps,
+      "currentMenu" | "onApplyAllProjects" | "onApplySelectedProject" | "selectedProjectSummary"
+    >
+    & {
+      readonly selectedGpu: ProjectGpuMode | null
+    }
+): JSX.Element | null => {
+  if (currentMenu !== "Select") {
+    return null
+  }
+
+  return (
+    <>
+      {selectedProjectSummary === undefined
+        ? null
+        : <ProjectGpuControls onApplySelectedProject={onApplySelectedProject} selectedGpu={selectedGpu} />}
+      {selectedProjectSummary === undefined
+        ? null
+        : (
+          <ActionButton
+            label="Apply"
+            onClick={() => {
+              onApplySelectedProject()
+            }}
+          />
+        )}
+      <ActionButton label="Apply all" onClick={onApplyAllProjects} />
+    </>
+  )
+}
+
+const PrimaryMenuAction = (
+  {
+    currentMenu,
     onRunCurrentMenuAction,
-    project,
     projectBrowser,
     selectedProjectSummary
   }: Pick<
-    MainPanelsProps,
-    | "currentMenu"
-    | "onApplyAllProjects"
-    | "onApplySelectedProject"
-    | "onRunCurrentMenuAction"
-    | "project"
-    | "projectBrowser"
-    | "selectedProjectSummary"
+    ProjectActionBarProps,
+    "currentMenu" | "onRunCurrentMenuAction" | "projectBrowser" | "selectedProjectSummary"
   >
 ): JSX.Element => {
-  const selectedGpu = selectedProjectSummary !== undefined && project !== null && project.id === selectedProjectSummary.id
-    ? project.gpu
-    : null
+  const label = actionLabel(currentMenu)
+  const browserUnavailable = currentMenu === "Browser" &&
+    !canOpenProjectBrowser(projectBrowser, selectedProjectSummary?.id ?? null)
+
+  return browserUnavailable
+    ? <Text bold={true} fg="#8fa6c4">{label}</Text>
+    : <ActionButton label={label} onClick={onRunCurrentMenuAction} />
+}
+
+const ProjectActionBar = (props: ProjectActionBarProps): JSX.Element => {
+  const selectedGpu = selectedProjectGpu(props)
 
   return (
     <Box
@@ -115,56 +228,25 @@ const ProjectActionBar = (
       justifyContent="space-between"
       padding={1}
     >
-      <Box flexDirection="column" width="auto">
-        <Text fg="#aab7c4" wrap="truncate">
-          {selectedProjectSummary === undefined ? "No project selected." : selectedProjectSummary.displayName}
-        </Text>
-        {currentMenu === "Select" && selectedProjectSummary !== undefined
-          ? <Text fg="#8fa6c4">GPU: {selectedGpu ?? "unknown"}</Text>
-          : null}
-      </Box>
+      <ProjectSelectionSummary
+        currentMenu={props.currentMenu}
+        project={props.project}
+        selectedProjectSummary={props.selectedProjectSummary}
+      />
       <Box flexWrap="wrap" gap={1} justifyContent="flex-end" width="auto">
-        {currentMenu === "Select" && selectedProjectSummary !== undefined
-          ? (
-            <Box onClick={() => {
-              onApplySelectedProject("all")
-            }} width="auto">
-              <Text bold={true} fg={selectedGpu === "all" ? "#56f39a" : "#78f0a3"}>GPU on</Text>
-            </Box>
-          )
-          : null}
-        {currentMenu === "Select" && selectedProjectSummary !== undefined
-          ? (
-            <Box onClick={() => {
-              onApplySelectedProject("none")
-            }} width="auto">
-              <Text bold={true} fg={selectedGpu === "none" ? "#ffd166" : "#ffb86b"}>GPU off</Text>
-            </Box>
-          )
-          : null}
-        {currentMenu === "Select" && selectedProjectSummary !== undefined
-          ? (
-            <Box onClick={() => {
-              onApplySelectedProject()
-            }} width="auto">
-              <Text bold={true} fg="#78f0a3">Apply</Text>
-            </Box>
-          )
-          : null}
-        {currentMenu === "Select"
-          ? (
-            <Box onClick={onApplyAllProjects} width="auto">
-              <Text bold={true} fg="#78f0a3">Apply all</Text>
-            </Box>
-          )
-          : null}
-        {currentMenu === "Browser" && !canOpenProjectBrowser(projectBrowser, selectedProjectSummary?.id ?? null)
-          ? <Text bold={true} fg="#8fa6c4">{actionLabel(currentMenu)}</Text>
-          : (
-            <Box onClick={onRunCurrentMenuAction} width="auto">
-              <Text bold={true} fg="#78f0a3">{actionLabel(currentMenu)}</Text>
-            </Box>
-          )}
+        <SelectProjectControls
+          currentMenu={props.currentMenu}
+          onApplyAllProjects={props.onApplyAllProjects}
+          onApplySelectedProject={props.onApplySelectedProject}
+          selectedGpu={selectedGpu}
+          selectedProjectSummary={props.selectedProjectSummary}
+        />
+        <PrimaryMenuAction
+          currentMenu={props.currentMenu}
+          onRunCurrentMenuAction={props.onRunCurrentMenuAction}
+          projectBrowser={props.projectBrowser}
+          selectedProjectSummary={props.selectedProjectSummary}
+        />
       </Box>
     </Box>
   )

--- a/packages/app/tests/docker-git/actions-projects.test.ts
+++ b/packages/app/tests/docker-git/actions-projects.test.ts
@@ -255,7 +255,7 @@ describe("web project actions", () => {
       applyProjectById("project-1", context)
 
       yield* _(waitForAssertion(() => {
-        expect(applyProjectMock).toHaveBeenCalledWith("project-1")
+        expect(applyProjectMock).toHaveBeenCalledWith("project-1", undefined)
       }))
 
       expect(confirmMock).toHaveBeenCalledWith(
@@ -265,7 +265,7 @@ describe("web project actions", () => {
       expect(context.setSelectedProjectId).toHaveBeenCalledWith("project-1")
       expect(context.setSelectedProject).toHaveBeenCalledWith(project)
       expect(reloadDashboard).toHaveBeenCalledTimes(1)
-      expect(setMessage).toHaveBeenLastCalledWith("Applied octocat/hello-world.")
+      expect(setMessage).toHaveBeenLastCalledWith("Applied octocat/hello-world (GPU none).")
     }))
 
   it("does not apply a project when the user declines confirmation", () => {

--- a/packages/app/tests/docker-git/app-ready-create.test.ts
+++ b/packages/app/tests/docker-git/app-ready-create.test.ts
@@ -64,6 +64,7 @@ describe("app-ready-create", () => {
       "repoUrl",
       "cpuLimit",
       "ramLimit",
+      "gpu",
       "runUp",
       "mcpPlaywright"
     ])

--- a/packages/app/tests/docker-git/controller.test.ts
+++ b/packages/app/tests/docker-git/controller.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "@effect/vitest"
 import { Effect } from "effect"
 
+import { controllerRevisionForMode, parseControllerGpuMode } from "../../src/docker-git/controller-docker.js"
 import {
   parseControllerRevisionEnvOutput,
   shouldForceRecreateController
@@ -97,5 +98,20 @@ describe("controller reachability", () => {
       expect(shouldForceRecreateController(true, "local-a", "local-a")).toBe(false)
       expect(shouldForceRecreateController(true, "local-a", "local-b")).toBe(true)
       expect(shouldForceRecreateController(true, "local-a", null)).toBe(true)
+    }))
+
+  it.effect("parses controller GPU mode from environment values", () =>
+    Effect.sync(() => {
+      expect(parseControllerGpuMode()).toBe("none")
+      expect(parseControllerGpuMode("")).toBe("none")
+      expect(parseControllerGpuMode("none")).toBe("none")
+      expect(parseControllerGpuMode("all")).toBe("all")
+      expect(parseControllerGpuMode("gpu")).toBeNull()
+    }))
+
+  it.effect("includes controller GPU mode in the revision", () =>
+    Effect.sync(() => {
+      expect(controllerRevisionForMode("abc123def4567890", "none")).toBe("abc123def4567890-none")
+      expect(controllerRevisionForMode("abc123def4567890", "all")).toBe("abc123def4567890-all")
     }))
 })

--- a/packages/app/tests/docker-git/menu-create-shared.test.ts
+++ b/packages/app/tests/docker-git/menu-create-shared.test.ts
@@ -56,6 +56,7 @@ describe("menu-create-shared", () => {
       "repoUrl",
       "cpuLimit",
       "ramLimit",
+      "gpu",
       "runUp",
       "mcpPlaywright",
       "force"
@@ -86,7 +87,8 @@ describe("menu-create-shared", () => {
     expect(resolveCreateFlowSteps(view.values)).toEqual([
       "repoUrl",
       "cpuLimit",
-      "ramLimit"
+      "ramLimit",
+      "gpu"
     ])
   })
 
@@ -94,13 +96,14 @@ describe("menu-create-shared", () => {
     const inputs = expectCompleteResult(advanceCreateFlow(
       cwd,
       createInitialFlowView(
-        "https://github.com/org/repo/tree/feature-x --cpu 25% --ram 4g --no-up --mcp-playwright --force"
+        "https://github.com/org/repo/tree/feature-x --cpu 25% --ram 4g --gpu all --no-up --mcp-playwright --force"
       )
     ))
 
     expectFeatureRepoDefaults(inputs, defaultRoot)
     expect(inputs.cpuLimit).toBe("25%")
     expect(inputs.ramLimit).toBe("4g")
+    expect(inputs.gpu).toBe("all")
     expect(inputs.runUp).toBe(false)
     expect(inputs.enableMcpPlaywright).toBe(true)
     expect(inputs.force).toBe(true)

--- a/packages/app/tests/docker-git/parser-project-actions.test.ts
+++ b/packages/app/tests/docker-git/parser-project-actions.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+import { expectProjectDirRunUpCommand, parseOrThrow } from "./parser-helpers.js"
+
+describe("parseArgs project actions", () => {
+  it.effect("parses mcp-playwright command in current directory", () =>
+    expectProjectDirRunUpCommand(["mcp-playwright"], "McpPlaywrightUp", ".", true))
+
+  it.effect("parses mcp-playwright command with --no-up", () =>
+    expectProjectDirRunUpCommand(["mcp-playwright", "--no-up"], "McpPlaywrightUp", ".", false))
+
+  it.effect("parses mcp-playwright with positional repo url into project dir", () =>
+    Effect.sync(() => {
+      const command = parseOrThrow(["mcp-playwright", "https://github.com/org/repo.git"])
+      if (command._tag !== "McpPlaywrightUp") {
+        throw new Error("expected McpPlaywrightUp command")
+      }
+      expect(command.projectDir).toBe(".docker-git/org/repo")
+    }))
+
+  it.effect("parses apply command in current directory", () =>
+    expectProjectDirRunUpCommand(["apply"], "Apply", ".", true))
+
+  it.effect("parses apply command with --no-up", () =>
+    expectProjectDirRunUpCommand(["apply", "--no-up"], "Apply", ".", false))
+
+  it.effect("parses apply with positional repo url into project dir", () =>
+    Effect.sync(() => {
+      const command = parseOrThrow(["apply", "https://github.com/org/repo.git"])
+      if (command._tag !== "Apply") {
+        throw new Error("expected Apply command")
+      }
+      expect(command.projectDir).toBe(".docker-git/org/repo")
+    }))
+
+  it.effect("parses apply token and mcp overrides", () =>
+    Effect.sync(() => {
+      const command = parseOrThrow([
+        "apply",
+        "--git-token=agien_main",
+        "--codex-token=Team A",
+        "--claude-token=Team B",
+        "--cpu=2",
+        "--ram=4g",
+        "--gpu=all",
+        "--mcp-playwright",
+        "--no-up"
+      ])
+      if (command._tag !== "Apply") {
+        throw new Error("expected Apply command")
+      }
+      expect(command.runUp).toBe(false)
+      expect(command.gitTokenLabel).toBe("agien_main")
+      expect(command.codexTokenLabel).toBe("Team A")
+      expect(command.claudeTokenLabel).toBe("Team B")
+      expect(command.cpuLimit).toBe("2")
+      expect(command.ramLimit).toBe("4g")
+      expect(command.gpu).toBe("all")
+      expect(command.enableMcpPlaywright).toBe(true)
+    }))
+
+  it.effect("parses apply-all and update-all commands", () =>
+    Effect.sync(() => {
+      expect(parseOrThrow(["apply-all"])._tag).toBe("ApplyAll")
+      expect(parseOrThrow(["update-all"])._tag).toBe("ApplyAll")
+    }))
+
+  it.effect("parses down-all command", () =>
+    Effect.sync(() => {
+      const command = parseOrThrow(["down-all"])
+      expect(command._tag).toBe("DownAll")
+    }))
+
+  it.effect("parses state path command", () =>
+    Effect.sync(() => {
+      const command = parseOrThrow(["state", "path"])
+      expect(command._tag).toBe("StatePath")
+    }))
+
+  it.effect("parses state init command", () =>
+    Effect.sync(() => {
+      const command = parseOrThrow(["state", "init", "--repo-url", "https://github.com/org/state.git"])
+      if (command._tag !== "StateInit") {
+        throw new Error("expected StateInit command")
+      }
+      expect(command.repoUrl).toBe("https://github.com/org/state.git")
+      expect(command.repoRef).toBe("main")
+    }))
+
+  it.effect("parses state commit command", () =>
+    Effect.sync(() => {
+      const command = parseOrThrow(["state", "commit", "-m", "sync state"])
+      if (command._tag !== "StateCommit") {
+        throw new Error("expected StateCommit command")
+      }
+      expect(command.message).toBe("sync state")
+    }))
+
+  it.effect("parses state sync command", () =>
+    Effect.sync(() => {
+      const command = parseOrThrow(["state", "sync", "-m", "sync state"])
+      if (command._tag !== "StateSync") {
+        throw new Error("expected StateSync command")
+      }
+      expect(command.message).toBe("sync state")
+    }))
+})

--- a/packages/app/tests/docker-git/parser.test.ts
+++ b/packages/app/tests/docker-git/parser.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from "@effect/vitest"
-import { Effect } from "effect"
 
 import { defaultTemplateConfig } from "../../src/docker-git/frontend-lib/core/domain.js"
 import { expandContainerHome } from "../../src/docker-git/frontend-lib/usecases/scrap-path.js"
@@ -8,9 +7,7 @@ import {
   expectAttachProjectDirCommand,
   expectCreateCommand,
   expectOpenCommand,
-  expectParseErrorTag,
-  expectProjectDirRunUpCommand,
-  parseOrThrow
+  expectParseErrorTag
 } from "./parser-helpers.js"
 
 const expectCreateDefaults = (command: CreateCommand) => {
@@ -252,107 +249,5 @@ describe("parseArgs", () => {
     expectOpenCommand(["open"], (command) => {
       expect(command.projectRef).toBeUndefined()
       expect(command.projectDir).toBeUndefined()
-    }))
-
-  it.effect("parses mcp-playwright command in current directory", () =>
-    expectProjectDirRunUpCommand(["mcp-playwright"], "McpPlaywrightUp", ".", true))
-
-  it.effect("parses mcp-playwright command with --no-up", () =>
-    expectProjectDirRunUpCommand(["mcp-playwright", "--no-up"], "McpPlaywrightUp", ".", false))
-
-  it.effect("parses mcp-playwright with positional repo url into project dir", () =>
-    Effect.sync(() => {
-      const command = parseOrThrow(["mcp-playwright", "https://github.com/org/repo.git"])
-      if (command._tag !== "McpPlaywrightUp") {
-        throw new Error("expected McpPlaywrightUp command")
-      }
-      expect(command.projectDir).toBe(".docker-git/org/repo")
-    }))
-
-  it.effect("parses apply command in current directory", () =>
-    expectProjectDirRunUpCommand(["apply"], "Apply", ".", true))
-
-  it.effect("parses apply command with --no-up", () =>
-    expectProjectDirRunUpCommand(["apply", "--no-up"], "Apply", ".", false))
-
-  it.effect("parses apply with positional repo url into project dir", () =>
-    Effect.sync(() => {
-      const command = parseOrThrow(["apply", "https://github.com/org/repo.git"])
-      if (command._tag !== "Apply") {
-        throw new Error("expected Apply command")
-      }
-      expect(command.projectDir).toBe(".docker-git/org/repo")
-    }))
-
-  it.effect("parses apply token and mcp overrides", () =>
-    Effect.sync(() => {
-      const command = parseOrThrow([
-        "apply",
-        "--git-token=agien_main",
-        "--codex-token=Team A",
-        "--claude-token=Team B",
-        "--cpu=2",
-        "--ram=4g",
-        "--gpu=all",
-        "--mcp-playwright",
-        "--no-up"
-      ])
-      if (command._tag !== "Apply") {
-        throw new Error("expected Apply command")
-      }
-      expect(command.runUp).toBe(false)
-      expect(command.gitTokenLabel).toBe("agien_main")
-      expect(command.codexTokenLabel).toBe("Team A")
-      expect(command.claudeTokenLabel).toBe("Team B")
-      expect(command.cpuLimit).toBe("2")
-      expect(command.ramLimit).toBe("4g")
-      expect(command.gpu).toBe("all")
-      expect(command.enableMcpPlaywright).toBe(true)
-    }))
-
-  it.effect("parses apply-all and update-all commands", () =>
-    Effect.sync(() => {
-      expect(parseOrThrow(["apply-all"])._tag).toBe("ApplyAll")
-      expect(parseOrThrow(["update-all"])._tag).toBe("ApplyAll")
-    }))
-
-  it.effect("parses down-all command", () =>
-    Effect.sync(() => {
-      const command = parseOrThrow(["down-all"])
-      expect(command._tag).toBe("DownAll")
-    }))
-
-  it.effect("parses state path command", () =>
-    Effect.sync(() => {
-      const command = parseOrThrow(["state", "path"])
-      expect(command._tag).toBe("StatePath")
-    }))
-
-  it.effect("parses state init command", () =>
-    Effect.sync(() => {
-      const command = parseOrThrow(["state", "init", "--repo-url", "https://github.com/org/state.git"])
-      if (command._tag !== "StateInit") {
-        throw new Error("expected StateInit command")
-      }
-      expect(command.repoUrl).toBe("https://github.com/org/state.git")
-      expect(command.repoRef).toBe("main")
-    }))
-
-  it.effect("parses state commit command", () =>
-    Effect.sync(() => {
-      const command = parseOrThrow(["state", "commit", "-m", "sync state"])
-      if (command._tag !== "StateCommit") {
-        throw new Error("expected StateCommit command")
-      }
-      expect(command.message).toBe("sync state")
-    }))
-
-  it.effect("parses state sync command", () =>
-    Effect.sync(() => {
-      const command = parseOrThrow(["state", "sync", "-m", "sync state"])
-      if (command._tag !== "StateSync") {
-        throw new Error("expected StateSync command")
-      }
-      expect(command.message).toBe("sync state")
     }))
 })

--- a/packages/lib/src/core/domain.ts
+++ b/packages/lib/src/core/domain.ts
@@ -241,8 +241,7 @@ export type Command =
 export const isDockerNetworkMode = (value: string): value is DockerNetworkMode =>
   value === "shared" || value === "project"
 
-export const isGpuMode = (value: string): value is GpuMode =>
-  value === "none" || value === "all"
+export const isGpuMode = (value: string): value is GpuMode => value === "none" || value === "all"
 
 // CHANGE: derive compose network name from typed template config
 // WHY: keep network naming deterministic across template generation and runtime checks

--- a/packages/lib/src/core/templates/docker-compose.ts
+++ b/packages/lib/src/core/templates/docker-compose.ts
@@ -180,7 +180,9 @@ const renderComposeServices = (
     build: .
     container_name: ${config.containerName}
     restart: unless-stopped
-${renderGpu(config.gpu)}${renderEnvFiles(config)}    # runtime auth/env must be loaded into the container process, not only bootstrap scripts
+${renderGpu(config.gpu)}${
+    renderEnvFiles(config)
+  }    # runtime auth/env must be loaded into the container process, not only bootstrap scripts
     environment:
       REPO_URL: "${config.repoUrl}"
       REPO_REF: "${config.repoRef}"

--- a/packages/lib/src/usecases/apply-overrides.ts
+++ b/packages/lib/src/usecases/apply-overrides.ts
@@ -1,16 +1,20 @@
 import type { ApplyCommand, TemplateConfig } from "../core/domain.js"
 import { normalizeAuthLabel, normalizeGitTokenLabel } from "../core/token-labels.js"
 
+const applyOverrideKeys = [
+  "gitTokenLabel",
+  "codexTokenLabel",
+  "claudeTokenLabel",
+  "cpuLimit",
+  "ramLimit",
+  "playwrightCpuLimit",
+  "playwrightRamLimit",
+  "gpu",
+  "enableMcpPlaywright"
+] satisfies ReadonlyArray<keyof ApplyCommand>
+
 export const hasApplyOverrides = (command: ApplyCommand): boolean =>
-  command.gitTokenLabel !== undefined ||
-  command.codexTokenLabel !== undefined ||
-  command.claudeTokenLabel !== undefined ||
-  command.cpuLimit !== undefined ||
-  command.ramLimit !== undefined ||
-  command.playwrightCpuLimit !== undefined ||
-  command.playwrightRamLimit !== undefined ||
-  command.gpu !== undefined ||
-  command.enableMcpPlaywright !== undefined
+  applyOverrideKeys.some((key) => command[key] !== undefined)
 
 const applyTokenOverrides = (template: TemplateConfig, command: ApplyCommand): TemplateConfig => {
   let next = template


### PR DESCRIPTION
## Summary
- make controller GPU access opt-in via compose overlays instead of unconditional `gpus: all`
- keep per-project GPU controls isolated to each project/container
- refactor action bar and split parser tests to satisfy CI lint gates

## Verification
- `docker compose config` has no `gpus` by default
- `docker compose -f docker-compose.yml -f docker-compose.gpu.yml config` includes `gpus`
- `bun run --cwd packages/app lint`
- `bun run --cwd packages/app test`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app build`
- `bun run --cwd packages/lib lint`
- `bun run --cwd packages/lib test`
- `bun run --cwd packages/lib typecheck`
- `bun test packages/lib/tests/core/templates.test.ts`
- `git diff --check`