### PR TITLE
chore: configure hosted OSS review agents

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -41,43 +41,33 @@ reviews:
   path_instructions:
     - path: "**/*"
       instructions: |
-        Review every PR against its source of truth, not only against the diff.
+        Ты строгий ревьюер SPEC DRIVEN DEVELOPMENT.
 
-        Requirement sources, in priority order:
-        1. Linked GitHub issues in the PR body (`Fixes #123`, `Closes #123`, full issue URLs).
-        2. Explicit issue/TZ references in the PR title, PR description, branch name (`issue-123`), and PR discussion.
-        3. Changed-code markers such as `QUOTE(ТЗ): ...`, `REF: issue-...`, and nearby tests.
-        4. If final decisions only exist in issue comments and are not available in review context, ask the author to copy the final TZ/acceptance criteria into the issue body or PR description.
+        Перед выводами изучи README.md, другие *.md файлы, linked issues,
+        PR description, PR comments/discussion и релевантную кодовую базу.
 
-        Always include a "Соответствие ТЗ" section when the PR has an issue/TZ reference:
-        - list the concrete issue/TZ requirements that the diff implements;
-        - flag any requirement from the issue, PR body, or PR discussion that is missing or contradicted by the code;
-        - flag scope creep when the diff changes behavior not requested by the issue/TZ;
-        - verify that tests cover the observable behavior promised by the issue/TZ.
+        Сверь изменения с исходным ТЗ/спекой и обсуждением. Флагай любой уход
+        от спеки, недокументированное изменение поведения, отсутствие тестов
+        для заявленного поведения и security-риск. Если спека не видна,
+        попроси автора добавить ее в issue или PR description.
 
-        Security review priorities:
-        - command injection, shell argument escaping, unsafe `docker`, `git`, `ssh`, `gh`, `sudo`, or process spawning;
-        - path traversal, unsafe filesystem access, and accidental writes outside `.docker-git` or the project workspace;
-        - SSRF/open redirects/network access introduced by user-controlled input;
-        - leaked secrets, tokens, private keys, and sensitive data in logs;
-        - GitHub Actions permission escalation, unpinned risky actions, unsafe `pull_request_target`, and supply-chain risks;
-        - Docker socket exposure, privileged containers, host mounts, GPU/resource flags, and cross-container isolation breaks.
+        Проверь решение с точки зрения формальной верификации: какие инварианты,
+        предусловия и постусловия можно доказать математически, а где доказуемость
+        слабая. Оцени решение с точки зрения теории игр: устойчивы ли стимулы,
+        нет ли выгодного обхода правил, и какое решение было бы сильнее.
 
   pre_merge_checks:
     issue_assessment:
       mode: "warning"
     custom_checks:
       - name: "Requirements alignment"
-        mode: "warning"
+        mode: "error"
         instructions: |
-          Fail if any of these are true:
-          - The PR has no discoverable source requirement: no linked issue, no issue/TZ reference in the PR title/body/branch/discussion, and no changed-code `QUOTE(ТЗ)` or `REF` marker.
-          - The changed code contradicts a linked issue title/body, PR description, PR discussion decision, or changed-code `QUOTE(ТЗ)`/`REF` marker.
-          - A concrete acceptance criterion from the linked issue or PR description is not implemented and not explicitly marked out of scope in the PR description.
-          - Observable behavior promised by the issue/TZ is changed without matching tests or a clear explanation in the PR description.
-
-          Pass when the source requirement is traceable and every explicit requirement is implemented, tested, or explicitly documented as out of scope.
-          Return Inconclusive only when the relevant issue/TZ discussion is referenced but not available in the review context; ask the author to copy the final TZ into the issue body or PR description.
+          Fail if the diff contradicts the visible spec/TZ, linked issue, PR
+          discussion, README/docs, or changes behavior without documenting it.
+          Fail if promised behavior has no relevant tests. Return Inconclusive
+          when the spec is missing and ask the author to add it. Also flag weak
+          formal invariants or game-theory incentives when they undermine the spec.
       - name: "Security regression"
         mode: "warning"
         instructions: |

