### PR TITLE
chore: configure CodeRabbit PR reviews

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,150 @@
+# yaml-language-server: $schema=https://coderabbit.ai/integrations/schema.v2.json
+language: "ru-RU"
+early_access: false
+
+reviews:
+  profile: "assertive"
+  request_changes_workflow: false
+  high_level_summary: true
+  high_level_summary_in_walkthrough: true
+  review_status: true
+  review_details: true
+  commit_status: true
+  fail_commit_status: true
+  collapse_walkthrough: true
+  changed_files_summary: true
+  sequence_diagrams: true
+  estimate_code_review_effort: true
+  assess_linked_issues: true
+  related_issues: true
+  related_prs: true
+  suggested_labels: true
+  poem: false
+  in_progress_fortune: false
+  abort_on_close: true
+
+  auto_review:
+    enabled: true
+    auto_incremental_review: true
+    auto_pause_after_reviewed_commits: 0
+    drafts: true
+    base_branches:
+      - ".*"
+    labels:
+      - "!do-not-review"
+      - "!skip-coderabbit"
+    ignore_title_keywords:
+      - "[skip review]"
+      - "[skip coderabbit]"
+      - "do not review"
+
+  path_instructions:
+    - path: "**/*"
+      instructions: |
+        Review every PR against its source of truth, not only against the diff.
+
+        Requirement sources, in priority order:
+        1. Linked GitHub issues in the PR body (`Fixes #123`, `Closes #123`, full issue URLs).
+        2. Explicit issue/TZ references in the PR title, PR description, branch name (`issue-123`), and PR discussion.
+        3. Changed-code markers such as `QUOTE(ТЗ): ...`, `REF: issue-...`, and nearby tests.
+        4. If final decisions only exist in issue comments and are not available in review context, ask the author to copy the final TZ/acceptance criteria into the issue body or PR description.
+
+        Always include a "Соответствие ТЗ" section when the PR has an issue/TZ reference:
+        - list the concrete issue/TZ requirements that the diff implements;
+        - flag any requirement from the issue, PR body, or PR discussion that is missing or contradicted by the code;
+        - flag scope creep when the diff changes behavior not requested by the issue/TZ;
+        - verify that tests cover the observable behavior promised by the issue/TZ.
+
+        Security review priorities:
+        - command injection, shell argument escaping, unsafe `docker`, `git`, `ssh`, `gh`, `sudo`, or process spawning;
+        - path traversal, unsafe filesystem access, and accidental writes outside `.docker-git` or the project workspace;
+        - SSRF/open redirects/network access introduced by user-controlled input;
+        - leaked secrets, tokens, private keys, and sensitive data in logs;
+        - GitHub Actions permission escalation, unpinned risky actions, unsafe `pull_request_target`, and supply-chain risks;
+        - Docker socket exposure, privileged containers, host mounts, GPU/resource flags, and cross-container isolation breaks.
+
+  pre_merge_checks:
+    issue_assessment:
+      mode: "warning"
+    custom_checks:
+      - name: "Requirements alignment"
+        mode: "warning"
+        instructions: |
+          Fail if any of these are true:
+          - The PR has no discoverable source requirement: no linked issue, no issue/TZ reference in the PR title/body/branch/discussion, and no changed-code `QUOTE(ТЗ)` or `REF` marker.
+          - The changed code contradicts a linked issue title/body, PR description, PR discussion decision, or changed-code `QUOTE(ТЗ)`/`REF` marker.
+          - A concrete acceptance criterion from the linked issue or PR description is not implemented and not explicitly marked out of scope in the PR description.
+          - Observable behavior promised by the issue/TZ is changed without matching tests or a clear explanation in the PR description.
+
+          Pass when the source requirement is traceable and every explicit requirement is implemented, tested, or explicitly documented as out of scope.
+          Return Inconclusive only when the relevant issue/TZ discussion is referenced but not available in the review context; ask the author to copy the final TZ into the issue body or PR description.
+      - name: "Security regression"
+        mode: "warning"
+        instructions: |
+          Fail if changed files introduce a high-confidence security regression, including:
+          - command injection or unsafe shell/process execution with user-controlled input;
+          - path traversal or writes outside intended project/container state directories;
+          - credential, token, private-key, or PII exposure in source, generated config, logs, or CI output;
+          - unsafe Docker/GitHub Actions configuration such as privileged containers, broad host mounts, unbounded Docker socket access, unsafe `pull_request_target`, or unnecessary write permissions;
+          - dependency or package-manager changes that materially increase supply-chain risk without justification.
+
+          Pass when no high-confidence regression is found. Return Inconclusive when the diff is too large or lacks enough context to determine risk.
+
+  tools:
+    github-checks:
+      enabled: true
+      timeout_ms: 900000
+    gitleaks:
+      enabled: true
+    trufflehog:
+      enabled: true
+    semgrep:
+      enabled: true
+    opengrep:
+      enabled: true
+    osvScanner:
+      enabled: true
+    checkov:
+      enabled: true
+    trivy:
+      enabled: true
+    presidio:
+      enabled: true
+    actionlint:
+      enabled: true
+    hadolint:
+      enabled: true
+    shellcheck:
+      enabled: true
+    eslint:
+      enabled: true
+    oxc:
+      enabled: true
+    yamllint:
+      enabled: true
+    dotenvLint:
+      enabled: true
+
+knowledge_base:
+  opt_out: false
+  web_search:
+    enabled: true
+  code_guidelines:
+    enabled: true
+    filePatterns:
+      - "AGENTS.md"
+      - "CLAUDE.md"
+      - "GEMINI.md"
+      - "README.md"
+      - "docs/**/*.md"
+  issues:
+    scope: "local"
+  pull_requests:
+    scope: "local"
+  learnings:
+    scope: "local"
+
+chat:
+  art: false
+  auto_reply: true
+  allow_non_org_members: true

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-## Source TZ / Issues
+# Source TZ / Issues
 
 - Fixes #
 - Related discussion:

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,18 @@
+## Source TZ / Issues
+
+- Fixes #
+- Related discussion:
+
+## Summary
+
+-
+
+## Requirements Alignment
+
+- Implemented:
+- Out of scope:
+- Security-sensitive changes:
+
+## Verification
+
+-


