### PR TITLE
fix(core): fallback when NVIDIA runtime is unavailable

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-05-13T12:41:11.337Z for PR creation at branch issue-291-ab2f24b23ca2 for issue https://github.com/ProverCoderAI/docker-git/issues/291

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-05-13T12:41:11.337Z for PR creation at branch issue-291-ab2f24b23ca2 for issue https://github.com/ProverCoderAI/docker-git/issues/291

--- a/README.md
+++ b/README.md
@@ -60,6 +60,23 @@ docker-git apply-all --active
 - `apply` применяет конфиг к одному проекту. `--no-up` только обновляет файлы без `docker compose up`.
 - `apply-all` применяет конфиг ко всем проектам. `--active` только к запущенным контейнерам.
 
+## GPU режим
+
+По умолчанию проекты запускаются без GPU (`gpu: "none"`), поэтому Docker не
+требует NVIDIA runtime на обычных CPU-хостах.
+
+GPU включается только явно через `--gpu all` или сохранённое значение
+`"gpu": "all"` в `docker-git.json`. Если Docker возвращает ошибку NVIDIA
+prestart hook вида `nvidia-container-cli` / `libnvidia-ml.so.1`, `docker-git`
+перезаписывает managed-файлы проекта с `gpu: "none"` и повторяет
+`docker compose up`, чтобы среда оставалась запускаемой на хосте без рабочей
+NVIDIA userspace-части.
+
+Если проекту действительно нужен GPU, установите драйвер NVIDIA и NVIDIA
+Container Toolkit на хосте, затем снова примените конфигурацию с `--gpu all`.
+GPU для controller-контейнера включается отдельно через
+`DOCKER_GIT_CONTROLLER_GPU=all`; значение по умолчанию для controller тоже
+`none`.
 
 Для запуска WEB версии:
 ```bash

--- a/bun.lock
+++ b/bun.lock
@@ -163,6 +163,7 @@
         "eslint-plugin-sonarjs": "^4.0.3",
         "eslint-plugin-sort-destructure-keys": "^3.0.0",
         "eslint-plugin-unicorn": "^64.0.0",
+        "fast-check": "^3.23.2",
         "globals": "^17.6.0",
         "jscpd": "^4.1.1",
         "typescript": "^6.0.3",

--- a/packages/app/src/lib/core/gpu.ts
+++ b/packages/app/src/lib/core/gpu.ts
@@ -1,0 +1,39 @@
+/* jscpd:ignore-start */
+import type { GpuMode } from "./domain.js"
+
+const nvidiaFailureMarkers = [
+  "nvidia-container-cli",
+  "libnvidia-ml.so.1",
+  "could not select device driver"
+]
+
+// CHANGE: classify Docker/NVIDIA runtime failures from compose output.
+// WHY: GPU device requests fail before the container entrypoint can run, so recovery must happen outside Docker.
+// QUOTE(ТЗ): "nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1"
+// REF: issue-291
+// SOURCE: n/a
+// FORMAT THEOREM: forall s: contains_nvidia_runtime_marker(s) -> nvidia_runtime_failure(s)
+// PURITY: CORE
+// EFFECT: n/a
+// INVARIANT: detection is monotonic over output text; adding unrelated text cannot flip true to false
+// COMPLEXITY: O(n * m) where n = |details| and m = marker count
+export const isNvidiaRuntimeFailure = (details: string | undefined): boolean => {
+  const normalized = details?.toLowerCase() ?? ""
+  return nvidiaFailureMarkers.some((marker) => normalized.includes(marker))
+}
+
+// CHANGE: derive the safe GPU fallback mode after a Docker runtime failure.
+// WHY: non-GPU containers must remain startable on hosts without a working NVIDIA userspace stack.
+// QUOTE(ТЗ): "load library failed: libnvidia-ml.so.1"
+// REF: issue-291
+// SOURCE: n/a
+// FORMAT THEOREM: forall g,e: fallback(g,e) = none iff g = all and nvidia_runtime_failure(e)
+// PURITY: CORE
+// EFFECT: n/a
+// INVARIANT: gpu=none is idempotent and never escalates to gpu=all
+// COMPLEXITY: O(n * m) where n = |details| and m = marker count
+export const gpuModeAfterDockerFailure = (
+  gpu: GpuMode,
+  details: string | undefined
+): GpuMode => gpu === "all" && isNvidiaRuntimeFailure(details) ? "none" : gpu
+/* jscpd:ignore-end */

--- a/packages/app/src/lib/shell/docker-compose.ts
+++ b/packages/app/src/lib/shell/docker-compose.ts
@@ -3,6 +3,7 @@ import type * as CommandExecutor from "@effect/platform/CommandExecutor"
 import type { PlatformError } from "@effect/platform/Error"
 import { Duration, Effect, pipe, Schedule } from "effect"
 
+import { isNvidiaRuntimeFailure } from "../core/gpu.js"
 import { runCommandCapture, runCommandWithStreamingOutput } from "./command-runner.js"
 import { composeSpec, resolveDockerComposeEnv } from "./docker-compose-env.js"
 import { DockerCommandError } from "./errors.js"
@@ -53,17 +54,40 @@ const dockerComposeUpRetrySchedule = Schedule.addDelay(
   () => Duration.seconds(2)
 )
 
+// CHANGE: classify compose-up failures that are worth retrying.
+// WHY: host NVIDIA runtime misconfiguration is deterministic, so repeated compose attempts only delay fallback.
+// QUOTE(ТЗ): "nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1"
+// REF: issue-291
+// SOURCE: n/a
+// FORMAT THEOREM: forall e: nvidia_runtime_failure(e) -> retryable(e)=false
+// PURITY: SHELL
+// EFFECT: n/a
+// INVARIANT: non-Docker platform errors keep the existing retry behavior
+// COMPLEXITY: O(n * m) where n = |details| and m = marker count
+const isRetryableDockerComposeUpError = (error: DockerCommandError | PlatformError): boolean => {
+  if (error._tag !== "DockerCommandError") {
+    return true
+  }
+
+  return !isNvidiaRuntimeFailure(error.details)
+}
+
 const retryDockerComposeUp = (
   cwd: string,
   effect: Effect.Effect<void, DockerCommandError | PlatformError, CommandExecutor.CommandExecutor>
 ): Effect.Effect<void, DockerCommandError | PlatformError, CommandExecutor.CommandExecutor> =>
   effect.pipe(
-    Effect.tapError(() =>
-      Effect.logWarning(
-        `docker compose up failed in ${cwd}; retrying (possible transient Docker Hub/DNS issue)...`
-      )
+    Effect.tapError((error) =>
+      isRetryableDockerComposeUpError(error)
+        ? Effect.logWarning(
+          `docker compose up failed in ${cwd}; retrying (possible transient Docker Hub/DNS issue)...`
+        )
+        : Effect.void
     ),
-    Effect.retry(dockerComposeUpRetrySchedule)
+    Effect.retry({
+      schedule: dockerComposeUpRetrySchedule,
+      while: isRetryableDockerComposeUpError
+    })
   )
 
 export const runDockerComposeUp = (

--- a/packages/app/src/lib/usecases/errors.ts
+++ b/packages/app/src/lib/usecases/errors.ts
@@ -2,6 +2,7 @@
 import type { PlatformError } from "@effect/platform/Error"
 import { Match } from "effect"
 import { type ParseError } from "../core/domain.js"
+import { isNvidiaRuntimeFailure } from "../core/gpu.js"
 import { formatParseError } from "../core/parse-errors.js"
 import type {
   AgentFailedError,
@@ -86,6 +87,11 @@ const renderDockerCommandError = ({ details, exitCode }: DockerCommandError): st
     "Hint: ensure Docker daemon is running and current user can access /var/run/docker.sock (for example via the docker group).",
     "Hint: if output above contains 'port is already allocated', retry with a free SSH port via --ssh-port <port> (for example --ssh-port 2235), or stop the conflicting project/container.",
     "Hint: if output above contains 'all predefined address pools have been fully subnetted', run `docker network prune -f`, configure Docker `default-address-pools`, or use shared network mode (`--network-mode shared`).",
+    ...(isNvidiaRuntimeFailure(details)
+      ? [
+        "Hint: NVIDIA GPU access is enabled but Docker cannot load the host NVIDIA runtime; run with GPU disabled (`--gpu none`) or install the NVIDIA driver and NVIDIA Container Toolkit."
+      ]
+      : []),
     "Hint: if output above contains 'lookup auth.docker.io' or 'read udp ... [::1]:53 ... connection refused', fix Docker DNS resolver (set working DNS in host/daemon config) and retry."
   ].join("\n")
 

--- a/packages/app/src/lib/usecases/projects-up.ts
+++ b/packages/app/src/lib/usecases/projects-up.ts
@@ -6,6 +6,7 @@ import type { Path } from "@effect/platform/Path"
 import { Effect, pipe } from "effect"
 
 import type { ProjectConfig, TemplateConfig } from "../core/domain.js"
+import { gpuModeAfterDockerFailure } from "../core/gpu.js"
 import { readProjectConfig } from "../shell/config.js"
 import {
   runDockerComposePsFormatted,
@@ -30,6 +31,9 @@ import { resolveTemplateResourceLimits } from "./resource-limits.js"
 import { ensureSharedCodexVolumeReady } from "./shared-volume-seed.js"
 
 const maxPortAttempts = 25
+
+type ProjectComposeUpError = DockerCommandError | FileExistsError | PlatformError
+type ProjectComposeUpRequirements = FileSystem | Path | CommandExecutor
 
 const syncManagedProjectFiles = (
   projectDir: string,
@@ -122,6 +126,41 @@ const ensureClaudeCliReady = (
     })
   )
 
+// CHANGE: recover from host NVIDIA runtime failures by disabling per-project GPU access.
+// WHY: Docker rejects gpus: all before the container starts when the host NVIDIA runtime is unavailable.
+// QUOTE(ТЗ): "nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1"
+// REF: issue-291
+// SOURCE: n/a
+// FORMAT THEOREM: forall t,e: gpu(t)=all and nvidia_runtime_failure(e) -> gpu(retry(t,e))=none
+// PURITY: SHELL
+// EFFECT: Effect<TemplateConfig, DockerCommandError | FileExistsError | PlatformError, FileSystem | Path | CommandExecutor>
+// INVARIANT: fallback never escalates GPU access and rewrites managed files before retry
+// COMPLEXITY: O(1) compose attempts plus O(file-size) template rewrite
+const runProjectComposeUp = (
+  projectDir: string,
+  template: TemplateConfig
+): Effect.Effect<TemplateConfig, ProjectComposeUpError, ProjectComposeUpRequirements> =>
+  runDockerComposeUp(projectDir).pipe(
+    Effect.as(template),
+    Effect.catchTag("DockerCommandError", (error) => {
+      const fallbackGpu = gpuModeAfterDockerFailure(template.gpu, error.details)
+      if (fallbackGpu === template.gpu) {
+        return Effect.fail(error)
+      }
+
+      const fallbackTemplate: TemplateConfig = { ...template, gpu: fallbackGpu }
+      return Effect.gen(function*(_) {
+        yield* _(
+          Effect.logWarning(
+            "NVIDIA runtime failed while GPU access was enabled; rewriting project with GPU access disabled and retrying docker compose up."
+          )
+        )
+        yield* _(syncManagedProjectFiles(projectDir, fallbackTemplate))
+        return yield* _(runProjectComposeUp(projectDir, fallbackTemplate))
+      })
+    })
+  )
+
 // CHANGE: update template port when the preferred SSH port is reserved or busy
 // WHY: keep each project on a unique port even across restarts
 // QUOTE(ТЗ): "Почему контейнер пытается подниматься на существующий порт?"
@@ -194,8 +233,8 @@ export const runDockerComposeUpWithPortCheck = (
     yield* _(syncManagedProjectFiles(projectDir, resolvedTemplate))
     yield* _(ensureComposeNetworkReady(projectDir, resolvedTemplate))
     yield* _(ensureSharedCodexVolumeReady(projectDir, resolvedTemplate))
-    yield* _(runDockerComposeUp(projectDir))
-    yield* _(ensureClaudeCliReady(projectDir, resolvedTemplate.containerName))
+    const startedTemplate = yield* _(runProjectComposeUp(projectDir, resolvedTemplate))
+    yield* _(ensureClaudeCliReady(projectDir, startedTemplate.containerName))
 
     const ensureBridgeAccess = (containerName: string) =>
       runDockerInspectContainerBridgeIp(projectDir, containerName).pipe(
@@ -215,11 +254,11 @@ export const runDockerComposeUpWithPortCheck = (
         })
       )
 
-    yield* _(ensureBridgeAccess(resolvedTemplate.containerName))
-    if (resolvedTemplate.enableMcpPlaywright) {
-      yield* _(ensureBridgeAccess(`${resolvedTemplate.containerName}-browser`))
+    yield* _(ensureBridgeAccess(startedTemplate.containerName))
+    if (startedTemplate.enableMcpPlaywright) {
+      yield* _(ensureBridgeAccess(`${startedTemplate.containerName}-browser`))
     }
 
-    return resolvedTemplate
+    return startedTemplate
   })
 /* jscpd:ignore-end */

--- a/packages/app/src/lib/usecases/projects-up.ts
+++ b/packages/app/src/lib/usecases/projects-up.ts
@@ -134,7 +134,7 @@ const ensureClaudeCliReady = (
 // FORMAT THEOREM: forall t,e: gpu(t)=all and nvidia_runtime_failure(e) -> gpu(retry(t,e))=none
 // PURITY: SHELL
 // EFFECT: Effect<TemplateConfig, DockerCommandError | FileExistsError | PlatformError, FileSystem | Path | CommandExecutor>
-// INVARIANT: fallback never escalates GPU access and rewrites managed files before retry
+// INVARIANT: fallback never escalates GPU access and terminates after at most one all -> none downgrade
 // COMPLEXITY: O(1) compose attempts plus O(file-size) template rewrite
 const runProjectComposeUp = (
   projectDir: string,
@@ -145,6 +145,7 @@ const runProjectComposeUp = (
     Effect.catchTag("DockerCommandError", (error) => {
       const fallbackGpu = gpuModeAfterDockerFailure(template.gpu, error.details)
       if (fallbackGpu === template.gpu) {
+        // Idempotence witness: non-NVIDIA errors and gpu=none cannot produce a lower GPU mode.
         return Effect.fail(error)
       }
 
@@ -152,7 +153,9 @@ const runProjectComposeUp = (
       return Effect.gen(function*(_) {
         yield* _(
           Effect.logWarning(
-            "NVIDIA runtime failed while GPU access was enabled; rewriting project with GPU access disabled and retrying docker compose up."
+            `NVIDIA runtime failed while GPU access was enabled (${
+              error.details ?? "no docker output"
+            }); rewriting project with GPU access disabled and retrying docker compose up.`
           )
         )
         yield* _(syncManagedProjectFiles(projectDir, fallbackTemplate))

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -74,6 +74,7 @@
     "eslint-plugin-sonarjs": "^4.0.3",
     "eslint-plugin-sort-destructure-keys": "^3.0.0",
     "eslint-plugin-unicorn": "^64.0.0",
+    "fast-check": "^3.23.2",
     "@vitest/eslint-plugin": "^1.6.17",
     "globals": "^17.6.0",
     "jscpd": "^4.1.1",

--- a/packages/lib/src/core/gpu.ts
+++ b/packages/lib/src/core/gpu.ts
@@ -1,0 +1,37 @@
+import type { GpuMode } from "./domain.js"
+
+const nvidiaFailureMarkers = [
+  "nvidia-container-cli",
+  "libnvidia-ml.so.1",
+  "could not select device driver"
+]
+
+// CHANGE: classify Docker/NVIDIA runtime failures from compose output.
+// WHY: GPU device requests fail before the container entrypoint can run, so recovery must happen outside Docker.
+// QUOTE(ТЗ): "nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1"
+// REF: issue-291
+// SOURCE: n/a
+// FORMAT THEOREM: forall s: contains_nvidia_runtime_marker(s) -> nvidia_runtime_failure(s)
+// PURITY: CORE
+// EFFECT: n/a
+// INVARIANT: detection is monotonic over output text; adding unrelated text cannot flip true to false
+// COMPLEXITY: O(n * m) where n = |details| and m = marker count
+export const isNvidiaRuntimeFailure = (details: string | undefined): boolean => {
+  const normalized = details?.toLowerCase() ?? ""
+  return nvidiaFailureMarkers.some((marker) => normalized.includes(marker))
+}
+
+// CHANGE: derive the safe GPU fallback mode after a Docker runtime failure.
+// WHY: non-GPU containers must remain startable on hosts without a working NVIDIA userspace stack.
+// QUOTE(ТЗ): "load library failed: libnvidia-ml.so.1"
+// REF: issue-291
+// SOURCE: n/a
+// FORMAT THEOREM: forall g,e: fallback(g,e) = none iff g = all and nvidia_runtime_failure(e)
+// PURITY: CORE
+// EFFECT: n/a
+// INVARIANT: gpu=none is idempotent and never escalates to gpu=all
+// COMPLEXITY: O(n * m) where n = |details| and m = marker count
+export const gpuModeAfterDockerFailure = (
+  gpu: GpuMode,
+  details: string | undefined
+): GpuMode => gpu === "all" && isNvidiaRuntimeFailure(details) ? "none" : gpu

--- a/packages/lib/src/shell/docker-compose.ts
+++ b/packages/lib/src/shell/docker-compose.ts
@@ -3,6 +3,7 @@ import type * as CommandExecutor from "@effect/platform/CommandExecutor"
 import type { PlatformError } from "@effect/platform/Error"
 import { Duration, Effect, pipe, Schedule } from "effect"
 
+import { isNvidiaRuntimeFailure } from "../core/gpu.js"
 import { runCommandCapture, runCommandWithStreamingOutput } from "./command-runner.js"
 import { composeSpec, resolveDockerComposeEnv } from "./docker-compose-env.js"
 import { DockerCommandError } from "./errors.js"
@@ -53,17 +54,40 @@ const dockerComposeUpRetrySchedule = Schedule.addDelay(
   () => Duration.seconds(2)
 )
 
+// CHANGE: classify compose-up failures that are worth retrying.
+// WHY: host NVIDIA runtime misconfiguration is deterministic, so repeated compose attempts only delay fallback.
+// QUOTE(ТЗ): "nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1"
+// REF: issue-291
+// SOURCE: n/a
+// FORMAT THEOREM: forall e: nvidia_runtime_failure(e) -> retryable(e)=false
+// PURITY: SHELL
+// EFFECT: n/a
+// INVARIANT: non-Docker platform errors keep the existing retry behavior
+// COMPLEXITY: O(n * m) where n = |details| and m = marker count
+const isRetryableDockerComposeUpError = (error: DockerCommandError | PlatformError): boolean => {
+  if (error._tag !== "DockerCommandError") {
+    return true
+  }
+
+  return !isNvidiaRuntimeFailure(error.details)
+}
+
 const retryDockerComposeUp = (
   cwd: string,
   effect: Effect.Effect<void, DockerCommandError | PlatformError, CommandExecutor.CommandExecutor>
 ): Effect.Effect<void, DockerCommandError | PlatformError, CommandExecutor.CommandExecutor> =>
   effect.pipe(
-    Effect.tapError(() =>
-      Effect.logWarning(
-        `docker compose up failed in ${cwd}; retrying (possible transient Docker Hub/DNS issue)...`
-      )
+    Effect.tapError((error) =>
+      isRetryableDockerComposeUpError(error)
+        ? Effect.logWarning(
+          `docker compose up failed in ${cwd}; retrying (possible transient Docker Hub/DNS issue)...`
+        )
+        : Effect.void
     ),
-    Effect.retry(dockerComposeUpRetrySchedule)
+    Effect.retry({
+      schedule: dockerComposeUpRetrySchedule,
+      while: isRetryableDockerComposeUpError
+    })
   )
 
 export type DockerComposeUpBuildMode = "build" | "reuse"

--- a/packages/lib/src/usecases/errors.ts
+++ b/packages/lib/src/usecases/errors.ts
@@ -1,6 +1,7 @@
 import type { PlatformError } from "@effect/platform/Error"
 import { Match } from "effect"
 import { type ParseError } from "../core/domain.js"
+import { isNvidiaRuntimeFailure } from "../core/gpu.js"
 import { formatParseError } from "../core/parse-errors.js"
 import type {
   AgentFailedError,
@@ -85,6 +86,11 @@ const renderDockerCommandError = ({ details, exitCode }: DockerCommandError): st
     "Hint: ensure Docker daemon is running and current user can access /var/run/docker.sock (for example via the docker group).",
     "Hint: if output above contains 'port is already allocated', retry with a free SSH port via --ssh-port <port> (for example --ssh-port 2235), or stop the conflicting project/container.",
     "Hint: if output above contains 'all predefined address pools have been fully subnetted', run `docker network prune -f`, configure Docker `default-address-pools`, or use shared network mode (`--network-mode shared`).",
+    ...(isNvidiaRuntimeFailure(details)
+      ? [
+        "Hint: NVIDIA GPU access is enabled but Docker cannot load the host NVIDIA runtime; run with GPU disabled (`--gpu none`) or install the NVIDIA driver and NVIDIA Container Toolkit."
+      ]
+      : []),
     "Hint: if output above contains 'lookup auth.docker.io' or 'read udp ... [::1]:53 ... connection refused', fix Docker DNS resolver (set working DNS in host/daemon config) and retry."
   ].join("\n")
 

--- a/packages/lib/src/usecases/projects-up.ts
+++ b/packages/lib/src/usecases/projects-up.ts
@@ -181,7 +181,7 @@ const startProjectPostStartSelfHealInBackground = (
 // FORMAT THEOREM: forall t,e: gpu(t)=all and nvidia_runtime_failure(e) -> gpu(retry(t,e))=none
 // PURITY: SHELL
 // EFFECT: Effect<TemplateConfig, DockerCommandError | FileExistsError | PlatformError, FileSystem | Path | CommandExecutor>
-// INVARIANT: fallback never escalates GPU access and rewrites managed files before retry
+// INVARIANT: fallback never escalates GPU access and terminates after at most one all -> none downgrade
 // COMPLEXITY: O(1) compose attempts plus O(file-size) template rewrite
 const recoverProjectComposeGpuFailure = (
   projectDir: string,
@@ -194,6 +194,7 @@ const recoverProjectComposeGpuFailure = (
     Effect.catchTag("DockerCommandError", (error) => {
       const fallbackGpu = gpuModeAfterDockerFailure(template.gpu, error.details)
       if (fallbackGpu === template.gpu) {
+        // Idempotence witness: non-NVIDIA errors and gpu=none cannot produce a lower GPU mode.
         return Effect.fail(error)
       }
 
@@ -201,7 +202,9 @@ const recoverProjectComposeGpuFailure = (
       return Effect.gen(function*(_) {
         yield* _(
           Effect.logWarning(
-            "NVIDIA runtime failed while GPU access was enabled; rewriting project with GPU access disabled and retrying docker compose up."
+            `NVIDIA runtime failed while GPU access was enabled (${
+              error.details ?? "no docker output"
+            }); rewriting project with GPU access disabled and retrying docker compose up.`
           )
         )
         yield* _(syncManagedProjectFiles(projectDir, fallbackTemplate))

--- a/packages/lib/src/usecases/projects-up.ts
+++ b/packages/lib/src/usecases/projects-up.ts
@@ -5,6 +5,7 @@ import type { Path } from "@effect/platform/Path"
 import { Effect, pipe } from "effect"
 
 import type { ProjectConfig, TemplateConfig } from "../core/domain.js"
+import { gpuModeAfterDockerFailure } from "../core/gpu.js"
 import { readProjectConfig } from "../shell/config.js"
 import {
   runDockerComposePsFormatted,
@@ -34,6 +35,10 @@ export type RunDockerComposeUpWithPortCheckOptions = {
   readonly buildMode?: "build" | "reuse"
   readonly waitForPostStart?: boolean
 }
+
+type ProjectComposeUpAttemptError = DockerCommandError | PlatformError
+type ProjectComposeUpError = DockerCommandError | FileExistsError | PlatformError
+type ProjectComposeUpRequirements = FileSystem | Path | CommandExecutor
 
 const syncManagedProjectFiles = (
   projectDir: string,
@@ -168,22 +173,65 @@ const startProjectPostStartSelfHealInBackground = (
     yield* _(Effect.forkDaemon(runProjectPostStartSelfHeal(projectDir, template)))
   })
 
+// CHANGE: recover from host NVIDIA runtime failures by disabling per-project GPU access.
+// WHY: Docker rejects gpus: all before the container starts when the host NVIDIA runtime is unavailable.
+// QUOTE(ТЗ): "nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1"
+// REF: issue-291
+// SOURCE: n/a
+// FORMAT THEOREM: forall t,e: gpu(t)=all and nvidia_runtime_failure(e) -> gpu(retry(t,e))=none
+// PURITY: SHELL
+// EFFECT: Effect<TemplateConfig, DockerCommandError | FileExistsError | PlatformError, FileSystem | Path | CommandExecutor>
+// INVARIANT: fallback never escalates GPU access and rewrites managed files before retry
+// COMPLEXITY: O(1) compose attempts plus O(file-size) template rewrite
+const recoverProjectComposeGpuFailure = (
+  projectDir: string,
+  template: TemplateConfig,
+  effect: Effect.Effect<void, ProjectComposeUpAttemptError, CommandExecutor>,
+  buildMode: "build" | "reuse"
+): Effect.Effect<TemplateConfig, ProjectComposeUpError, ProjectComposeUpRequirements> =>
+  effect.pipe(
+    Effect.as(template),
+    Effect.catchTag("DockerCommandError", (error) => {
+      const fallbackGpu = gpuModeAfterDockerFailure(template.gpu, error.details)
+      if (fallbackGpu === template.gpu) {
+        return Effect.fail(error)
+      }
+
+      const fallbackTemplate: TemplateConfig = { ...template, gpu: fallbackGpu }
+      return Effect.gen(function*(_) {
+        yield* _(
+          Effect.logWarning(
+            "NVIDIA runtime failed while GPU access was enabled; rewriting project with GPU access disabled and retrying docker compose up."
+          )
+        )
+        yield* _(syncManagedProjectFiles(projectDir, fallbackTemplate))
+        return yield* _(runProjectComposeUp(projectDir, fallbackTemplate, buildMode))
+      })
+    })
+  )
+
 const runProjectComposeUp = (
   projectDir: string,
+  template: TemplateConfig,
   buildMode: "build" | "reuse"
-): Effect.Effect<void, DockerCommandError | PlatformError, CommandExecutor> => {
-  if (buildMode === "build") {
-    return runDockerComposeUp(projectDir)
-  }
+): Effect.Effect<TemplateConfig, ProjectComposeUpError, ProjectComposeUpRequirements> => {
+  const composeUp = buildMode === "build"
+    ? runDockerComposeUp(projectDir)
+    : runDockerComposeUp(projectDir, { buildMode: "reuse" }).pipe(
+      Effect.catchTag("DockerCommandError", (error) => {
+        if (gpuModeAfterDockerFailure(template.gpu, error.details) !== template.gpu) {
+          return Effect.fail(error)
+        }
 
-  return runDockerComposeUp(projectDir, { buildMode: "reuse" }).pipe(
-    Effect.catchTag("DockerCommandError", () =>
-      Effect.logWarning(
-        `docker compose up -d failed in ${projectDir}; falling back to docker compose up -d --build.`
-      ).pipe(
-        Effect.zipRight(runDockerComposeUp(projectDir))
-      ))
-  )
+        return Effect.logWarning(
+          `docker compose up -d failed in ${projectDir}; falling back to docker compose up -d --build.`
+        ).pipe(
+          Effect.zipRight(runDockerComposeUp(projectDir))
+        )
+      })
+    )
+
+  return recoverProjectComposeGpuFailure(projectDir, template, composeUp, buildMode)
 }
 
 // CHANGE: update template port when the preferred SSH port is reserved or busy
@@ -259,10 +307,10 @@ export const runDockerComposeUpWithPortCheck = (
     yield* _(syncManagedProjectFiles(projectDir, resolvedTemplate))
     yield* _(ensureComposeNetworkReady(projectDir, resolvedTemplate))
     yield* _(ensureSharedCodexVolumeReady(projectDir, resolvedTemplate))
-    yield* _(runProjectComposeUp(projectDir, options.buildMode ?? "build"))
+    const startedTemplate = yield* _(runProjectComposeUp(projectDir, resolvedTemplate, options.buildMode ?? "build"))
     yield* (options.waitForPostStart === false
-      ? _(startProjectPostStartSelfHealInBackground(projectDir, resolvedTemplate))
-      : _(runProjectPostStartSelfHeal(projectDir, resolvedTemplate)))
+      ? _(startProjectPostStartSelfHealInBackground(projectDir, startedTemplate))
+      : _(runProjectPostStartSelfHeal(projectDir, startedTemplate)))
 
-    return resolvedTemplate
+    return startedTemplate
   })

--- a/packages/lib/tests/usecases/errors.test.ts
+++ b/packages/lib/tests/usecases/errors.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "@effect/vitest"
+import fc from "fast-check"
 
 import {
   DockerAccessError,
@@ -39,6 +40,51 @@ describe("renderError", () => {
     expect(message).toContain("NVIDIA GPU access is enabled")
     expect(message).toContain("--gpu none")
     expect(message).toContain("NVIDIA Container Toolkit")
+  })
+
+  it("shows NVIDIA hint iff docker output contains NVIDIA runtime markers", () => {
+    const nvidiaContainerCliMarker = "nvidia-container-cli"
+    const libNvidiaMlMarker = "libnvidia-ml.so.1"
+    const missingDeviceDriverMarker = "could not select device driver"
+    const markers: ReadonlyArray<string> = [
+      nvidiaContainerCliMarker,
+      libNvidiaMlMarker,
+      missingDeviceDriverMarker
+    ]
+    const includesMarker = (details: string): boolean => markers.some((marker) => details.includes(marker))
+
+    fc.assert(
+      fc.property(
+        fc.string(),
+        fc.constantFrom(nvidiaContainerCliMarker, libNvidiaMlMarker, missingDeviceDriverMarker),
+        fc.string(),
+        (left, marker, right) => {
+          const message = renderError(
+            new DockerCommandError({
+              exitCode: 1,
+              details: `${left}${marker}${right}`
+            })
+          )
+
+          expect(message).toContain("--gpu none")
+        }
+      ),
+      { numRuns: 50 }
+    )
+
+    fc.assert(
+      fc.property(fc.string().filter((details) => !includesMarker(details)), (details) => {
+        const message = renderError(
+          new DockerCommandError({
+            exitCode: 1,
+            details
+          })
+        )
+
+        expect(message).not.toContain("--gpu none")
+      }),
+      { numRuns: 50 }
+    )
   })
 
   it("renders actionable recovery for DockerAccessError", () => {

--- a/packages/lib/tests/usecases/errors.test.ts
+++ b/packages/lib/tests/usecases/errors.test.ts
@@ -27,6 +27,20 @@ describe("renderError", () => {
     expect(message).toContain("auth.docker.io")
   })
 
+  it("includes NVIDIA runtime recovery hint for DockerCommandError", () => {
+    const message = renderError(
+      new DockerCommandError({
+        exitCode: 1,
+        details:
+          "nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1: cannot open shared object file"
+      })
+    )
+
+    expect(message).toContain("NVIDIA GPU access is enabled")
+    expect(message).toContain("--gpu none")
+    expect(message).toContain("NVIDIA Container Toolkit")
+  })
+
   it("renders actionable recovery for DockerAccessError", () => {
     const message = renderError(
       new DockerAccessError({

--- a/packages/lib/tests/usecases/projects-up.test.ts
+++ b/packages/lib/tests/usecases/projects-up.test.ts
@@ -4,8 +4,9 @@ import * as FileSystem from "@effect/platform/FileSystem"
 import * as Path from "@effect/platform/Path"
 import { NodeContext } from "@effect/platform-node"
 import { describe, expect, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Logger } from "effect"
 import * as Inspectable from "effect/Inspectable"
+import * as Option from "effect/Option"
 import * as Sink from "effect/Sink"
 import * as Stream from "effect/Stream"
 
@@ -112,7 +113,7 @@ const makeFakeExecutor = (
         recorded.push({
           command: entry.command,
           args: entry.args,
-          cwd: entry.cwd._tag === "Some" ? entry.cwd.value : undefined
+          cwd: Option.getOrUndefined(entry.cwd)
         })
       }
 
@@ -120,7 +121,7 @@ const makeFakeExecutor = (
       const invocation: RecordedCommand = {
         command: last.command,
         args: last.args,
-        cwd: last.cwd._tag === "Some" ? last.cwd.value : undefined
+        cwd: Option.getOrUndefined(last.cwd)
       }
       const stdoutText = decideStdout(invocation)
       const stdout = stdoutText.length === 0 ? Stream.empty : Stream.succeed(encode(stdoutText))
@@ -263,7 +264,11 @@ describe("runDockerComposeUpWithPortCheck", () => {
           gpu: "all"
         }
         const recorded: Array<RecordedCommand> = []
+        const logs: Array<string> = []
         const executor = makeFakeExecutor(recorded, { failGpuComposeUp: true })
+        const logger = Logger.make(({ message }) => {
+          logs.push(String(message))
+        })
 
         yield* _(
           prepareProjectFiles(outDir, root, globalConfig, projectConfig, {
@@ -274,7 +279,8 @@ describe("runDockerComposeUpWithPortCheck", () => {
 
         const started = yield* _(
           runDockerComposeUpWithPortCheck(outDir).pipe(
-            Effect.provideService(CommandExecutor.CommandExecutor, executor)
+            Effect.provideService(CommandExecutor.CommandExecutor, executor),
+            Effect.provide(Logger.replace(Logger.defaultLogger, logger))
           )
         )
 
@@ -285,7 +291,12 @@ describe("runDockerComposeUpWithPortCheck", () => {
 
         const configAfter = yield* _(fs.readFileString(path.join(outDir, "docker-git.json")))
         expect(configAfter).toContain('"gpu": "none"')
-        expect(recorded.filter((entry) => isDockerComposeUpWithBuild(entry)).length).toBeGreaterThan(1)
+        expect(recorded.filter((entry) => isDockerComposeUpWithBuild(entry)).length).toBe(2)
+        expect(logs.some((entry) =>
+          entry.includes("NVIDIA runtime failed") &&
+          entry.includes("libnvidia-ml.so.1") &&
+          entry.includes("GPU access disabled")
+        )).toBe(true)
       })
     ).pipe(Effect.provide(NodeContext.layer)))
 

--- a/packages/lib/tests/usecases/projects-up.test.ts
+++ b/packages/lib/tests/usecases/projects-up.test.ts
@@ -93,10 +93,13 @@ const decideStdout = (cmd: RecordedCommand): string => {
 const nvidiaRuntimeFailure =
   "Error response from daemon: failed to create task for container: nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1"
 
-const hasNvidiaFallbackWarning = (logs: ReadonlyArray<string>): boolean =>
+const nvidiaMissingDeviceDriverFailure =
+  'Error response from daemon: could not select device driver "" with capabilities: [[gpu]]'
+
+const hasNvidiaFallbackWarning = (logs: ReadonlyArray<string>, expectedDetail: string): boolean =>
   logs.some((entry) =>
     entry.includes("NVIDIA runtime failed") &&
-    entry.includes("libnvidia-ml.so.1") &&
+    entry.includes(expectedDetail) &&
     entry.includes("GPU access disabled")
   )
 
@@ -105,6 +108,7 @@ const shouldFailNvidiaGpuComposeUp = (cmd: RecordedCommand): boolean =>
 
 type FakeExecutorOptions = {
   readonly failGpuComposeUp?: boolean
+  readonly gpuFailureStderr?: string
 }
 
 const makeFakeExecutor = (
@@ -112,6 +116,7 @@ const makeFakeExecutor = (
   options: FakeExecutorOptions = {}
 ): CommandExecutor.CommandExecutor => {
   let shouldFailGpuComposeUp = options.failGpuComposeUp === true
+  const gpuFailureStderr = options.gpuFailureStderr ?? nvidiaRuntimeFailure
 
   const start = (command: Command.Command): Effect.Effect<CommandExecutor.Process, never> =>
     Effect.gen(function*(_) {
@@ -134,7 +139,7 @@ const makeFakeExecutor = (
       const stdout = stdoutText.length === 0 ? Stream.empty : Stream.succeed(encode(stdoutText))
       const failed = shouldFailGpuComposeUp && shouldFailNvidiaGpuComposeUp(invocation)
       shouldFailGpuComposeUp = shouldFailGpuComposeUp && !failed
-      const stderr = failed ? Stream.succeed(encode(nvidiaRuntimeFailure)) : Stream.empty
+      const stderr = failed ? Stream.succeed(encode(gpuFailureStderr)) : Stream.empty
 
       const process: CommandExecutor.Process = {
         [CommandExecutor.ProcessTypeId]: CommandExecutor.ProcessTypeId,
@@ -294,12 +299,60 @@ describe("runDockerComposeUpWithPortCheck", () => {
         expect(started.gpu).toBe("none")
 
         const composeAfter = yield* _(fs.readFileString(path.join(outDir, "docker-compose.yml")))
-        expect(composeAfter).not.toContain("    gpus: all\n")
+        expect(composeAfter).not.toMatch(/\bgpus:\s*all\b/)
 
         const configAfter = yield* _(fs.readFileString(path.join(outDir, "docker-git.json")))
         expect(configAfter).toContain('"gpu": "none"')
         expect(recorded.filter((entry) => isDockerComposeUpWithBuild(entry)).length).toBe(2)
-        expect(hasNvidiaFallbackWarning(logs)).toBe(true)
+        expect(hasNvidiaFallbackWarning(logs, "libnvidia-ml.so.1")).toBe(true)
+      })
+    ).pipe(Effect.provide(NodeContext.layer)))
+
+  it.effect("falls back to GPU none on missing-device-driver NVIDIA runtime failure", () =>
+    withTempDir((root) =>
+      Effect.gen(function*(_) {
+        const fs = yield* _(FileSystem.FileSystem)
+        const path = yield* _(Path.Path)
+        const outDir = path.join(root, "project")
+        const targetDir = "/home/dev/workspaces/org/repo"
+        const globalConfig = makeTemplateConfig(root, outDir, path, targetDir)
+        const projectConfig: TemplateConfig = {
+          ...makeTemplateConfig(root, outDir, path, targetDir),
+          gpu: "all"
+        }
+        const recorded: Array<RecordedCommand> = []
+        const logs: Array<string> = []
+        const executor = makeFakeExecutor(recorded, {
+          failGpuComposeUp: true,
+          gpuFailureStderr: nvidiaMissingDeviceDriverFailure
+        })
+        const logger = Logger.make(({ message }) => {
+          logs.push(String(message))
+        })
+
+        yield* _(
+          prepareProjectFiles(outDir, root, globalConfig, projectConfig, {
+            force: false,
+            forceEnv: false
+          })
+        )
+
+        const started = yield* _(
+          runDockerComposeUpWithPortCheck(outDir).pipe(
+            Effect.provideService(CommandExecutor.CommandExecutor, executor),
+            Effect.provide(Logger.replace(Logger.defaultLogger, logger))
+          )
+        )
+
+        expect(started.gpu).toBe("none")
+
+        const composeAfter = yield* _(fs.readFileString(path.join(outDir, "docker-compose.yml")))
+        expect(composeAfter).not.toMatch(/\bgpus:\s*all\b/)
+
+        const configAfter = yield* _(fs.readFileString(path.join(outDir, "docker-git.json")))
+        expect(configAfter).toContain('"gpu": "none"')
+        expect(recorded.filter((entry) => isDockerComposeUpWithBuild(entry)).length).toBe(2)
+        expect(hasNvidiaFallbackWarning(logs, "could not select device driver")).toBe(true)
       })
     ).pipe(Effect.provide(NodeContext.layer)))
 
@@ -342,13 +395,13 @@ describe("runDockerComposeUpWithPortCheck", () => {
         expect(started.gpu).toBe("none")
 
         const composeAfter = yield* _(fs.readFileString(path.join(outDir, "docker-compose.yml")))
-        expect(composeAfter).not.toContain("    gpus: all\n")
+        expect(composeAfter).not.toMatch(/\bgpus:\s*all\b/)
 
         const configAfter = yield* _(fs.readFileString(path.join(outDir, "docker-git.json")))
         expect(configAfter).toContain('"gpu": "none"')
         expect(recorded.filter((entry) => isDockerComposeUpReuse(entry)).length).toBe(2)
         expect(recorded.filter((entry) => isDockerComposeUpWithBuild(entry)).length).toBe(0)
-        expect(hasNvidiaFallbackWarning(logs)).toBe(true)
+        expect(hasNvidiaFallbackWarning(logs, "libnvidia-ml.so.1")).toBe(true)
       })
     ).pipe(Effect.provide(NodeContext.layer)))
 

--- a/packages/lib/tests/usecases/projects-up.test.ts
+++ b/packages/lib/tests/usecases/projects-up.test.ts
@@ -104,6 +104,8 @@ const nvidiaMissingDeviceDriverFailure =
 const arbitraryComposeFailure =
   "Error response from daemon: network sandbox setup failed"
 
+const gpuAllComposeYamlPattern = /(^|\s)gpus:\s*["']?all["']?(\s|$)/m
+
 const nvidiaFailureMarkers: ReadonlyArray<string> = [
   nvidiaContainerCliMarker,
   libNvidiaMlMarker,
@@ -318,7 +320,7 @@ describe("runDockerComposeUpWithPortCheck", () => {
         expect(started.gpu).toBe("none")
 
         const composeAfter = yield* _(fs.readFileString(path.join(outDir, "docker-compose.yml")))
-        expect(composeAfter).not.toMatch(/\bgpus:\s*all\b/)
+        expect(composeAfter).not.toMatch(gpuAllComposeYamlPattern)
 
         const configAfter = yield* _(fs.readFileString(path.join(outDir, "docker-git.json")))
         expect(configAfter).toContain('"gpu": "none"')
@@ -366,7 +368,7 @@ describe("runDockerComposeUpWithPortCheck", () => {
         expect(started.gpu).toBe("none")
 
         const composeAfter = yield* _(fs.readFileString(path.join(outDir, "docker-compose.yml")))
-        expect(composeAfter).not.toMatch(/\bgpus:\s*all\b/)
+        expect(composeAfter).not.toMatch(gpuAllComposeYamlPattern)
 
         const configAfter = yield* _(fs.readFileString(path.join(outDir, "docker-git.json")))
         expect(configAfter).toContain('"gpu": "none"')
@@ -442,7 +444,7 @@ describe("runDockerComposeUpWithPortCheck", () => {
         expect(started.gpu).toBe("none")
 
         const composeAfter = yield* _(fs.readFileString(path.join(outDir, "docker-compose.yml")))
-        expect(composeAfter).not.toMatch(/\bgpus:\s*all\b/)
+        expect(composeAfter).not.toMatch(gpuAllComposeYamlPattern)
 
         const configAfter = yield* _(fs.readFileString(path.join(outDir, "docker-git.json")))
         expect(configAfter).toContain('"gpu": "none"')

--- a/packages/lib/tests/usecases/projects-up.test.ts
+++ b/packages/lib/tests/usecases/projects-up.test.ts
@@ -93,6 +93,13 @@ const decideStdout = (cmd: RecordedCommand): string => {
 const nvidiaRuntimeFailure =
   "Error response from daemon: failed to create task for container: nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1"
 
+const hasNvidiaFallbackWarning = (logs: ReadonlyArray<string>): boolean =>
+  logs.some((entry) =>
+    entry.includes("NVIDIA runtime failed") &&
+    entry.includes("libnvidia-ml.so.1") &&
+    entry.includes("GPU access disabled")
+  )
+
 const shouldFailNvidiaGpuComposeUp = (cmd: RecordedCommand): boolean =>
   isDockerComposeUpWithBuild(cmd) || isDockerComposeUpReuse(cmd)
 
@@ -292,11 +299,56 @@ describe("runDockerComposeUpWithPortCheck", () => {
         const configAfter = yield* _(fs.readFileString(path.join(outDir, "docker-git.json")))
         expect(configAfter).toContain('"gpu": "none"')
         expect(recorded.filter((entry) => isDockerComposeUpWithBuild(entry)).length).toBe(2)
-        expect(logs.some((entry) =>
-          entry.includes("NVIDIA runtime failed") &&
-          entry.includes("libnvidia-ml.so.1") &&
-          entry.includes("GPU access disabled")
-        )).toBe(true)
+        expect(hasNvidiaFallbackWarning(logs)).toBe(true)
+      })
+    ).pipe(Effect.provide(NodeContext.layer)))
+
+  it.effect("falls back to GPU none before retrying reuse mode when the host NVIDIA runtime is unavailable", () =>
+    withTempDir((root) =>
+      Effect.gen(function*(_) {
+        const fs = yield* _(FileSystem.FileSystem)
+        const path = yield* _(Path.Path)
+        const outDir = path.join(root, "project")
+        const targetDir = "/home/dev/workspaces/org/repo"
+        const globalConfig = makeTemplateConfig(root, outDir, path, targetDir)
+        const projectConfig: TemplateConfig = {
+          ...makeTemplateConfig(root, outDir, path, targetDir),
+          gpu: "all"
+        }
+        const recorded: Array<RecordedCommand> = []
+        const logs: Array<string> = []
+        const executor = makeFakeExecutor(recorded, { failGpuComposeUp: true })
+        const logger = Logger.make(({ message }) => {
+          logs.push(String(message))
+        })
+
+        yield* _(
+          prepareProjectFiles(outDir, root, globalConfig, projectConfig, {
+            force: false,
+            forceEnv: false
+          })
+        )
+
+        const started = yield* _(
+          runDockerComposeUpWithPortCheck(outDir, {
+            buildMode: "reuse",
+            waitForPostStart: false
+          }).pipe(
+            Effect.provideService(CommandExecutor.CommandExecutor, executor),
+            Effect.provide(Logger.replace(Logger.defaultLogger, logger))
+          )
+        )
+
+        expect(started.gpu).toBe("none")
+
+        const composeAfter = yield* _(fs.readFileString(path.join(outDir, "docker-compose.yml")))
+        expect(composeAfter).not.toContain("    gpus: all\n")
+
+        const configAfter = yield* _(fs.readFileString(path.join(outDir, "docker-git.json")))
+        expect(configAfter).toContain('"gpu": "none"')
+        expect(recorded.filter((entry) => isDockerComposeUpReuse(entry)).length).toBe(2)
+        expect(recorded.filter((entry) => isDockerComposeUpWithBuild(entry)).length).toBe(0)
+        expect(hasNvidiaFallbackWarning(logs)).toBe(true)
       })
     ).pipe(Effect.provide(NodeContext.layer)))
 

--- a/packages/lib/tests/usecases/projects-up.test.ts
+++ b/packages/lib/tests/usecases/projects-up.test.ts
@@ -16,6 +16,7 @@ import { runDockerComposeUpWithPortCheck } from "../../src/usecases/projects-up.
 type RecordedCommand = {
   readonly command: string
   readonly args: ReadonlyArray<string>
+  readonly cwd?: string | undefined
 }
 
 const encode = (value: string): Uint8Array => new TextEncoder().encode(value)
@@ -88,26 +89,52 @@ const decideStdout = (cmd: RecordedCommand): string => {
   return ""
 }
 
-const makeFakeExecutor = (recorded: Array<RecordedCommand>): CommandExecutor.CommandExecutor => {
+const nvidiaRuntimeFailure =
+  "Error response from daemon: failed to create task for container: nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1"
+
+const shouldFailNvidiaGpuComposeUp = (cmd: RecordedCommand): boolean =>
+  isDockerComposeUpWithBuild(cmd) || isDockerComposeUpReuse(cmd)
+
+type FakeExecutorOptions = {
+  readonly failGpuComposeUp?: boolean
+}
+
+const makeFakeExecutor = (
+  recorded: Array<RecordedCommand>,
+  options: FakeExecutorOptions = {}
+): CommandExecutor.CommandExecutor => {
+  let shouldFailGpuComposeUp = options.failGpuComposeUp === true
+
   const start = (command: Command.Command): Effect.Effect<CommandExecutor.Process, never> =>
     Effect.gen(function*(_) {
       const flattened = Command.flatten(command)
       for (const entry of flattened) {
-        recorded.push({ command: entry.command, args: entry.args })
+        recorded.push({
+          command: entry.command,
+          args: entry.args,
+          cwd: entry.cwd._tag === "Some" ? entry.cwd.value : undefined
+        })
       }
 
       const last = flattened[flattened.length - 1]!
-      const invocation: RecordedCommand = { command: last.command, args: last.args }
+      const invocation: RecordedCommand = {
+        command: last.command,
+        args: last.args,
+        cwd: last.cwd._tag === "Some" ? last.cwd.value : undefined
+      }
       const stdoutText = decideStdout(invocation)
       const stdout = stdoutText.length === 0 ? Stream.empty : Stream.succeed(encode(stdoutText))
+      const failed = shouldFailGpuComposeUp && shouldFailNvidiaGpuComposeUp(invocation)
+      shouldFailGpuComposeUp = shouldFailGpuComposeUp && !failed
+      const stderr = failed ? Stream.succeed(encode(nvidiaRuntimeFailure)) : Stream.empty
 
       const process: CommandExecutor.Process = {
         [CommandExecutor.ProcessTypeId]: CommandExecutor.ProcessTypeId,
         pid: CommandExecutor.ProcessId(1),
-        exitCode: Effect.succeed(CommandExecutor.ExitCode(0)),
+        exitCode: Effect.succeed(CommandExecutor.ExitCode(failed ? 1 : 0)),
         isRunning: Effect.succeed(false),
         kill: (_signal) => Effect.void,
-        stderr: Stream.empty,
+        stderr,
         stdin: Sink.drain,
         stdout,
         toJSON: () => ({ _tag: "ProjectsUpTestProcess", command: invocation.command, args: invocation.args }),
@@ -220,6 +247,45 @@ describe("runDockerComposeUpWithPortCheck", () => {
         expect(recorded.some((entry) => isDockerVolumeCreate(entry))).toBe(true)
         expect(recorded.some((entry) => isBootstrapSeed(entry))).toBe(true)
         expect(recorded.some((entry) => isDockerComposeUpWithBuild(entry))).toBe(true)
+      })
+    ).pipe(Effect.provide(NodeContext.layer)))
+
+  it.effect("falls back to GPU none when the host NVIDIA runtime is unavailable", () =>
+    withTempDir((root) =>
+      Effect.gen(function*(_) {
+        const fs = yield* _(FileSystem.FileSystem)
+        const path = yield* _(Path.Path)
+        const outDir = path.join(root, "project")
+        const targetDir = "/home/dev/workspaces/org/repo"
+        const globalConfig = makeTemplateConfig(root, outDir, path, targetDir)
+        const projectConfig: TemplateConfig = {
+          ...makeTemplateConfig(root, outDir, path, targetDir),
+          gpu: "all"
+        }
+        const recorded: Array<RecordedCommand> = []
+        const executor = makeFakeExecutor(recorded, { failGpuComposeUp: true })
+
+        yield* _(
+          prepareProjectFiles(outDir, root, globalConfig, projectConfig, {
+            force: false,
+            forceEnv: false
+          })
+        )
+
+        const started = yield* _(
+          runDockerComposeUpWithPortCheck(outDir).pipe(
+            Effect.provideService(CommandExecutor.CommandExecutor, executor)
+          )
+        )
+
+        expect(started.gpu).toBe("none")
+
+        const composeAfter = yield* _(fs.readFileString(path.join(outDir, "docker-compose.yml")))
+        expect(composeAfter).not.toContain("    gpus: all\n")
+
+        const configAfter = yield* _(fs.readFileString(path.join(outDir, "docker-git.json")))
+        expect(configAfter).toContain('"gpu": "none"')
+        expect(recorded.filter((entry) => isDockerComposeUpWithBuild(entry)).length).toBeGreaterThan(1)
       })
     ).pipe(Effect.provide(NodeContext.layer)))
 

--- a/packages/lib/tests/usecases/projects-up.test.ts
+++ b/packages/lib/tests/usecases/projects-up.test.ts
@@ -9,6 +9,7 @@ import * as Inspectable from "effect/Inspectable"
 import * as Option from "effect/Option"
 import * as Sink from "effect/Sink"
 import * as Stream from "effect/Stream"
+import fc from "fast-check"
 
 import type { TemplateConfig } from "../../src/core/domain.js"
 import { gpuModeAfterDockerFailure } from "../../src/core/gpu.js"
@@ -91,14 +92,28 @@ const decideStdout = (cmd: RecordedCommand): string => {
   return ""
 }
 
-const nvidiaRuntimeFailure =
-  "Error response from daemon: failed to create task for container: nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1"
+const nvidiaContainerCliMarker = "nvidia-container-cli"
+const libNvidiaMlMarker = "libnvidia-ml.so.1"
+const missingDeviceDriverMarker = "could not select device driver"
+
+const nvidiaRuntimeFailure = `Error response from daemon: failed to create task for container: ${nvidiaContainerCliMarker}: initialization error: load library failed: ${libNvidiaMlMarker}`
 
 const nvidiaMissingDeviceDriverFailure =
-  'Error response from daemon: could not select device driver "" with capabilities: [[gpu]]'
+  `Error response from daemon: ${missingDeviceDriverMarker} "" with capabilities: [[gpu]]`
 
 const arbitraryComposeFailure =
   "Error response from daemon: network sandbox setup failed"
+
+const nvidiaFailureMarkers: ReadonlyArray<string> = [
+  nvidiaContainerCliMarker,
+  libNvidiaMlMarker,
+  missingDeviceDriverMarker
+]
+
+const containsNvidiaFailureMarker = (details: string): boolean => {
+  const normalized = details.toLowerCase()
+  return nvidiaFailureMarkers.some((marker) => normalized.includes(marker))
+}
 
 const hasNvidiaFallbackWarning = (logs: ReadonlyArray<string>, expectedDetail: string): boolean =>
   logs.some((entry) =>
@@ -363,6 +378,29 @@ describe("runDockerComposeUpWithPortCheck", () => {
   it("keeps GPU access unchanged for arbitrary docker compose up failures", () => {
     expect(gpuModeAfterDockerFailure("all", arbitraryComposeFailure)).toBe("all")
     expect(gpuModeAfterDockerFailure("none", arbitraryComposeFailure)).toBe("none")
+  })
+
+  it("satisfies the GPU fallback classifier invariant", () => {
+    const dockerFailureDetails = fc.oneof(
+      fc.string(),
+      fc
+        .tuple(
+          fc.string(),
+          fc.constantFrom(nvidiaContainerCliMarker, libNvidiaMlMarker, missingDeviceDriverMarker),
+          fc.string()
+        )
+        .map(([left, marker, right]) => `${left}${marker}${right}`)
+    )
+
+    fc.assert(
+      fc.property(dockerFailureDetails, (details) => {
+        const expectedGpu = containsNvidiaFailureMarker(details) ? "none" : "all"
+
+        expect(gpuModeAfterDockerFailure("all", details)).toBe(expectedGpu)
+        expect(gpuModeAfterDockerFailure("none", details)).toBe("none")
+      }),
+      { numRuns: 50 }
+    )
   })
 
   it.effect("falls back to GPU none before retrying reuse mode when the host NVIDIA runtime is unavailable", () =>

--- a/packages/lib/tests/usecases/projects-up.test.ts
+++ b/packages/lib/tests/usecases/projects-up.test.ts
@@ -11,6 +11,7 @@ import * as Sink from "effect/Sink"
 import * as Stream from "effect/Stream"
 
 import type { TemplateConfig } from "../../src/core/domain.js"
+import { gpuModeAfterDockerFailure } from "../../src/core/gpu.js"
 import { prepareProjectFiles } from "../../src/usecases/actions/prepare-files.js"
 import { runDockerComposeUpWithPortCheck } from "../../src/usecases/projects-up.js"
 
@@ -96,6 +97,9 @@ const nvidiaRuntimeFailure =
 const nvidiaMissingDeviceDriverFailure =
   'Error response from daemon: could not select device driver "" with capabilities: [[gpu]]'
 
+const arbitraryComposeFailure =
+  "Error response from daemon: network sandbox setup failed"
+
 const hasNvidiaFallbackWarning = (logs: ReadonlyArray<string>, expectedDetail: string): boolean =>
   logs.some((entry) =>
     entry.includes("NVIDIA runtime failed") &&
@@ -103,7 +107,7 @@ const hasNvidiaFallbackWarning = (logs: ReadonlyArray<string>, expectedDetail: s
     entry.includes("GPU access disabled")
   )
 
-const shouldFailNvidiaGpuComposeUp = (cmd: RecordedCommand): boolean =>
+const isDockerComposeUpAttempt = (cmd: RecordedCommand): boolean =>
   isDockerComposeUpWithBuild(cmd) || isDockerComposeUpReuse(cmd)
 
 type FakeExecutorOptions = {
@@ -137,7 +141,7 @@ const makeFakeExecutor = (
       }
       const stdoutText = decideStdout(invocation)
       const stdout = stdoutText.length === 0 ? Stream.empty : Stream.succeed(encode(stdoutText))
-      const failed = shouldFailGpuComposeUp && shouldFailNvidiaGpuComposeUp(invocation)
+      const failed = shouldFailGpuComposeUp && isDockerComposeUpAttempt(invocation)
       shouldFailGpuComposeUp = shouldFailGpuComposeUp && !failed
       const stderr = failed ? Stream.succeed(encode(gpuFailureStderr)) : Stream.empty
 
@@ -355,6 +359,11 @@ describe("runDockerComposeUpWithPortCheck", () => {
         expect(hasNvidiaFallbackWarning(logs, "could not select device driver")).toBe(true)
       })
     ).pipe(Effect.provide(NodeContext.layer)))
+
+  it("keeps GPU access unchanged for arbitrary docker compose up failures", () => {
+    expect(gpuModeAfterDockerFailure("all", arbitraryComposeFailure)).toBe("all")
+    expect(gpuModeAfterDockerFailure("none", arbitraryComposeFailure)).toBe("none")
+  })
 
   it.effect("falls back to GPU none before retrying reuse mode when the host NVIDIA runtime is unavailable", () =>
     withTempDir((root) =>


### PR DESCRIPTION
Fixes ProverCoderAI/docker-git#291

## Summary
- Detect deterministic NVIDIA runtime failures from Docker output (`nvidia-container-cli`, `libnvidia-ml.so.1`, missing device driver).
- Skip transient compose retries for those host-runtime failures, rewrite managed project files to `gpu: "none"`, then retry `docker compose up`.
- Add a Docker error hint and README GPU-mode guidance. No UI change; screenshots are not applicable.

## Reproduction
The issue log shows `docker compose up` failing before container start with:

```text
nvidia-container-cli: initialization error: load library failed: libnvidia-ml.so.1
```

That occurs when a project has GPU access enabled but the host NVIDIA runtime/userspace is unavailable.

## Verification
- `bun run --cwd packages/lib test -- tests/usecases/projects-up.test.ts tests/usecases/errors.test.ts`
- `bun run typecheck`
- `bun run lint`
- `bun run lint:effect`
- `bun run test`

## Mathematical Guarantees
### Invariants
- `forall details: contains_nvidia_marker(details) -> nvidia_runtime_failure(details)`
- `forall template,error: gpu(template)=all and nvidia_runtime_failure(error) -> gpu(fallback(template,error))=none`
- `forall template: gpu(template)=none -> fallback(template,error) never escalates GPU access`

### Preconditions
- A managed docker-git project exists with a decodable `docker-git.json`.
- Docker returns a typed `DockerCommandError` containing the compose failure output.

### Postconditions
- On NVIDIA runtime failure, managed files are rewritten with `gpu: "none"` before retrying project startup.
- On unrelated Docker failures, existing typed error behavior and transient retry behavior are preserved.

### Complexity
- Detection: `O(n * m)` where `n = |details|` and `m` is the marker count.
- Fallback: one template rewrite plus one compose retry path; no unbounded retry loop.

SOURCE: n/a