--- a/.greptile/config.json
+++ b/.greptile/config.json
@@ -1,0 +1,43 @@
+{
+  "strictness": 1,
+  "commentTypes": ["logic", "syntax", "style", "info"],
+  "triggerOnUpdates": true,
+  "triggerOnDrafts": true,
+  "ignorePatterns": "node_modules/**\ndist/**\ncoverage/**\nthird_party/**",
+  "statusCheck": true,
+  "statusCommentsEnabled": true,
+  "updateExistingSummaryComment": true,
+  "summarySection": {
+    "included": true,
+    "collapsible": true,
+    "defaultOpen": false
+  },
+  "instructions": "This is a public MIT open-source TypeScript/Bun monorepo. Review every PR as SPEC DRIVEN DEVELOPMENT: compare the diff with README.md, repository Markdown docs, linked issues, PR description, PR comments and the relevant codebase. Flag spec drift, undocumented behavior changes, missing tests for promised behavior, high-confidence security risks, weak formal invariants, and game-theory incentive problems.",
+  "rules": [
+    {
+      "id": "spec-source-required",
+      "rule": "Every behavioral change must be traceable to a visible source of truth: linked issue, PR description, PR discussion, README/docs, or changed-code reference. If the spec is missing, ask the author to add it before approval.",
+      "severity": "high"
+    },
+    {
+      "id": "spec-alignment",
+      "rule": "Flag any change that contradicts the visible issue/TZ/spec, PR discussion, README/docs, or changes behavior without documentation.",
+      "severity": "high"
+    },
+    {
+      "id": "security-review",
+      "rule": "Look for injection, path traversal, secret leaks, unsafe Docker/GitHub Actions settings, supply-chain risk, and cross-container isolation regressions.",
+      "severity": "high"
+    },
+    {
+      "id": "formal-verification",
+      "rule": "Assess which invariants, preconditions, and postconditions are mathematically defensible. Flag weak or unstated invariants when they affect correctness.",
+      "severity": "medium"
+    },
+    {
+      "id": "game-theory",
+      "rule": "Assess whether the implementation creates incentives to bypass intended rules or safety controls. Suggest a stronger mechanism when incentives are misaligned.",
+      "severity": "medium"
+    }
+  ]
+}

--- a/.greptile/files.json
+++ b/.greptile/files.json
@@ -1,0 +1,16 @@
+{
+  "files": [
+    {
+      "path": "README.md",
+      "description": "Main project behavior, CLI usage, runtime contracts, and architecture notes."
+    },
+    {
+      "path": "AGENTS.md",
+      "description": "Repository engineering rules, formal verification expectations, and review constraints."
+    },
+    {
+      "path": "LICENSE",
+      "description": "Project license text, legal terms, and copyright."
+    }
+  ]
+}

--- a/.greptile/rules.md
+++ b/.greptile/rules.md
@@ -1,0 +1,15 @@
+# SPEC-DRIVEN DEVELOPMENT Review Rules
+
+Review every PR against its source of truth, not only against the diff.
+
+Use README.md, repository Markdown docs, linked issues, PR description, PR comments/discussion, and the relevant codebase as review context.
+
+Flag:
+- Spec drift or contradiction with the issue/TZ/spec.
+- Undocumented behavior changes.
+- Missing tests for promised behavior.
+- Security regressions.
+- Weak formal invariants, preconditions, or postconditions.
+- Game-theory incentive problems where users can profitably bypass intended rules.
+
+If the spec is not visible, ask the author to copy the final requirements into the issue or PR description.