### PR DESCRIPTION
## Source TZ / Issues

- Source TZ: maintainer request to enable free CodeRabbit reviews for the public `docker-git` repository.
- Requirements: review every PR automatically, read linked issues and PR discussion where available, verify code against issue/TZ discussion, and flag security regressions.
- Related discussion: local implementation plan from maintainer chat; no public issue was created for this repository-configuration change.

## Summary

- Adds `.coderabbit.yaml` with automatic assertive reviews for all base branches, including draft PRs.
- Enables linked issue assessment, local issues/PR knowledge base, PR-discussion/TZ-focused review instructions, and security-oriented tools.
- Adds a PR template so future PRs surface source TZ, linked issues, requirements alignment, security-sensitive changes, and verification.

## Requirements Alignment

- Implemented: CodeRabbit is instructed to inspect linked issues, PR title/body/discussion, `issue-123` branch names, and changed-code `QUOTE(ТЗ)` / `REF` markers.
- Implemented: custom pre-merge checks warn on missing requirements traceability, TZ mismatch, and high-confidence security regressions.
- Out of scope: enabling the GitHub App in the CodeRabbit dashboard, because that is an organization/repository installation setting outside the git tree.
- Security-sensitive changes: enables secret scanning, SAST, IaC/Docker/GitHub Actions checks, package vulnerability scanning, and PII scanning through CodeRabbit-supported tools.

## Verification

- `bunx --bun js-yaml .coderabbit.yaml >/tmp/coderabbit-config.json`
- `bunx --bun ajv-cli validate --strict=false -s /tmp/coderabbit-schema.json -d /tmp/coderabbit-config.json`
- `git diff --check`
- `bun run check`