--- a/.pr_agent.toml
+++ b/.pr_agent.toml
@@ -1,0 +1,24 @@
+[github_app]
+pr_commands = [
+  "/agentic_describe",
+  "/agentic_review"
+]
+handle_push_trigger = true
+push_commands = [
+  "/agentic_review"
+]
+
+[review_agent]
+comments_location_policy = "both"
+inline_comments_severity_threshold = 2
+issues_user_guidelines = """
+Review as SPEC DRIVEN DEVELOPMENT.
+Read README.md, repository Markdown docs, linked issues, PR description, PR comments/discussion, and relevant code.
+Flag spec drift, undocumented behavior changes, missing tests for promised behavior, and security risks.
+"""
+compliance_user_guidelines = """
+Check whether the code matches the visible issue/TZ/spec and discussion.
+Check formal-verification quality: invariants, preconditions, postconditions, and what can be proved mathematically.
+Check game-theory quality: whether incentives let users bypass intended rules, and suggest stronger mechanisms.
+If the spec is missing, ask the author to add it to the issue or PR description.
+"""

--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -1,0 +1,13 @@
+ignore:
+  - .git
+  - node_modules
+  - dist
+  - coverage
+  - third_party
+
+github:
+  labels: []
+  ignore_labels:
+    - sourcery-ignore
+    - do-not-review
+    - skip-review

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 ProverCoderAI Contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -3,6 +3,8 @@
 `docker-git` создаёт отдельную Docker-среду для каждого репозитория, issue или PR.
 По умолчанию проекты лежат в `~/.docker-git`.
 
+License: MIT. See [LICENSE](LICENSE).
+
 ## Установка
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -68,5 +68,5 @@
     "url": "https://github.com/ProverCoderAI/docker-git/issues"
   },
   "homepage": "https://github.com/ProverCoderAI/docker-git#readme",
-  "license": "ISC"
+  "license": "MIT"
 }

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -31,6 +31,7 @@
     "type": "git",
     "url": "git+https://github.com/ProverCoderAI/docker-git.git"
   },
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/ProverCoderAI/docker-git/issues"
   },

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -50,7 +50,7 @@
     "console"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "module",
   "bugs": {
     "url": "https://github.com/ProverCoderAI/docker-git/issues"

--- a/packages/docker-git-session-sync/package.json
+++ b/packages/docker-git-session-sync/package.json
@@ -26,7 +26,7 @@
     "agents"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "module",
   "bugs": {
     "url": "https://github.com/ProverCoderAI/docker-git/issues"

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -26,7 +26,7 @@
     "console"
   ],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "type": "module",
   "bugs": {
     "url": "https://github.com/ProverCoderAI/docker-git/issues"


### PR DESCRIPTION
## Source TZ / Issues
User request: add hosted-only PR review agents for public MIT OSS usage. Desired agents: Sourcery OSS, Greptile OSS Program, CodeRabbit OSS as an additional reviewer, and hosted Qodo/PR-Agent. Self-hosted agents are out of scope.

## Requirements Alignment
### Implemented
- Marked the repository as MIT OSS via LICENSE, README, and package metadata.
- Kept CodeRabbit auto review enabled and simplified its SPEC-driven review prompt.
- Added Greptile config with strict automatic review, spec alignment, security, formal-verification, and game-theory checks.
- Added Qodo Git / PR-Agent hosted config for automatic agentic describe/review.
- Added Sourcery config for hosted GitHub App review with generated/build/vendor ignores.

### Out of scope
- Self-hosted PR-Agent setup.
- Installing or approving third-party GitHub Apps from inside the repository. Sourcery, Greptile, Qodo Git, and CodeRabbit still need org/repo app enablement where not already installed.
- Applying the new configs automatically to old PRs before this lands on main.

### Security-sensitive
- No secrets, tokens, workflows, or elevated GitHub permissions were added.
- Review prompts explicitly ask agents to check security regressions, supply-chain risk, unsafe Docker/GitHub Actions settings, and spec drift.

## Verification
- jq empty package.json packages/app/package.json packages/docker-git-session-sync/package.json packages/lib/package.json packages/api/package.json .greptile/config.json .greptile/files.json
- python3 tomllib validation for .pr_agent.toml
- bunx yaml valid for .sourcery.yaml and .coderabbit.yaml
- git diff --check
- bun run check
- bun run test
- GitHub Actions: all 16 checks passed on PR #290
- CodeRabbit: passed after addressed comments