### PR TITLE
feat(api): add ActivityPub schema parity proof

### DIFF
--- a/packages/api/src/api/activitypub-schema.ts
+++ b/packages/api/src/api/activitypub-schema.ts
@@ -1,0 +1,144 @@
+import * as Schema from "effect/Schema"
+
+import {
+  activityStreamsJsonLdContext,
+  forgeFedJsonLdContext,
+  securityJsonLdContext
+} from "./contracts.js"
+
+export type JsonPrimitive = boolean | number | string | null
+export type JsonValue = JsonPrimitive | JsonObject | ReadonlyArray<JsonValue>
+export type JsonObject = Readonly<{ [key: string]: JsonValue }>
+
+export const JsonValueSchema: Schema.Schema<JsonValue> = Schema.suspend(() =>
+  Schema.Union(
+    Schema.Null,
+    Schema.Boolean,
+    Schema.Number,
+    Schema.String,
+    Schema.Array(JsonValueSchema),
+    Schema.Record({ key: Schema.String, value: JsonValueSchema })
+  )
+)
+
+const OptionalString = Schema.optional(Schema.String)
+const OptionalBoolean = Schema.optional(Schema.Boolean)
+const JsonObjectSchema = Schema.Record({ key: Schema.String, value: JsonValueSchema })
+const JsonLdContextEntrySchema = Schema.Union(Schema.String, JsonObjectSchema)
+
+export const ActivityForgeFedJsonLdContextSchema = Schema.Tuple(
+  Schema.Literal(activityStreamsJsonLdContext),
+  Schema.Literal(forgeFedJsonLdContext)
+)
+
+export const ActorJsonLdContextSchema = Schema.Tuple(
+  Schema.Literal(activityStreamsJsonLdContext),
+  Schema.Literal(securityJsonLdContext),
+  Schema.Literal(forgeFedJsonLdContext)
+)
+
+export const JsonLdContextSchema = Schema.Union(
+  Schema.String,
+  JsonObjectSchema,
+  Schema.Array(JsonLdContextEntrySchema)
+)
+
+export const ForgeFedTicketSourceSchema = Schema.Struct({
+  content: OptionalString,
+  mediaType: OptionalString
+})
+
+export const ForgeFedTicketSchema = Schema.Struct({
+  id: Schema.String,
+  attributedTo: Schema.String,
+  summary: Schema.String,
+  content: Schema.String,
+  mediaType: OptionalString,
+  source: Schema.optional(Schema.Union(Schema.String, ForgeFedTicketSourceSchema)),
+  published: OptionalString,
+  updated: OptionalString,
+  url: OptionalString,
+  context: OptionalString,
+  workType: OptionalString,
+  attachment: Schema.optional(Schema.Array(Schema.Unknown)),
+  raw: Schema.optional(Schema.Unknown)
+})
+
+export const ActivityPubPublicKeySchema = Schema.Struct({
+  id: Schema.String,
+  owner: Schema.String,
+  publicKeyPem: Schema.String
+})
+
+const ActivityPubEndpointsSchema = Schema.Struct({
+  sharedInbox: OptionalString
+})
+
+const ActivityPubInteractionPolicySchema = Schema.Record({
+  key: Schema.String,
+  value: JsonValueSchema
+})
+
+export const ActivityPubPersonSchema = Schema.Struct({
+  "@context": JsonLdContextSchema,
+  type: Schema.Literal("Person"),
+  id: Schema.String,
+  name: Schema.String,
+  preferredUsername: Schema.String,
+  summary: Schema.String,
+  inbox: Schema.String,
+  outbox: Schema.String,
+  followers: Schema.String,
+  following: Schema.String,
+  liked: OptionalString,
+  publicKey: Schema.optional(ActivityPubPublicKeySchema),
+  endpoints: Schema.optional(ActivityPubEndpointsSchema),
+  webfinger: OptionalString,
+  featured: OptionalString,
+  featuredTags: OptionalString,
+  url: OptionalString,
+  manuallyApprovesFollowers: OptionalBoolean,
+  discoverable: OptionalBoolean,
+  indexable: OptionalBoolean,
+  published: OptionalString,
+  memorial: OptionalBoolean,
+  showFeatured: OptionalBoolean,
+  showMedia: OptionalBoolean,
+  showRepliesInMedia: OptionalBoolean,
+  interactionPolicy: Schema.optional(ActivityPubInteractionPolicySchema),
+  featuredCollections: OptionalString,
+  tag: Schema.optional(Schema.Array(JsonValueSchema)),
+  attachment: Schema.optional(Schema.Array(JsonValueSchema))
+})
+
+export const ActivityPubFollowActivitySchema = Schema.Struct({
+  "@context": ActivityForgeFedJsonLdContextSchema,
+  id: Schema.String,
+  type: Schema.Literal("Follow"),
+  actor: Schema.String,
+  object: Schema.String,
+  to: Schema.optional(Schema.Array(Schema.String)),
+  capability: OptionalString
+})
+
+export const ActivityPubOrderedCollectionSchema = Schema.Struct({
+  "@context": JsonLdContextSchema,
+  type: Schema.Literal("OrderedCollection"),
+  id: Schema.String,
+  totalItems: Schema.Number,
+  first: OptionalString,
+  last: OptionalString,
+  current: OptionalString,
+  orderedItems: Schema.optionalWith(Schema.Array(Schema.Unknown), { default: () => [] })
+})
+
+export const ActivityPubOrderedCollectionPageSchema = Schema.Struct({
+  "@context": JsonLdContextSchema,
+  type: Schema.Literal("OrderedCollectionPage"),
+  id: Schema.String,
+  totalItems: Schema.Number,
+  partOf: Schema.String,
+  next: OptionalString,
+  prev: OptionalString,
+  orderedItems: Schema.Array(Schema.Unknown)
+})

--- a/packages/api/src/api/activitypub-schema.ts
+++ b/packages/api/src/api/activitypub-schema.ts
@@ -1,4 +1,5 @@
 import * as Schema from "effect/Schema"
+import type * as SchemaAST from "effect/SchemaAST"
 
 import {
   activityStreamsJsonLdContext,
@@ -10,6 +11,10 @@ import {
 export type JsonPrimitive = boolean | number | string | null
 export type JsonValue = JsonPrimitive | JsonObject | ReadonlyArray<JsonValue>
 export type JsonObject = Readonly<{ [key: string]: JsonValue }>
+
+export const exactActivityPubParseOptions: SchemaAST.ParseOptions = {
+  onExcessProperty: "error"
+}
 
 export const JsonValueSchema: Schema.Schema<JsonValue> = Schema.suspend(() =>
   Schema.Union(
@@ -23,13 +28,12 @@ export const JsonValueSchema: Schema.Schema<JsonValue> = Schema.suspend(() =>
 )
 
 const OptionalString = Schema.optional(Schema.String)
-const OptionalBoolean = Schema.optional(Schema.Boolean)
 const JsonObjectSchema = Schema.Record({ key: Schema.String, value: JsonValueSchema })
 const JsonLdContextEntrySchema = Schema.Union(Schema.String, JsonObjectSchema)
 const JsonLdIdMappingSchema = Schema.Struct({
   "@id": Schema.String,
-  "@type": OptionalString
-}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+  "@type": Schema.Literal("@id")
+})
 
 export const ActivityForgeFedJsonLdContextSchema = Schema.Tuple(
   Schema.Literal(activityStreamsJsonLdContext),
@@ -43,29 +47,29 @@ export const LocalActorJsonLdContextSchema = Schema.Tuple(
 )
 
 export const MastodonActorContextExtensionsSchema = Schema.Struct({
-  manuallyApprovesFollowers: OptionalString,
-  toot: OptionalString,
-  featured: Schema.optional(JsonLdIdMappingSchema),
-  featuredTags: Schema.optional(JsonLdIdMappingSchema),
-  alsoKnownAs: Schema.optional(JsonLdIdMappingSchema),
-  movedTo: Schema.optional(JsonLdIdMappingSchema),
-  schema: OptionalString,
-  PropertyValue: OptionalString,
-  value: OptionalString,
-  discoverable: OptionalString,
-  suspended: OptionalString,
-  memorial: OptionalString,
-  indexable: OptionalString,
-  attributionDomains: Schema.optional(JsonLdIdMappingSchema),
-  showFeatured: OptionalString,
-  showMedia: OptionalString,
-  showRepliesInMedia: OptionalString,
-  gts: OptionalString,
-  interactionPolicy: Schema.optional(JsonLdIdMappingSchema),
-  canQuote: Schema.optional(JsonLdIdMappingSchema),
-  automaticApproval: Schema.optional(JsonLdIdMappingSchema),
-  manualApproval: Schema.optional(JsonLdIdMappingSchema)
-}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+  manuallyApprovesFollowers: Schema.String,
+  toot: Schema.String,
+  featured: JsonLdIdMappingSchema,
+  featuredTags: JsonLdIdMappingSchema,
+  alsoKnownAs: JsonLdIdMappingSchema,
+  movedTo: JsonLdIdMappingSchema,
+  schema: Schema.String,
+  PropertyValue: Schema.String,
+  value: Schema.String,
+  discoverable: Schema.String,
+  suspended: Schema.String,
+  memorial: Schema.String,
+  indexable: Schema.String,
+  attributionDomains: JsonLdIdMappingSchema,
+  showFeatured: Schema.String,
+  showMedia: Schema.String,
+  showRepliesInMedia: Schema.String,
+  gts: Schema.String,
+  interactionPolicy: JsonLdIdMappingSchema,
+  canQuote: JsonLdIdMappingSchema,
+  automaticApproval: JsonLdIdMappingSchema,
+  manualApproval: JsonLdIdMappingSchema
+})
 
 export const MastodonActorJsonLdContextSchema = Schema.Tuple(
   Schema.Literal(activityStreamsJsonLdContext),
@@ -113,7 +117,7 @@ export const ActivityPubPublicKeySchema = Schema.Struct({
 })
 
 const ActivityPubEndpointsSchema = Schema.Struct({
-  sharedInbox: OptionalString
+  sharedInbox: Schema.String
 })
 
 const ActivityPubImageSchema = Schema.Struct({
@@ -166,44 +170,57 @@ const MastodonInteractionPolicySchema = Schema.Struct({
     policy.canQuote !== undefined)
 )
 
-export const ActivityPubPersonSchema = Schema.Struct({
-  "@context": ActorJsonLdContextSchema,
+export const LocalActivityPubPersonSchema = Schema.Struct({
+  "@context": LocalActorJsonLdContextSchema,
   type: Schema.Literal("Person"),
   id: Schema.String,
-  name: OptionalString,
+  name: Schema.String,
   preferredUsername: Schema.String,
   summary: Schema.String,
   inbox: Schema.String,
   outbox: Schema.String,
   followers: Schema.String,
   following: Schema.String,
-  liked: OptionalString,
-  publicKey: Schema.optional(ActivityPubPublicKeySchema),
-  endpoints: Schema.optional(ActivityPubEndpointsSchema),
-  webfinger: OptionalString,
-  featured: OptionalString,
-  featuredTags: OptionalString,
-  url: OptionalString,
-  manuallyApprovesFollowers: OptionalBoolean,
-  discoverable: OptionalBoolean,
-  indexable: OptionalBoolean,
-  published: OptionalString,
-  memorial: OptionalBoolean,
-  alsoKnownAs: Schema.optional(Schema.Array(Schema.String)),
-  movedTo: OptionalString,
-  suspended: OptionalBoolean,
-  attributionDomains: Schema.optional(Schema.Array(Schema.String)),
-  icon: Schema.optional(ActivityPubImageSchema),
-  image: Schema.optional(ActivityPubImageSchema),
-  devices: OptionalString,
-  showFeatured: OptionalBoolean,
-  showMedia: OptionalBoolean,
-  showRepliesInMedia: OptionalBoolean,
-  interactionPolicy: Schema.optional(MastodonInteractionPolicySchema),
-  featuredCollections: OptionalString,
-  tag: Schema.optional(Schema.Array(ActivityPubActorTagSchema)),
-  attachment: Schema.optional(Schema.Array(ActivityPubActorAttachmentSchema))
+  liked: Schema.String,
+  publicKey: ActivityPubPublicKeySchema,
+  endpoints: ActivityPubEndpointsSchema
 })
+
+export const MastodonIssueActivityPubPersonSchema = Schema.Struct({
+  "@context": MastodonActorJsonLdContextSchema,
+  id: Schema.String,
+  webfinger: Schema.String,
+  type: Schema.Literal("Person"),
+  following: Schema.String,
+  followers: Schema.String,
+  inbox: Schema.String,
+  outbox: Schema.String,
+  featured: Schema.String,
+  featuredTags: Schema.String,
+  preferredUsername: Schema.String,
+  name: Schema.String,
+  summary: Schema.String,
+  url: Schema.String,
+  manuallyApprovesFollowers: Schema.Boolean,
+  discoverable: Schema.Boolean,
+  indexable: Schema.Boolean,
+  published: Schema.String,
+  memorial: Schema.Boolean,
+  showFeatured: Schema.Boolean,
+  showMedia: Schema.Boolean,
+  showRepliesInMedia: Schema.Boolean,
+  interactionPolicy: MastodonInteractionPolicySchema,
+  featuredCollections: Schema.String,
+  publicKey: ActivityPubPublicKeySchema,
+  tag: Schema.Array(ActivityPubActorTagSchema),
+  attachment: Schema.Array(ActivityPubActorAttachmentSchema),
+  endpoints: ActivityPubEndpointsSchema
+})
+
+export const ActivityPubPersonSchema = Schema.Union(
+  LocalActivityPubPersonSchema,
+  MastodonIssueActivityPubPersonSchema
+)
 
 export const ActivityPubFollowActivitySchema = Schema.Struct({
   "@context": ActivityForgeFedJsonLdContextSchema,
@@ -215,24 +232,57 @@ export const ActivityPubFollowActivitySchema = Schema.Struct({
   capability: OptionalString
 })
 
-export const ActivityPubOrderedCollectionSchema = Schema.Struct({
-  "@context": JsonLdContextSchema,
+export const LocalActivityPubOrderedCollectionSchema = Schema.Struct({
+  "@context": ActivityForgeFedJsonLdContextSchema,
   type: Schema.Literal("OrderedCollection"),
   id: Schema.String,
   totalItems: Schema.Number,
-  first: OptionalString,
-  last: OptionalString,
-  current: OptionalString,
-  orderedItems: Schema.optionalWith(Schema.Array(JsonValueSchema), { default: () => [] })
+  orderedItems: Schema.Array(JsonValueSchema)
 })
 
-export const ActivityPubOrderedCollectionPageSchema = Schema.Struct({
-  "@context": JsonLdContextSchema,
+export const LocalActivityPubFollowersCollectionSchema = Schema.Struct({
+  "@context": ActivityForgeFedJsonLdContextSchema,
+  type: Schema.Literal("OrderedCollection"),
+  id: Schema.String,
+  totalItems: Schema.Number,
+  first: Schema.String,
+  orderedItems: Schema.Array(JsonValueSchema)
+})
+
+export const MastodonFollowersOrderedCollectionSchema = Schema.Struct({
+  "@context": Schema.Literal(activityStreamsJsonLdContext),
+  id: Schema.String,
+  type: Schema.Literal("OrderedCollection"),
+  totalItems: Schema.Number,
+  first: Schema.String
+})
+
+export const ActivityPubOrderedCollectionSchema = Schema.Union(
+  LocalActivityPubOrderedCollectionSchema,
+  LocalActivityPubFollowersCollectionSchema,
+  MastodonFollowersOrderedCollectionSchema
+)
+
+export const LocalActivityPubOrderedCollectionPageSchema = Schema.Struct({
+  "@context": ActivityForgeFedJsonLdContextSchema,
   type: Schema.Literal("OrderedCollectionPage"),
   id: Schema.String,
   totalItems: Schema.Number,
   partOf: Schema.String,
-  next: OptionalString,
-  prev: OptionalString,
   orderedItems: Schema.Array(JsonValueSchema)
 })
+
+export const MastodonFollowersOrderedCollectionPageSchema = Schema.Struct({
+  "@context": Schema.Literal(activityStreamsJsonLdContext),
+  id: Schema.String,
+  type: Schema.Literal("OrderedCollectionPage"),
+  totalItems: Schema.Number,
+  partOf: Schema.String,
+  next: Schema.String,
+  orderedItems: Schema.Array(Schema.String)
+})
+
+export const ActivityPubOrderedCollectionPageSchema = Schema.Union(
+  LocalActivityPubOrderedCollectionPageSchema,
+  MastodonFollowersOrderedCollectionPageSchema
+)

--- a/packages/api/src/api/activitypub-schema.ts
+++ b/packages/api/src/api/activitypub-schema.ts
@@ -116,42 +116,55 @@ const ActivityPubEndpointsSchema = Schema.Struct({
   sharedInbox: OptionalString
 })
 
-const ActivityPubInteractionPolicySchema = Schema.Record({
-  key: Schema.String,
-  value: JsonValueSchema
+const ActivityPubImageSchema = Schema.Struct({
+  type: Schema.Literal("Image"),
+  mediaType: OptionalString,
+  url: Schema.String,
+  name: OptionalString
 })
 
-const ActivityPubImageSchema = Schema.Struct({
-  type: OptionalString,
-  mediaType: OptionalString,
-  url: OptionalString,
-  name: OptionalString
-}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
-
 const ActivityPubActorAttachmentSchema = Schema.Struct({
-  type: OptionalString,
-  name: OptionalString,
-  value: OptionalString
-}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+  type: Schema.Literal("PropertyValue"),
+  name: Schema.String,
+  value: Schema.String
+})
 
-const ActivityPubActorTagSchema = Schema.Struct({
-  type: OptionalString,
-  name: OptionalString,
-  href: OptionalString,
-  id: OptionalString,
-  icon: Schema.optional(ActivityPubImageSchema),
+const ActivityPubHashtagTagSchema = Schema.Struct({
+  type: Schema.Literal("Hashtag"),
+  name: Schema.String,
+  href: Schema.String
+})
+
+const ActivityPubEmojiTagSchema = Schema.Struct({
+  type: Schema.Literal("Emoji"),
+  id: Schema.String,
+  name: Schema.String,
+  icon: ActivityPubImageSchema,
   updated: OptionalString
-}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+})
+
+const ActivityPubActorTagSchema = Schema.Union(
+  ActivityPubHashtagTagSchema,
+  ActivityPubEmojiTagSchema
+)
 
 const ActivityPubInteractionApprovalSchema = Schema.Struct({
   automaticApproval: Schema.optional(Schema.Array(Schema.String)),
   manualApproval: Schema.optional(Schema.Array(Schema.String))
-}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+}).pipe(
+  Schema.filter((approval) =>
+    approval.automaticApproval !== undefined ||
+    approval.manualApproval !== undefined)
+)
 
 const MastodonInteractionPolicySchema = Schema.Struct({
   canFeature: Schema.optional(ActivityPubInteractionApprovalSchema),
   canQuote: Schema.optional(ActivityPubInteractionApprovalSchema)
-}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+}).pipe(
+  Schema.filter((policy) =>
+    policy.canFeature !== undefined ||
+    policy.canQuote !== undefined)
+)
 
 export const ActivityPubPersonSchema = Schema.Struct({
   "@context": ActorJsonLdContextSchema,
@@ -186,7 +199,7 @@ export const ActivityPubPersonSchema = Schema.Struct({
   showFeatured: OptionalBoolean,
   showMedia: OptionalBoolean,
   showRepliesInMedia: OptionalBoolean,
-  interactionPolicy: Schema.optional(Schema.Union(MastodonInteractionPolicySchema, ActivityPubInteractionPolicySchema)),
+  interactionPolicy: Schema.optional(MastodonInteractionPolicySchema),
   featuredCollections: OptionalString,
   tag: Schema.optional(Schema.Array(ActivityPubActorTagSchema)),
   attachment: Schema.optional(Schema.Array(ActivityPubActorAttachmentSchema))

--- a/packages/api/src/api/activitypub-schema.ts
+++ b/packages/api/src/api/activitypub-schema.ts
@@ -3,7 +3,8 @@ import * as Schema from "effect/Schema"
 import {
   activityStreamsJsonLdContext,
   forgeFedJsonLdContext,
-  securityJsonLdContext
+  securityJsonLdContext,
+  socialWebWebfingerJsonLdContext
 } from "./contracts.js"
 
 export type JsonPrimitive = boolean | number | string | null
@@ -25,16 +26,57 @@ const OptionalString = Schema.optional(Schema.String)
 const OptionalBoolean = Schema.optional(Schema.Boolean)
 const JsonObjectSchema = Schema.Record({ key: Schema.String, value: JsonValueSchema })
 const JsonLdContextEntrySchema = Schema.Union(Schema.String, JsonObjectSchema)
+const JsonLdIdMappingSchema = Schema.Struct({
+  "@id": Schema.String,
+  "@type": OptionalString
+}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
 
 export const ActivityForgeFedJsonLdContextSchema = Schema.Tuple(
   Schema.Literal(activityStreamsJsonLdContext),
   Schema.Literal(forgeFedJsonLdContext)
 )
 
-export const ActorJsonLdContextSchema = Schema.Tuple(
+export const LocalActorJsonLdContextSchema = Schema.Tuple(
   Schema.Literal(activityStreamsJsonLdContext),
   Schema.Literal(securityJsonLdContext),
   Schema.Literal(forgeFedJsonLdContext)
+)
+
+export const MastodonActorContextExtensionsSchema = Schema.Struct({
+  manuallyApprovesFollowers: OptionalString,
+  toot: OptionalString,
+  featured: Schema.optional(JsonLdIdMappingSchema),
+  featuredTags: Schema.optional(JsonLdIdMappingSchema),
+  alsoKnownAs: Schema.optional(JsonLdIdMappingSchema),
+  movedTo: Schema.optional(JsonLdIdMappingSchema),
+  schema: OptionalString,
+  PropertyValue: OptionalString,
+  value: OptionalString,
+  discoverable: OptionalString,
+  suspended: OptionalString,
+  memorial: OptionalString,
+  indexable: OptionalString,
+  attributionDomains: Schema.optional(JsonLdIdMappingSchema),
+  showFeatured: OptionalString,
+  showMedia: OptionalString,
+  showRepliesInMedia: OptionalString,
+  gts: OptionalString,
+  interactionPolicy: Schema.optional(JsonLdIdMappingSchema),
+  canQuote: Schema.optional(JsonLdIdMappingSchema),
+  automaticApproval: Schema.optional(JsonLdIdMappingSchema),
+  manualApproval: Schema.optional(JsonLdIdMappingSchema)
+}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+
+export const MastodonActorJsonLdContextSchema = Schema.Tuple(
+  Schema.Literal(activityStreamsJsonLdContext),
+  Schema.Literal(securityJsonLdContext),
+  Schema.Literal(socialWebWebfingerJsonLdContext),
+  MastodonActorContextExtensionsSchema
+)
+
+export const ActorJsonLdContextSchema = Schema.Union(
+  LocalActorJsonLdContextSchema,
+  MastodonActorJsonLdContextSchema
 )
 
 export const JsonLdContextSchema = Schema.Union(
@@ -60,8 +102,8 @@ export const ForgeFedTicketSchema = Schema.Struct({
   url: OptionalString,
   context: OptionalString,
   workType: OptionalString,
-  attachment: Schema.optional(Schema.Array(Schema.Unknown)),
-  raw: Schema.optional(Schema.Unknown)
+  attachment: Schema.optional(Schema.Array(JsonValueSchema)),
+  raw: Schema.optional(JsonValueSchema)
 })
 
 export const ActivityPubPublicKeySchema = Schema.Struct({
@@ -79,11 +121,43 @@ const ActivityPubInteractionPolicySchema = Schema.Record({
   value: JsonValueSchema
 })
 
+const ActivityPubImageSchema = Schema.Struct({
+  type: OptionalString,
+  mediaType: OptionalString,
+  url: OptionalString,
+  name: OptionalString
+}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+
+const ActivityPubActorAttachmentSchema = Schema.Struct({
+  type: OptionalString,
+  name: OptionalString,
+  value: OptionalString
+}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+
+const ActivityPubActorTagSchema = Schema.Struct({
+  type: OptionalString,
+  name: OptionalString,
+  href: OptionalString,
+  id: OptionalString,
+  icon: Schema.optional(ActivityPubImageSchema),
+  updated: OptionalString
+}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+
+const ActivityPubInteractionApprovalSchema = Schema.Struct({
+  automaticApproval: Schema.optional(Schema.Array(Schema.String)),
+  manualApproval: Schema.optional(Schema.Array(Schema.String))
+}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+
+const MastodonInteractionPolicySchema = Schema.Struct({
+  canFeature: Schema.optional(ActivityPubInteractionApprovalSchema),
+  canQuote: Schema.optional(ActivityPubInteractionApprovalSchema)
+}, Schema.Record({ key: Schema.String, value: JsonValueSchema }))
+
 export const ActivityPubPersonSchema = Schema.Struct({
-  "@context": JsonLdContextSchema,
+  "@context": ActorJsonLdContextSchema,
   type: Schema.Literal("Person"),
   id: Schema.String,
-  name: Schema.String,
+  name: OptionalString,
   preferredUsername: Schema.String,
   summary: Schema.String,
   inbox: Schema.String,
@@ -102,13 +176,20 @@ export const ActivityPubPersonSchema = Schema.Struct({
   indexable: OptionalBoolean,
   published: OptionalString,
   memorial: OptionalBoolean,
+  alsoKnownAs: Schema.optional(Schema.Array(Schema.String)),
+  movedTo: OptionalString,
+  suspended: OptionalBoolean,
+  attributionDomains: Schema.optional(Schema.Array(Schema.String)),
+  icon: Schema.optional(ActivityPubImageSchema),
+  image: Schema.optional(ActivityPubImageSchema),
+  devices: OptionalString,
   showFeatured: OptionalBoolean,
   showMedia: OptionalBoolean,
   showRepliesInMedia: OptionalBoolean,
-  interactionPolicy: Schema.optional(ActivityPubInteractionPolicySchema),
+  interactionPolicy: Schema.optional(Schema.Union(MastodonInteractionPolicySchema, ActivityPubInteractionPolicySchema)),
   featuredCollections: OptionalString,
-  tag: Schema.optional(Schema.Array(JsonValueSchema)),
-  attachment: Schema.optional(Schema.Array(JsonValueSchema))
+  tag: Schema.optional(Schema.Array(ActivityPubActorTagSchema)),
+  attachment: Schema.optional(Schema.Array(ActivityPubActorAttachmentSchema))
 })
 
 export const ActivityPubFollowActivitySchema = Schema.Struct({
@@ -129,7 +210,7 @@ export const ActivityPubOrderedCollectionSchema = Schema.Struct({
   first: OptionalString,
   last: OptionalString,
   current: OptionalString,
-  orderedItems: Schema.optionalWith(Schema.Array(Schema.Unknown), { default: () => [] })
+  orderedItems: Schema.optionalWith(Schema.Array(JsonValueSchema), { default: () => [] })
 })
 
 export const ActivityPubOrderedCollectionPageSchema = Schema.Struct({
@@ -140,5 +221,5 @@ export const ActivityPubOrderedCollectionPageSchema = Schema.Struct({
   partOf: Schema.String,
   next: OptionalString,
   prev: OptionalString,
-  orderedItems: Schema.Array(Schema.Unknown)
+  orderedItems: Schema.Array(JsonValueSchema)
 })

--- a/packages/api/src/api/contracts.ts
+++ b/packages/api/src/api/contracts.ts
@@ -9,7 +9,11 @@ import type {
   ActivityPubPublicKeySchema,
   ActorJsonLdContextSchema,
   ForgeFedTicketSchema,
-  ForgeFedTicketSourceSchema
+  ForgeFedTicketSourceSchema,
+  LocalActivityPubFollowersCollectionSchema,
+  LocalActivityPubOrderedCollectionPageSchema,
+  LocalActivityPubOrderedCollectionSchema,
+  LocalActivityPubPersonSchema
 } from "./activitypub-schema.js"
 
 export type ProjectStatus = "running" | "stopped" | "unknown"
@@ -622,9 +626,18 @@ export type ActivityPubPublicKey = Schema.Schema.Type<typeof ActivityPubPublicKe
 
 export type ActivityPubPerson = Schema.Schema.Type<typeof ActivityPubPersonSchema>
 
+export type LocalActivityPubPerson = Schema.Schema.Type<typeof LocalActivityPubPersonSchema>
+
 export type ActivityPubOrderedCollection = Schema.Schema.Type<typeof ActivityPubOrderedCollectionSchema>
 
+export type LocalActivityPubOrderedCollection =
+  | Schema.Schema.Type<typeof LocalActivityPubOrderedCollectionSchema>
+  | Schema.Schema.Type<typeof LocalActivityPubFollowersCollectionSchema>
+
 export type ActivityPubOrderedCollectionPage = Schema.Schema.Type<typeof ActivityPubOrderedCollectionPageSchema>
+
+export type LocalActivityPubOrderedCollectionPage =
+  Schema.Schema.Type<typeof LocalActivityPubOrderedCollectionPageSchema>
 
 export type FollowSubscription = {
   readonly id: string

--- a/packages/api/src/api/contracts.ts
+++ b/packages/api/src/api/contracts.ts
@@ -556,6 +556,7 @@ export type ContainerTaskSnapshot = {
 export const activityStreamsJsonLdContext = "https://www.w3.org/ns/activitystreams" as const
 export const forgeFedJsonLdContext = "https://forgefed.org/ns" as const
 export const securityJsonLdContext = "https://w3id.org/security/v1" as const
+export const socialWebWebfingerJsonLdContext = "https://purl.archive.org/socialweb/webfinger" as const
 export const activityForgeFedJsonLdContext = [
   activityStreamsJsonLdContext,
   forgeFedJsonLdContext

--- a/packages/api/src/api/contracts.ts
+++ b/packages/api/src/api/contracts.ts
@@ -1,3 +1,17 @@
+import type * as Schema from "effect/Schema"
+
+import type {
+  ActivityForgeFedJsonLdContextSchema,
+  ActivityPubFollowActivitySchema,
+  ActivityPubOrderedCollectionPageSchema,
+  ActivityPubOrderedCollectionSchema,
+  ActivityPubPersonSchema,
+  ActivityPubPublicKeySchema,
+  ActorJsonLdContextSchema,
+  ForgeFedTicketSchema,
+  ForgeFedTicketSourceSchema
+} from "./activitypub-schema.js"
+
 export type ProjectStatus = "running" | "stopped" | "unknown"
 
 export type AgentProvider = "codex" | "opencode" | "claude" | "grok" | "custom"
@@ -556,29 +570,12 @@ export const federationJsonLdContentType =
 export const federationJsonLdResponseContentType =
   `${federationJsonLdContentType}; charset=utf-8` as const
 
-export type ActivityForgeFedJsonLdContext = typeof activityForgeFedJsonLdContext
-export type ActorJsonLdContext = typeof actorJsonLdContext
+export type ActivityForgeFedJsonLdContext = Schema.Schema.Type<typeof ActivityForgeFedJsonLdContextSchema>
+export type ActorJsonLdContext = Schema.Schema.Type<typeof ActorJsonLdContextSchema>
 
-export type ForgeFedTicket = {
-  readonly id: string
-  readonly attributedTo: string
-  readonly summary: string
-  readonly content: string
-  readonly mediaType?: string | undefined
-  readonly source?: string | ForgeFedTicketSource | undefined
-  readonly published?: string | undefined
-  readonly updated?: string | undefined
-  readonly url?: string | undefined
-  readonly context?: string | undefined
-  readonly workType?: string | undefined
-  readonly attachment?: ReadonlyArray<unknown> | undefined
-  readonly raw?: unknown | undefined
-}
+export type ForgeFedTicket = Schema.Schema.Type<typeof ForgeFedTicketSchema>
 
-export type ForgeFedTicketSource = {
-  readonly content?: string | undefined
-  readonly mediaType?: string | undefined
-}
+export type ForgeFedTicketSource = Schema.Schema.Type<typeof ForgeFedTicketSourceSchema>
 
 export type FederationIssueStatus =
   | "offered"
@@ -618,47 +615,15 @@ export type CreateFollowRequest = {
 
 export type FollowStatus = "pending" | "accepted" | "rejected"
 
-export type ActivityPubFollowActivity = {
-  readonly "@context": ActivityForgeFedJsonLdContext
-  readonly id: string
-  readonly type: "Follow"
-  readonly actor: string
-  readonly object: string
-  readonly to?: ReadonlyArray<string> | undefined
-  readonly capability?: string | undefined
-}
+export type ActivityPubFollowActivity = Schema.Schema.Type<typeof ActivityPubFollowActivitySchema>
 
-export type ActivityPubPublicKey = {
-  readonly id: string
-  readonly owner: string
-  readonly publicKeyPem: string
-}
+export type ActivityPubPublicKey = Schema.Schema.Type<typeof ActivityPubPublicKeySchema>
 
-export type ActivityPubPerson = {
-  readonly "@context": ActorJsonLdContext
-  readonly type: "Person"
-  readonly id: string
-  readonly name: string
-  readonly preferredUsername: string
-  readonly summary: string
-  readonly inbox: string
-  readonly outbox: string
-  readonly followers: string
-  readonly following: string
-  readonly liked: string
-  readonly publicKey?: ActivityPubPublicKey | undefined
-  readonly endpoints?: {
-    readonly sharedInbox?: string | undefined
-  } | undefined
-}
+export type ActivityPubPerson = Schema.Schema.Type<typeof ActivityPubPersonSchema>
 
-export type ActivityPubOrderedCollection = {
-  readonly "@context": ActivityForgeFedJsonLdContext
-  readonly type: "OrderedCollection"
-  readonly id: string
-  readonly totalItems: number
-  readonly orderedItems: ReadonlyArray<unknown>
-}
+export type ActivityPubOrderedCollection = Schema.Schema.Type<typeof ActivityPubOrderedCollectionSchema>
+
+export type ActivityPubOrderedCollectionPage = Schema.Schema.Type<typeof ActivityPubOrderedCollectionPageSchema>
 
 export type FollowSubscription = {
   readonly id: string

--- a/packages/api/src/api/schema.ts
+++ b/packages/api/src/api/schema.ts
@@ -1,5 +1,19 @@
 import * as Schema from "effect/Schema"
 
+export {
+  ActivityForgeFedJsonLdContextSchema,
+  ActivityPubFollowActivitySchema,
+  ActivityPubOrderedCollectionPageSchema,
+  ActivityPubOrderedCollectionSchema,
+  ActivityPubPersonSchema,
+  ActivityPubPublicKeySchema,
+  ActorJsonLdContextSchema,
+  ForgeFedTicketSchema,
+  ForgeFedTicketSourceSchema,
+  JsonLdContextSchema,
+  JsonValueSchema
+} from "./activitypub-schema.js"
+
 const OptionalString = Schema.optional(Schema.String)
 const OptionalBoolean = Schema.optional(Schema.Boolean)
 const OptionalNullableString = Schema.optional(Schema.NullOr(Schema.String))

--- a/packages/api/src/api/schema.ts
+++ b/packages/api/src/api/schema.ts
@@ -11,7 +11,15 @@ export {
   ForgeFedTicketSchema,
   ForgeFedTicketSourceSchema,
   JsonLdContextSchema,
-  JsonValueSchema
+  JsonValueSchema,
+  LocalActivityPubFollowersCollectionSchema,
+  LocalActivityPubOrderedCollectionPageSchema,
+  LocalActivityPubOrderedCollectionSchema,
+  LocalActivityPubPersonSchema,
+  MastodonFollowersOrderedCollectionPageSchema,
+  MastodonFollowersOrderedCollectionSchema,
+  MastodonIssueActivityPubPersonSchema,
+  exactActivityPubParseOptions
 } from "./activitypub-schema.js"
 
 const OptionalString = Schema.optional(Schema.String)

--- a/packages/api/src/http.ts
+++ b/packages/api/src/http.ts
@@ -44,7 +44,8 @@ import {
   StateCommitRequestSchema,
   StateInitRequestSchema,
   StateSyncRequestSchema,
-  UpProjectRequestSchema
+  UpProjectRequestSchema,
+  exactActivityPubParseOptions
 } from "./api/schema.js"
 import type { UpProjectRequestInput } from "./api/schema.js"
 import { defaultProjectsRoot } from "@effect-template/lib/usecases/menu-helpers"
@@ -316,7 +317,7 @@ const validatedJsonLdResponse = <A, I>(
   label: string,
   status: number
 ) =>
-  Schema.decodeUnknown(schema)(data).pipe(
+  Schema.decodeUnknown(schema, exactActivityPubParseOptions)(data).pipe(
     Effect.mapError((error) =>
       new ApiInternalError({
         message: `${label} does not satisfy its ActivityPub JSON-LD schema: ${

--- a/packages/api/src/http.ts
+++ b/packages/api/src/http.ts
@@ -13,6 +13,9 @@ import { renderError, type AppError } from "@effect-template/lib/usecases/errors
 import { ApiAuthRequiredError, ApiBadRequestError, ApiConflictError, ApiInternalError, ApiNotFoundError, describeUnknown } from "./api/errors.js"
 import { federationJsonLdResponseContentType, type ApplyProjectRequest } from "./api/contracts.js"
 import {
+  ActivityPubOrderedCollectionPageSchema,
+  ActivityPubOrderedCollectionSchema,
+  ActivityPubPersonSchema,
   AuthMenuRequestSchema,
   AuthTerminalSessionRequestSchema,
   ActiveProjectTerminalSessionRequestSchema,
@@ -78,6 +81,7 @@ import {
   makeFederationContext,
   makeFederationExchangeStatus,
   makeFederationFollowersCollection,
+  makeFederationFollowersPageCollection,
   makeFederationFollowingCollection,
   makeFederationLikedCollection,
   makeFederationOutboxCollection,
@@ -306,6 +310,24 @@ const binaryResponse = (data: Uint8Array, contentType: string, status = 200) =>
 const jsonLdResponse = (data: unknown, status: number) =>
   textResponse(JSON.stringify(data), federationJsonLdResponseContentType, status)
 
+const validatedJsonLdResponse = <A, I>(
+  schema: Schema.Schema<A, I, never>,
+  data: unknown,
+  label: string,
+  status: number
+) =>
+  Schema.decodeUnknown(schema)(data).pipe(
+    Effect.mapError((error) =>
+      new ApiInternalError({
+        message: `${label} does not satisfy its ActivityPub JSON-LD schema: ${
+          ParseResult.TreeFormatter.formatIssueSync(error.issue)
+        }`,
+        cause: error
+      })
+    ),
+    Effect.flatMap((payload) => jsonLdResponse(payload, status))
+  )
+
 const parseQueryInt = (url: string, key: string, fallback: number): number => {
   const parsed = Number(new URL(url, "http://localhost").searchParams.get(key) ?? "")
   if (!Number.isFinite(parsed) || parsed <= 0) {
@@ -316,6 +338,16 @@ const parseQueryInt = (url: string, key: string, fallback: number): number => {
 
 const hasQueryParam = (url: string, key: string): boolean =>
   new URL(url, "http://localhost").searchParams.has(key)
+
+const readFollowersPageMode = (url: string): Effect.Effect<"collection" | "page", ApiBadRequestError> => {
+  const page = new URL(url, "http://localhost").searchParams.get("page")
+  if (page === null) {
+    return Effect.succeed("collection")
+  }
+  return page === "1"
+    ? Effect.succeed("page")
+    : Effect.fail(new ApiBadRequestError({ message: `Unsupported followers page: ${page}` }))
+}
 
 const parsePortParam = (value: string): Effect.Effect<number, ApiBadRequestError> => {
   const parsed = Number.parseInt(value, 10)
@@ -633,7 +665,14 @@ export const federationActorDocumentResponse = () =>
   Effect.gen(function*(_) {
     const request = yield* _(HttpServerRequest.HttpServerRequest)
     const context = yield* _(resolveFederationContext(request))
-    return yield* _(jsonLdResponse(makeFederationActorDocument(context), 200))
+    return yield* _(
+      validatedJsonLdResponse(
+        ActivityPubPersonSchema,
+        makeFederationActorDocument(context),
+        "Federation actor document",
+        200
+      )
+    )
   }).pipe(Effect.catchAll(errorResponse))
 
 /**
@@ -653,7 +692,14 @@ export const federationOutboxDocumentResponse = () =>
   Effect.gen(function*(_) {
     const request = yield* _(HttpServerRequest.HttpServerRequest)
     const context = yield* _(resolveFederationContext(request))
-    return yield* _(jsonLdResponse(makeFederationOutboxCollection(context), 200))
+    return yield* _(
+      validatedJsonLdResponse(
+        ActivityPubOrderedCollectionSchema,
+        makeFederationOutboxCollection(context),
+        "Federation outbox collection",
+        200
+      )
+    )
   }).pipe(Effect.catchAll(errorResponse))
 
 /**
@@ -673,7 +719,22 @@ export const federationFollowersDocumentResponse = () =>
   Effect.gen(function*(_) {
     const request = yield* _(HttpServerRequest.HttpServerRequest)
     const context = yield* _(resolveFederationContext(request))
-    return yield* _(jsonLdResponse(makeFederationFollowersCollection(context), 200))
+    const mode = yield* _(readFollowersPageMode(request.url))
+    return yield* _(
+      mode === "page"
+        ? validatedJsonLdResponse(
+          ActivityPubOrderedCollectionPageSchema,
+          makeFederationFollowersPageCollection(context),
+          "Federation followers page",
+          200
+        )
+        : validatedJsonLdResponse(
+          ActivityPubOrderedCollectionSchema,
+          makeFederationFollowersCollection(context),
+          "Federation followers collection",
+          200
+        )
+    )
   }).pipe(Effect.catchAll(errorResponse))
 
 /**
@@ -693,7 +754,14 @@ export const federationFollowingDocumentResponse = () =>
   Effect.gen(function*(_) {
     const request = yield* _(HttpServerRequest.HttpServerRequest)
     const context = yield* _(resolveFederationContext(request))
-    return yield* _(jsonLdResponse(makeFederationFollowingCollection(context), 200))
+    return yield* _(
+      validatedJsonLdResponse(
+        ActivityPubOrderedCollectionSchema,
+        makeFederationFollowingCollection(context),
+        "Federation following collection",
+        200
+      )
+    )
   }).pipe(Effect.catchAll(errorResponse))
 
 /**
@@ -713,7 +781,14 @@ export const federationLikedDocumentResponse = () =>
   Effect.gen(function*(_) {
     const request = yield* _(HttpServerRequest.HttpServerRequest)
     const context = yield* _(resolveFederationContext(request))
-    return yield* _(jsonLdResponse(makeFederationLikedCollection(context), 200))
+    return yield* _(
+      validatedJsonLdResponse(
+        ActivityPubOrderedCollectionSchema,
+        makeFederationLikedCollection(context),
+        "Federation liked collection",
+        200
+      )
+    )
   }).pipe(Effect.catchAll(errorResponse))
 
 const terminalWebSocketUpgradeResponse = Effect.gen(function*(_) {

--- a/packages/api/src/services/federation.ts
+++ b/packages/api/src/services/federation.ts
@@ -13,9 +13,6 @@ import { dirname, join } from "node:path"
 import type { JsonValue } from "../api/activitypub-schema.js"
 import type {
   ActivityPubFollowActivity,
-  ActivityPubOrderedCollection,
-  ActivityPubOrderedCollectionPage,
-  ActivityPubPerson,
   ActivityPubPublicKey,
   AgentProvider,
   AgentSession,
@@ -33,6 +30,9 @@ import type {
   FollowSubscriptionCreated,
   ForgeFedTicket,
   ForgeFedTicketSource,
+  LocalActivityPubOrderedCollection,
+  LocalActivityPubOrderedCollectionPage,
+  LocalActivityPubPerson,
   ProjectDetails
 } from "../api/contracts.js"
 import {
@@ -629,7 +629,7 @@ const followActivityJson = (activity: ActivityPubFollowActivity): JsonValue => (
 
 export const makeFederationActorDocument = (
   context: FederationContext
-): ActivityPubPerson => ({
+): LocalActivityPubPerson => ({
   "@context": actorJsonLdContext,
   type: "Person",
   id: context.actorId,
@@ -649,7 +649,7 @@ export const makeFederationActorDocument = (
 
 export const makeFederationOutboxCollection = (
   context: FederationContext
-): ActivityPubOrderedCollection => {
+): LocalActivityPubOrderedCollection => {
   const orderedItems = listFollowSubscriptions().map((subscription) => followActivityJson(subscription.activity))
   return {
     "@context": activityForgeFedJsonLdContext,
@@ -662,7 +662,7 @@ export const makeFederationOutboxCollection = (
 
 export const makeFederationFollowersCollection = (
   context: FederationContext
-): ActivityPubOrderedCollection => ({
+): LocalActivityPubOrderedCollection => ({
   "@context": activityForgeFedJsonLdContext,
   type: "OrderedCollection",
   id: context.followers,
@@ -673,7 +673,7 @@ export const makeFederationFollowersCollection = (
 
 export const makeFederationFollowersPageCollection = (
   context: FederationContext
-): ActivityPubOrderedCollectionPage => ({
+): LocalActivityPubOrderedCollectionPage => ({
   "@context": activityForgeFedJsonLdContext,
   type: "OrderedCollectionPage",
   id: `${context.followers}?page=1`,
@@ -684,7 +684,7 @@ export const makeFederationFollowersPageCollection = (
 
 export const makeFederationFollowingCollection = (
   context: FederationContext
-): ActivityPubOrderedCollection => {
+): LocalActivityPubOrderedCollection => {
   const orderedItems = listFollowSubscriptions()
     .filter((subscription) => subscription.status === "accepted")
     .map((subscription) => subscription.object)
@@ -700,7 +700,7 @@ export const makeFederationFollowingCollection = (
 
 export const makeFederationLikedCollection = (
   context: FederationContext
-): ActivityPubOrderedCollection => ({
+): LocalActivityPubOrderedCollection => ({
   "@context": activityForgeFedJsonLdContext,
   type: "OrderedCollection",
   id: context.liked,
@@ -1592,11 +1592,11 @@ const outboxItemId = (item: unknown, subscription: FollowSubscription): string =
 
 const fetchOutbox = (
   url: string
-): Effect.Effect<ActivityPubOrderedCollection, ApiBadRequestError> =>
+): Effect.Effect<LocalActivityPubOrderedCollection, ApiBadRequestError> =>
   fetchJson(url, "Exchange outbox").pipe(
     Effect.flatMap((record) =>
       requireFederationJsonLdContext(record, "Exchange outbox").pipe(
-        Effect.map((): ActivityPubOrderedCollection => ({
+        Effect.map((): LocalActivityPubOrderedCollection => ({
           "@context": activityForgeFedJsonLdContext,
           type: "OrderedCollection",
           id: readOptionalString(record, "id") ?? url,

--- a/packages/api/src/services/federation.ts
+++ b/packages/api/src/services/federation.ts
@@ -13,6 +13,7 @@ import { dirname, join } from "node:path"
 import type {
   ActivityPubFollowActivity,
   ActivityPubOrderedCollection,
+  ActivityPubOrderedCollectionPage,
   ActivityPubPerson,
   ActivityPubPublicKey,
   AgentProvider,
@@ -637,6 +638,18 @@ export const makeFederationFollowersCollection = (
   type: "OrderedCollection",
   id: context.followers,
   totalItems: 0,
+  first: `${context.followers}?page=1`,
+  orderedItems: []
+})
+
+export const makeFederationFollowersPageCollection = (
+  context: FederationContext
+): ActivityPubOrderedCollectionPage => ({
+  "@context": activityForgeFedJsonLdContext,
+  type: "OrderedCollectionPage",
+  id: `${context.followers}?page=1`,
+  totalItems: 0,
+  partOf: context.followers,
   orderedItems: []
 })
 

--- a/packages/api/src/services/federation.ts
+++ b/packages/api/src/services/federation.ts
@@ -10,6 +10,7 @@ import {
 import { promises as fs } from "node:fs"
 import { dirname, join } from "node:path"
 
+import type { JsonValue } from "../api/activitypub-schema.js"
 import type {
   ActivityPubFollowActivity,
   ActivityPubOrderedCollection,
@@ -125,6 +126,24 @@ const isRecord = (value: unknown): value is JsonRecord =>
 
 const asRecord = (value: unknown): JsonRecord | null =>
   isRecord(value) ? value : null
+
+const isJsonValue = (value: unknown): value is JsonValue => {
+  if (
+    value === null ||
+    typeof value === "string" ||
+    typeof value === "number" ||
+    typeof value === "boolean"
+  ) {
+    return true
+  }
+  if (Array.isArray(value)) {
+    return value.every(isJsonValue)
+  }
+  return isRecord(value) && Object.values(value).every(isJsonValue)
+}
+
+const readJsonValue = (value: unknown): JsonValue | undefined =>
+  isJsonValue(value) ? value : undefined
 
 /**
  * Extracts string JSON-LD context entries from a boundary value.
@@ -598,6 +617,16 @@ const publicKeyForContext = (context: FederationContext): ActivityPubPublicKey =
   publicKeyPem: ensureLocalActorKeys().publicKeyPem
 })
 
+const followActivityJson = (activity: ActivityPubFollowActivity): JsonValue => ({
+  "@context": [...activity["@context"]],
+  id: activity.id,
+  type: activity.type,
+  actor: activity.actor,
+  object: activity.object,
+  ...(activity.to === undefined ? {} : { to: [...activity.to] }),
+  ...(activity.capability === undefined ? {} : { capability: activity.capability })
+})
+
 export const makeFederationActorDocument = (
   context: FederationContext
 ): ActivityPubPerson => ({
@@ -621,7 +650,7 @@ export const makeFederationActorDocument = (
 export const makeFederationOutboxCollection = (
   context: FederationContext
 ): ActivityPubOrderedCollection => {
-  const orderedItems = listFollowSubscriptions().map((subscription) => subscription.activity)
+  const orderedItems = listFollowSubscriptions().map((subscription) => followActivityJson(subscription.activity))
   return {
     "@context": activityForgeFedJsonLdContext,
     type: "OrderedCollection",
@@ -693,9 +722,9 @@ const readTicketSource = (payload: JsonRecord): string | ForgeFedTicketSource | 
   return content === undefined && mediaType === undefined ? undefined : { content, mediaType }
 }
 
-const readTicketAttachment = (payload: JsonRecord): ReadonlyArray<unknown> | undefined => {
+const readTicketAttachment = (payload: JsonRecord): ReadonlyArray<JsonValue> | undefined => {
   const raw = payload["attachment"]
-  return Array.isArray(raw) ? raw : undefined
+  return Array.isArray(raw) && raw.every(isJsonValue) ? raw : undefined
 }
 
 const parseTicket = (
@@ -718,6 +747,7 @@ const parseTicket = (
     const summary = yield* _(readRequiredString(payload, "summary", "ForgeFed ticket"))
     const content = yield* _(readRequiredString(payload, "content", "ForgeFed ticket"))
     const id = readOptionalString(payload, "id") ?? `urn:docker-git:forgefed:ticket:${randomUUID()}`
+    const raw = readJsonValue(payload)
 
     return {
       id,
@@ -732,7 +762,7 @@ const parseTicket = (
       context: readOptionalString(payload, "context"),
       workType: readOptionalString(payload, "workType"),
       attachment: readTicketAttachment(payload),
-      raw: payload
+      ...(raw === undefined ? {} : { raw })
     }
   })
 

--- a/packages/api/tests/activitypub-schema-parity.test.ts
+++ b/packages/api/tests/activitypub-schema-parity.test.ts
@@ -1,0 +1,233 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Effect, Either, ParseResult, Schema } from "effect"
+
+import {
+  ActivityPubOrderedCollectionPageSchema,
+  ActivityPubOrderedCollectionSchema,
+  ActivityPubPersonSchema
+} from "../src/api/schema.js"
+
+const expectDecodedCoversFixtureKeys = (decoded: object, fixture: object): void => {
+  expect(Object.keys(decoded)).toEqual(expect.arrayContaining(Object.keys(fixture)))
+}
+
+const mastodonActorFixture = {
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/v1",
+    "https://purl.archive.org/socialweb/webfinger",
+    {
+      manuallyApprovesFollowers: "as:manuallyApprovesFollowers",
+      toot: "http://joinmastodon.org/ns#",
+      featured: {
+        "@id": "toot:featured",
+        "@type": "@id"
+      },
+      featuredTags: {
+        "@id": "toot:featuredTags",
+        "@type": "@id"
+      },
+      alsoKnownAs: {
+        "@id": "as:alsoKnownAs",
+        "@type": "@id"
+      },
+      movedTo: {
+        "@id": "as:movedTo",
+        "@type": "@id"
+      },
+      schema: "http://schema.org/#",
+      PropertyValue: "schema:PropertyValue",
+      value: "schema:value",
+      discoverable: "toot:discoverable",
+      suspended: "toot:suspended",
+      memorial: "toot:memorial",
+      indexable: "toot:indexable",
+      attributionDomains: {
+        "@id": "toot:attributionDomains",
+        "@type": "@id"
+      },
+      showFeatured: "toot:showFeatured",
+      showMedia: "toot:showMedia",
+      showRepliesInMedia: "toot:showRepliesInMedia",
+      gts: "https://gotosocial.org/ns#",
+      interactionPolicy: {
+        "@id": "gts:interactionPolicy",
+        "@type": "@id"
+      },
+      canQuote: {
+        "@id": "gts:canQuote",
+        "@type": "@id"
+      },
+      automaticApproval: {
+        "@id": "gts:automaticApproval",
+        "@type": "@id"
+      },
+      manualApproval: {
+        "@id": "gts:manualApproval",
+        "@type": "@id"
+      }
+    }
+  ],
+  id: "https://mastodon.social/users/GordonFreeman",
+  webfinger: "GordonFreeman@mastodon.social",
+  type: "Person",
+  following: "https://mastodon.social/users/GordonFreeman/following",
+  followers: "https://mastodon.social/users/GordonFreeman/followers",
+  inbox: "https://mastodon.social/users/GordonFreeman/inbox",
+  outbox: "https://mastodon.social/users/GordonFreeman/outbox",
+  featured: "https://mastodon.social/users/GordonFreeman/collections/featured",
+  featuredTags: "https://mastodon.social/users/GordonFreeman/collections/tags",
+  preferredUsername: "GordonFreeman",
+  name: "GordonFreeman",
+  summary: "",
+  url: "https://mastodon.social/@GordonFreeman",
+  manuallyApprovesFollowers: false,
+  discoverable: false,
+  indexable: false,
+  published: "2022-05-11T00:00:00Z",
+  memorial: false,
+  showFeatured: true,
+  showMedia: true,
+  showRepliesInMedia: true,
+  interactionPolicy: {
+    canFeature: {
+      automaticApproval: ["https://mastodon.social/users/GordonFreeman"]
+    }
+  },
+  featuredCollections: "https://mastodon.social/ap/users/108283196203417442/featured_collections",
+  publicKey: {
+    id: "https://mastodon.social/users/GordonFreeman#main-key",
+    owner: "https://mastodon.social/users/GordonFreeman",
+    publicKeyPem:
+      "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtest\n-----END PUBLIC KEY-----\n"
+  },
+  tag: [],
+  attachment: [],
+  endpoints: {
+    sharedInbox: "https://mastodon.social/inbox"
+  }
+}
+
+const mastodonFollowersCollectionFixture = {
+  "@context": "https://www.w3.org/ns/activitystreams",
+  id: "https://mastodon.social/users/nixCraft/followers",
+  type: "OrderedCollection",
+  totalItems: 114133,
+  first: "https://mastodon.social/users/nixCraft/followers?page=1"
+}
+
+const mastodonFollowersPageFixture = {
+  "@context": "https://www.w3.org/ns/activitystreams",
+  id: "https://mastodon.social/users/nixCraft/followers?page=1",
+  type: "OrderedCollectionPage",
+  totalItems: 114133,
+  partOf: "https://mastodon.social/users/nixCraft/followers",
+  next: "https://mastodon.social/users/nixCraft/followers?max_id=123&page=1",
+  orderedItems: [
+    "https://mastodon.social/users/GordonFreeman",
+    {
+      id: "https://mastodon.social/users/example",
+      type: "Person",
+      following: "https://mastodon.social/users/example/following",
+      followers: "https://mastodon.social/users/example/followers",
+      inbox: "https://mastodon.social/users/example/inbox",
+      outbox: "https://mastodon.social/users/example/outbox",
+      preferredUsername: "example",
+      publicKey: {
+        id: "https://mastodon.social/users/example#main-key",
+        owner: "https://mastodon.social/users/example",
+        publicKeyPem:
+          "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtest\n-----END PUBLIC KEY-----\n"
+      }
+    }
+  ]
+}
+
+describe("ActivityPub and ForgeFed schema parity", () => {
+  it.effect("decodes a Mastodon actor Person fixture", () =>
+    Effect.sync(() => {
+      const result = Schema.decodeUnknownEither(ActivityPubPersonSchema)(mastodonActorFixture)
+
+      Either.match(result, {
+        onLeft: (error) => {
+          throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
+        },
+        onRight: (decoded) => {
+          expectDecodedCoversFixtureKeys(decoded, mastodonActorFixture)
+        }
+      })
+    }))
+
+  it.effect("decodes a Mastodon followers OrderedCollection fixture", () =>
+    Effect.sync(() => {
+      const result = Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)(
+        mastodonFollowersCollectionFixture
+      )
+
+      Either.match(result, {
+        onLeft: (error) => {
+          throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
+        },
+        onRight: (decoded) => {
+          expectDecodedCoversFixtureKeys(decoded, mastodonFollowersCollectionFixture)
+        }
+      })
+    }))
+
+  it.effect("decodes a Mastodon followers OrderedCollectionPage fixture", () =>
+    Effect.sync(() => {
+      const result = Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)(
+        mastodonFollowersPageFixture
+      )
+
+      Either.match(result, {
+        onLeft: (error) => {
+          throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
+        },
+        onRight: (decoded) => {
+          expectDecodedCoversFixtureKeys(decoded, mastodonFollowersPageFixture)
+        }
+      })
+    }))
+
+  it.effect("rejects ActivityPub objects with wrong literal types", () =>
+    Effect.sync(() => {
+      const personResult = Schema.decodeUnknownEither(ActivityPubPersonSchema)({
+        ...mastodonActorFixture,
+        type: "Service"
+      })
+      const collectionResult = Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)({
+        ...mastodonFollowersCollectionFixture,
+        type: "Collection"
+      })
+      const pageResult = Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)({
+        ...mastodonFollowersPageFixture,
+        type: "OrderedCollection"
+      })
+
+      expect(Either.isLeft(personResult)).toBe(true)
+      expect(Either.isLeft(collectionResult)).toBe(true)
+      expect(Either.isLeft(pageResult)).toBe(true)
+    }))
+
+  it.effect("rejects ActivityPub objects missing required fields", () =>
+    Effect.sync(() => {
+      const personResult = Schema.decodeUnknownEither(ActivityPubPersonSchema)({
+        type: "Person",
+        id: "https://mastodon.social/users/missing"
+      })
+      const collectionResult = Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)({
+        type: "OrderedCollection",
+        id: "https://mastodon.social/users/nixCraft/followers"
+      })
+      const pageResult = Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)({
+        type: "OrderedCollectionPage",
+        id: "https://mastodon.social/users/nixCraft/followers?page=1",
+        orderedItems: []
+      })
+
+      expect(Either.isLeft(personResult)).toBe(true)
+      expect(Either.isLeft(collectionResult)).toBe(true)
+      expect(Either.isLeft(pageResult)).toBe(true)
+    }))
+})

--- a/packages/api/tests/activitypub-schema-parity.test.ts
+++ b/packages/api/tests/activitypub-schema-parity.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "@effect/vitest"
 import { Effect, Either, ParseResult, Schema } from "effect"
+import fc from "fast-check"
 
 import {
   ActivityPubOrderedCollectionPageSchema,
@@ -10,6 +11,75 @@ import {
 const expectDecodedCoversFixtureKeys = (decoded: object, fixture: object): void => {
   expect(Object.keys(decoded)).toEqual(expect.arrayContaining(Object.keys(fixture)))
 }
+
+const activityPubContextArbitrary = fc.constant("https://www.w3.org/ns/activitystreams")
+
+const activityPubActorContextArbitrary = fc.constant([
+  "https://www.w3.org/ns/activitystreams",
+  "https://w3id.org/security/v1",
+  "https://forgefed.org/ns"
+] as const)
+
+const schemaStringArbitrary = fc.string()
+
+const nonPersonTypeArbitrary = fc.string().filter((value) => value !== "Person")
+
+const nonOrderedCollectionTypeArbitrary = fc
+  .string()
+  .filter((value) => value !== "OrderedCollection")
+
+const nonOrderedCollectionPageTypeArbitrary = fc
+  .string()
+  .filter((value) => value !== "OrderedCollectionPage")
+
+const activityPubPersonRequiredFieldsArbitrary = fc.record({
+  "@context": activityPubActorContextArbitrary,
+  type: fc.constant("Person"),
+  id: schemaStringArbitrary,
+  name: schemaStringArbitrary,
+  preferredUsername: schemaStringArbitrary,
+  summary: schemaStringArbitrary,
+  inbox: schemaStringArbitrary,
+  outbox: schemaStringArbitrary,
+  followers: schemaStringArbitrary,
+  following: schemaStringArbitrary
+})
+
+const activityPubPersonMissingRequiredFieldsArbitrary = fc.record({
+  "@context": activityPubActorContextArbitrary,
+  type: fc.constant("Person"),
+  id: schemaStringArbitrary
+})
+
+const activityPubOrderedCollectionRequiredFieldsArbitrary = fc.record({
+  "@context": activityPubContextArbitrary,
+  type: fc.constant("OrderedCollection"),
+  id: schemaStringArbitrary,
+  totalItems: fc.integer({ min: 0 })
+})
+
+const activityPubOrderedCollectionMissingRequiredFieldsArbitrary = fc.record({
+  "@context": activityPubContextArbitrary,
+  type: fc.constant("OrderedCollection"),
+  id: schemaStringArbitrary
+})
+
+const activityPubOrderedCollectionPageRequiredFieldsArbitrary = fc.record({
+  "@context": activityPubContextArbitrary,
+  type: fc.constant("OrderedCollectionPage"),
+  id: schemaStringArbitrary,
+  totalItems: fc.integer({ min: 0 }),
+  partOf: schemaStringArbitrary,
+  orderedItems: fc.array(fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null)))
+})
+
+const activityPubOrderedCollectionPageMissingRequiredFieldsArbitrary = fc.record({
+  "@context": activityPubContextArbitrary,
+  type: fc.constant("OrderedCollectionPage"),
+  id: schemaStringArbitrary,
+  totalItems: fc.integer({ min: 0 }),
+  orderedItems: fc.array(fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null)))
+})
 
 const mastodonActorFixture = {
   "@context": [
@@ -229,5 +299,122 @@ describe("ActivityPub and ForgeFed schema parity", () => {
       expect(Either.isLeft(personResult)).toBe(true)
       expect(Either.isLeft(collectionResult)).toBe(true)
       expect(Either.isLeft(pageResult)).toBe(true)
+    }))
+
+  it.effect("accepts ActivityPub Person objects with required fields and correct type", () =>
+    Effect.sync(() => {
+      fc.assert(
+        fc.property(activityPubPersonRequiredFieldsArbitrary, (person) => {
+          expect(Either.isRight(Schema.decodeUnknownEither(ActivityPubPersonSchema)(person))).toBe(
+            true
+          )
+        })
+      )
+    }))
+
+  it.effect("rejects ActivityPub Person objects with wrong type", () =>
+    Effect.sync(() => {
+      fc.assert(
+        fc.property(activityPubPersonRequiredFieldsArbitrary, nonPersonTypeArbitrary, (person, type) => {
+          expect(
+            Either.isLeft(Schema.decodeUnknownEither(ActivityPubPersonSchema)({ ...person, type }))
+          ).toBe(true)
+        })
+      )
+    }))
+
+  it.effect("rejects ActivityPub Person objects missing required fields", () =>
+    Effect.sync(() => {
+      fc.assert(
+        fc.property(activityPubPersonMissingRequiredFieldsArbitrary, (person) => {
+          expect(Either.isLeft(Schema.decodeUnknownEither(ActivityPubPersonSchema)(person))).toBe(
+            true
+          )
+        })
+      )
+    }))
+
+  it.effect("accepts ActivityPub OrderedCollection objects with required fields and correct type", () =>
+    Effect.sync(() => {
+      fc.assert(
+        fc.property(activityPubOrderedCollectionRequiredFieldsArbitrary, (collection) => {
+          expect(
+            Either.isRight(Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)(collection))
+          ).toBe(true)
+        })
+      )
+    }))
+
+  it.effect("rejects ActivityPub OrderedCollection objects with wrong type", () =>
+    Effect.sync(() => {
+      fc.assert(
+        fc.property(
+          activityPubOrderedCollectionRequiredFieldsArbitrary,
+          nonOrderedCollectionTypeArbitrary,
+          (collection, type) => {
+            expect(
+              Either.isLeft(
+                Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)({
+                  ...collection,
+                  type
+                })
+              )
+            ).toBe(true)
+          }
+        )
+      )
+    }))
+
+  it.effect("rejects ActivityPub OrderedCollection objects missing required fields", () =>
+    Effect.sync(() => {
+      fc.assert(
+        fc.property(activityPubOrderedCollectionMissingRequiredFieldsArbitrary, (collection) => {
+          expect(
+            Either.isLeft(Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)(collection))
+          ).toBe(true)
+        })
+      )
+    }))
+
+  it.effect("accepts ActivityPub OrderedCollectionPage objects with required fields and correct type", () =>
+    Effect.sync(() => {
+      fc.assert(
+        fc.property(activityPubOrderedCollectionPageRequiredFieldsArbitrary, (page) => {
+          expect(
+            Either.isRight(Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)(page))
+          ).toBe(true)
+        })
+      )
+    }))
+
+  it.effect("rejects ActivityPub OrderedCollectionPage objects with wrong type", () =>
+    Effect.sync(() => {
+      fc.assert(
+        fc.property(
+          activityPubOrderedCollectionPageRequiredFieldsArbitrary,
+          nonOrderedCollectionPageTypeArbitrary,
+          (page, type) => {
+            expect(
+              Either.isLeft(
+                Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)({
+                  ...page,
+                  type
+                })
+              )
+            ).toBe(true)
+          }
+        )
+      )
+    }))
+
+  it.effect("rejects ActivityPub OrderedCollectionPage objects missing required fields", () =>
+    Effect.sync(() => {
+      fc.assert(
+        fc.property(activityPubOrderedCollectionPageMissingRequiredFieldsArbitrary, (page) => {
+          expect(
+            Either.isLeft(Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)(page))
+          ).toBe(true)
+        })
+      )
     }))
 })

--- a/packages/api/tests/activitypub-schema-parity.test.ts
+++ b/packages/api/tests/activitypub-schema-parity.test.ts
@@ -301,6 +301,75 @@ describe("ActivityPub and ForgeFed schema parity", () => {
       expect(Either.isLeft(pageResult)).toBe(true)
     }))
 
+  it.effect("accepts structured ActivityPub Person actor extensions", () =>
+    Effect.sync(() => {
+      const result = Schema.decodeUnknownEither(ActivityPubPersonSchema)({
+        ...mastodonActorFixture,
+        icon: {
+          type: "Image",
+          mediaType: "image/png",
+          url: "https://mastodon.social/system/accounts/avatars/icon.png"
+        },
+        image: {
+          type: "Image",
+          mediaType: "image/jpeg",
+          url: "https://mastodon.social/system/accounts/headers/header.jpeg"
+        },
+        tag: [
+          {
+            type: "Hashtag",
+            name: "#activitypub",
+            href: "https://mastodon.social/tags/activitypub"
+          },
+          {
+            type: "Emoji",
+            id: "https://mastodon.social/emojis/party",
+            name: ":party:",
+            updated: "2026-05-21T00:00:00Z",
+            icon: {
+              type: "Image",
+              mediaType: "image/png",
+              url: "https://mastodon.social/system/custom_emojis/images/party.png"
+            }
+          }
+        ],
+        attachment: [
+          {
+            type: "PropertyValue",
+            name: "Website",
+            value: "<a href=\"https://example.com\">https://example.com</a>"
+          }
+        ]
+      })
+
+      expect(Either.isRight(result)).toBe(true)
+    }))
+
+  it.effect("rejects structurally invalid ActivityPub Person actor extensions", () =>
+    Effect.sync(() => {
+      const invalidActors = [
+        { ...mastodonActorFixture, icon: {} },
+        { ...mastodonActorFixture, image: { type: "Image" } },
+        { ...mastodonActorFixture, tag: [{}] },
+        {
+          ...mastodonActorFixture,
+          tag: [{ type: "Emoji", id: "https://mastodon.social/emojis/party", name: ":party:" }]
+        },
+        { ...mastodonActorFixture, attachment: [{}] },
+        {
+          ...mastodonActorFixture,
+          attachment: [{ type: "Note", name: "Website", value: "https://example.com" }]
+        },
+        { ...mastodonActorFixture, interactionPolicy: {} },
+        { ...mastodonActorFixture, interactionPolicy: { arbitrary: true } },
+        { ...mastodonActorFixture, interactionPolicy: { canFeature: { arbitrary: true } } }
+      ]
+
+      invalidActors.forEach((actor) => {
+        expect(Either.isLeft(Schema.decodeUnknownEither(ActivityPubPersonSchema)(actor))).toBe(true)
+      })
+    }))
+
   it.effect("accepts ActivityPub Person objects with required fields and correct type", () =>
     Effect.sync(() => {
       fc.assert(

--- a/packages/api/tests/activitypub-schema-parity.test.ts
+++ b/packages/api/tests/activitypub-schema-parity.test.ts
@@ -5,14 +5,24 @@ import fc from "fast-check"
 import {
   ActivityPubOrderedCollectionPageSchema,
   ActivityPubOrderedCollectionSchema,
-  ActivityPubPersonSchema
+  ActivityPubPersonSchema,
+  exactActivityPubParseOptions
 } from "../src/api/schema.js"
 
-const expectDecodedCoversFixtureKeys = (decoded: object, fixture: object): void => {
-  expect(Object.keys(decoded)).toEqual(expect.arrayContaining(Object.keys(fixture)))
+const decodeActivityPubEither = <A, I>(schema: Schema.Schema<A, I, never>, value: unknown) =>
+  Schema.decodeUnknownEither(schema, exactActivityPubParseOptions)(value)
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const expectDecodedMatchesFixtureKeys = (decoded: object, fixture: object): void => {
+  expect(Object.keys(decoded).sort()).toEqual(Object.keys(fixture).sort())
 }
 
-const activityPubContextArbitrary = fc.constant("https://www.w3.org/ns/activitystreams")
+const activityForgeFedContextArbitrary = fc.constant([
+  "https://www.w3.org/ns/activitystreams",
+  "https://forgefed.org/ns"
+] as const)
 
 const activityPubActorContextArbitrary = fc.constant([
   "https://www.w3.org/ns/activitystreams",
@@ -32,6 +42,16 @@ const nonOrderedCollectionPageTypeArbitrary = fc
   .string()
   .filter((value) => value !== "OrderedCollectionPage")
 
+const activityPubPublicKeyArbitrary = fc.record({
+  id: schemaStringArbitrary,
+  owner: schemaStringArbitrary,
+  publicKeyPem: schemaStringArbitrary
+})
+
+const activityPubEndpointsArbitrary = fc.record({
+  sharedInbox: schemaStringArbitrary
+})
+
 const activityPubPersonRequiredFieldsArbitrary = fc.record({
   "@context": activityPubActorContextArbitrary,
   type: fc.constant("Person"),
@@ -42,7 +62,10 @@ const activityPubPersonRequiredFieldsArbitrary = fc.record({
   inbox: schemaStringArbitrary,
   outbox: schemaStringArbitrary,
   followers: schemaStringArbitrary,
-  following: schemaStringArbitrary
+  following: schemaStringArbitrary,
+  liked: schemaStringArbitrary,
+  publicKey: activityPubPublicKeyArbitrary,
+  endpoints: activityPubEndpointsArbitrary
 })
 
 const activityPubPersonMissingRequiredFieldsArbitrary = fc.record({
@@ -52,20 +75,22 @@ const activityPubPersonMissingRequiredFieldsArbitrary = fc.record({
 })
 
 const activityPubOrderedCollectionRequiredFieldsArbitrary = fc.record({
-  "@context": activityPubContextArbitrary,
+  "@context": activityForgeFedContextArbitrary,
+  type: fc.constant("OrderedCollection"),
+  id: schemaStringArbitrary,
+  totalItems: fc.integer({ min: 0 }),
+  orderedItems: fc.array(fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null)))
+})
+
+const activityPubOrderedCollectionMissingRequiredFieldsArbitrary = fc.record({
+  "@context": activityForgeFedContextArbitrary,
   type: fc.constant("OrderedCollection"),
   id: schemaStringArbitrary,
   totalItems: fc.integer({ min: 0 })
 })
 
-const activityPubOrderedCollectionMissingRequiredFieldsArbitrary = fc.record({
-  "@context": activityPubContextArbitrary,
-  type: fc.constant("OrderedCollection"),
-  id: schemaStringArbitrary
-})
-
 const activityPubOrderedCollectionPageRequiredFieldsArbitrary = fc.record({
-  "@context": activityPubContextArbitrary,
+  "@context": activityForgeFedContextArbitrary,
   type: fc.constant("OrderedCollectionPage"),
   id: schemaStringArbitrary,
   totalItems: fc.integer({ min: 0 }),
@@ -74,70 +99,74 @@ const activityPubOrderedCollectionPageRequiredFieldsArbitrary = fc.record({
 })
 
 const activityPubOrderedCollectionPageMissingRequiredFieldsArbitrary = fc.record({
-  "@context": activityPubContextArbitrary,
+  "@context": activityForgeFedContextArbitrary,
   type: fc.constant("OrderedCollectionPage"),
   id: schemaStringArbitrary,
   totalItems: fc.integer({ min: 0 }),
   orderedItems: fc.array(fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null)))
 })
 
+const mastodonActorContextExtensionsFixture = {
+  manuallyApprovesFollowers: "as:manuallyApprovesFollowers",
+  toot: "http://joinmastodon.org/ns#",
+  featured: {
+    "@id": "toot:featured",
+    "@type": "@id"
+  },
+  featuredTags: {
+    "@id": "toot:featuredTags",
+    "@type": "@id"
+  },
+  alsoKnownAs: {
+    "@id": "as:alsoKnownAs",
+    "@type": "@id"
+  },
+  movedTo: {
+    "@id": "as:movedTo",
+    "@type": "@id"
+  },
+  schema: "http://schema.org/#",
+  PropertyValue: "schema:PropertyValue",
+  value: "schema:value",
+  discoverable: "toot:discoverable",
+  suspended: "toot:suspended",
+  memorial: "toot:memorial",
+  indexable: "toot:indexable",
+  attributionDomains: {
+    "@id": "toot:attributionDomains",
+    "@type": "@id"
+  },
+  showFeatured: "toot:showFeatured",
+  showMedia: "toot:showMedia",
+  showRepliesInMedia: "toot:showRepliesInMedia",
+  gts: "https://gotosocial.org/ns#",
+  interactionPolicy: {
+    "@id": "gts:interactionPolicy",
+    "@type": "@id"
+  },
+  canQuote: {
+    "@id": "gts:canQuote",
+    "@type": "@id"
+  },
+  automaticApproval: {
+    "@id": "gts:automaticApproval",
+    "@type": "@id"
+  },
+  manualApproval: {
+    "@id": "gts:manualApproval",
+    "@type": "@id"
+  }
+}
+
+const mastodonActorContextFixture = [
+  "https://www.w3.org/ns/activitystreams",
+  "https://w3id.org/security/v1",
+  "https://purl.archive.org/socialweb/webfinger",
+  mastodonActorContextExtensionsFixture
+] as const
+
 const mastodonActorFixture = {
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/security/v1",
-    "https://purl.archive.org/socialweb/webfinger",
-    {
-      manuallyApprovesFollowers: "as:manuallyApprovesFollowers",
-      toot: "http://joinmastodon.org/ns#",
-      featured: {
-        "@id": "toot:featured",
-        "@type": "@id"
-      },
-      featuredTags: {
-        "@id": "toot:featuredTags",
-        "@type": "@id"
-      },
-      alsoKnownAs: {
-        "@id": "as:alsoKnownAs",
-        "@type": "@id"
-      },
-      movedTo: {
-        "@id": "as:movedTo",
-        "@type": "@id"
-      },
-      schema: "http://schema.org/#",
-      PropertyValue: "schema:PropertyValue",
-      value: "schema:value",
-      discoverable: "toot:discoverable",
-      suspended: "toot:suspended",
-      memorial: "toot:memorial",
-      indexable: "toot:indexable",
-      attributionDomains: {
-        "@id": "toot:attributionDomains",
-        "@type": "@id"
-      },
-      showFeatured: "toot:showFeatured",
-      showMedia: "toot:showMedia",
-      showRepliesInMedia: "toot:showRepliesInMedia",
-      gts: "https://gotosocial.org/ns#",
-      interactionPolicy: {
-        "@id": "gts:interactionPolicy",
-        "@type": "@id"
-      },
-      canQuote: {
-        "@id": "gts:canQuote",
-        "@type": "@id"
-      },
-      automaticApproval: {
-        "@id": "gts:automaticApproval",
-        "@type": "@id"
-      },
-      manualApproval: {
-        "@id": "gts:manualApproval",
-        "@type": "@id"
-      }
-    }
-  ],
+  "@context": mastodonActorContextFixture,
   id: "https://mastodon.social/users/GordonFreeman",
   webfinger: "GordonFreeman@mastodon.social",
   type: "Person",
@@ -195,42 +224,54 @@ const mastodonFollowersPageFixture = {
   next: "https://mastodon.social/users/nixCraft/followers?max_id=123&page=1",
   orderedItems: [
     "https://mastodon.social/users/GordonFreeman",
-    {
-      id: "https://mastodon.social/users/example",
-      type: "Person",
-      following: "https://mastodon.social/users/example/following",
-      followers: "https://mastodon.social/users/example/followers",
-      inbox: "https://mastodon.social/users/example/inbox",
-      outbox: "https://mastodon.social/users/example/outbox",
-      preferredUsername: "example",
-      publicKey: {
-        id: "https://mastodon.social/users/example#main-key",
-        owner: "https://mastodon.social/users/example",
-        publicKeyPem:
-          "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtest\n-----END PUBLIC KEY-----\n"
-      }
-    }
+    "https://mastodon.social/users/example"
   ]
 }
+
+const mastodonActorWithContextExtensions = (
+  extensions: unknown
+): object => ({
+  ...mastodonActorFixture,
+  "@context": [
+    "https://www.w3.org/ns/activitystreams",
+    "https://w3id.org/security/v1",
+    "https://purl.archive.org/socialweb/webfinger",
+    extensions
+  ]
+})
 
 describe("ActivityPub and ForgeFed schema parity", () => {
   it.effect("decodes a Mastodon actor Person fixture", () =>
     Effect.sync(() => {
-      const result = Schema.decodeUnknownEither(ActivityPubPersonSchema)(mastodonActorFixture)
+      const result = decodeActivityPubEither(ActivityPubPersonSchema, mastodonActorFixture)
 
       Either.match(result, {
         onLeft: (error) => {
           throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
         },
         onRight: (decoded) => {
-          expectDecodedCoversFixtureKeys(decoded, mastodonActorFixture)
+          expectDecodedMatchesFixtureKeys(decoded, mastodonActorFixture)
+          const decodedContext = Reflect.get(decoded, "@context")
+          expect(Array.isArray(decodedContext)).toBe(true)
+          if (!Array.isArray(decodedContext)) {
+            throw new Error("Decoded Mastodon actor context is not an array.")
+          }
+          const decodedExtensions = decodedContext[3]
+          expect(isRecord(decodedExtensions)).toBe(true)
+          if (!isRecord(decodedExtensions)) {
+            throw new Error("Decoded Mastodon actor context extensions are not an object.")
+          }
+          expect(Object.keys(decodedExtensions).sort()).toEqual(
+            Object.keys(mastodonActorContextExtensionsFixture).sort()
+          )
         }
       })
     }))
 
   it.effect("decodes a Mastodon followers OrderedCollection fixture", () =>
     Effect.sync(() => {
-      const result = Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)(
+      const result = decodeActivityPubEither(
+        ActivityPubOrderedCollectionSchema,
         mastodonFollowersCollectionFixture
       )
 
@@ -239,14 +280,15 @@ describe("ActivityPub and ForgeFed schema parity", () => {
           throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
         },
         onRight: (decoded) => {
-          expectDecodedCoversFixtureKeys(decoded, mastodonFollowersCollectionFixture)
+          expectDecodedMatchesFixtureKeys(decoded, mastodonFollowersCollectionFixture)
         }
       })
     }))
 
   it.effect("decodes a Mastodon followers OrderedCollectionPage fixture", () =>
     Effect.sync(() => {
-      const result = Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)(
+      const result = decodeActivityPubEither(
+        ActivityPubOrderedCollectionPageSchema,
         mastodonFollowersPageFixture
       )
 
@@ -255,22 +297,22 @@ describe("ActivityPub and ForgeFed schema parity", () => {
           throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
         },
         onRight: (decoded) => {
-          expectDecodedCoversFixtureKeys(decoded, mastodonFollowersPageFixture)
+          expectDecodedMatchesFixtureKeys(decoded, mastodonFollowersPageFixture)
         }
       })
     }))
 
   it.effect("rejects ActivityPub objects with wrong literal types", () =>
     Effect.sync(() => {
-      const personResult = Schema.decodeUnknownEither(ActivityPubPersonSchema)({
+      const personResult = decodeActivityPubEither(ActivityPubPersonSchema, {
         ...mastodonActorFixture,
         type: "Service"
       })
-      const collectionResult = Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)({
+      const collectionResult = decodeActivityPubEither(ActivityPubOrderedCollectionSchema, {
         ...mastodonFollowersCollectionFixture,
         type: "Collection"
       })
-      const pageResult = Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)({
+      const pageResult = decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, {
         ...mastodonFollowersPageFixture,
         type: "OrderedCollection"
       })
@@ -282,15 +324,15 @@ describe("ActivityPub and ForgeFed schema parity", () => {
 
   it.effect("rejects ActivityPub objects missing required fields", () =>
     Effect.sync(() => {
-      const personResult = Schema.decodeUnknownEither(ActivityPubPersonSchema)({
+      const personResult = decodeActivityPubEither(ActivityPubPersonSchema, {
         type: "Person",
         id: "https://mastodon.social/users/missing"
       })
-      const collectionResult = Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)({
+      const collectionResult = decodeActivityPubEither(ActivityPubOrderedCollectionSchema, {
         type: "OrderedCollection",
         id: "https://mastodon.social/users/nixCraft/followers"
       })
-      const pageResult = Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)({
+      const pageResult = decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, {
         type: "OrderedCollectionPage",
         id: "https://mastodon.social/users/nixCraft/followers?page=1",
         orderedItems: []
@@ -301,20 +343,10 @@ describe("ActivityPub and ForgeFed schema parity", () => {
       expect(Either.isLeft(pageResult)).toBe(true)
     }))
 
-  it.effect("accepts structured ActivityPub Person actor extensions", () =>
+  it.effect("accepts structured ActivityPub Person actor tag and attachment values", () =>
     Effect.sync(() => {
-      const result = Schema.decodeUnknownEither(ActivityPubPersonSchema)({
+      const result = decodeActivityPubEither(ActivityPubPersonSchema, {
         ...mastodonActorFixture,
-        icon: {
-          type: "Image",
-          mediaType: "image/png",
-          url: "https://mastodon.social/system/accounts/avatars/icon.png"
-        },
-        image: {
-          type: "Image",
-          mediaType: "image/jpeg",
-          url: "https://mastodon.social/system/accounts/headers/header.jpeg"
-        },
         tag: [
           {
             type: "Hashtag",
@@ -366,17 +398,56 @@ describe("ActivityPub and ForgeFed schema parity", () => {
       ]
 
       invalidActors.forEach((actor) => {
-        expect(Either.isLeft(Schema.decodeUnknownEither(ActivityPubPersonSchema)(actor))).toBe(true)
+        expect(Either.isLeft(decodeActivityPubEither(ActivityPubPersonSchema, actor))).toBe(true)
       })
+    }))
+
+  it.effect("rejects non-exact ActivityPub fixture shapes", () =>
+    Effect.sync(() => {
+      const contextWithoutManualApproval = Object.fromEntries(
+        Object.entries(mastodonActorContextExtensionsFixture).filter(
+          ([key]) => key !== "manualApproval"
+        )
+      )
+      const contextWithFeaturedWithoutType = {
+        ...mastodonActorContextExtensionsFixture,
+        featured: {
+          "@id": mastodonActorContextExtensionsFixture.featured["@id"]
+        }
+      }
+      const contextWithExtraKey = {
+        ...mastodonActorContextExtensionsFixture,
+        extraContextTerm: "toot:extraContextTerm"
+      }
+      const invalidDocuments = [
+        { ...mastodonActorFixture, extraField: "not in the issue fixture" },
+        mastodonActorWithContextExtensions(contextWithoutManualApproval),
+        mastodonActorWithContextExtensions(contextWithFeaturedWithoutType),
+        mastodonActorWithContextExtensions(contextWithExtraKey),
+        { ...mastodonFollowersCollectionFixture, orderedItems: [] },
+        { ...mastodonFollowersPageFixture, prev: "https://mastodon.social/users/nixCraft/followers" },
+        { ...mastodonFollowersPageFixture, orderedItems: ["ok", { id: "not-a-link" }] }
+      ]
+
+      invalidDocuments.slice(0, 4).forEach((document) => {
+        expect(Either.isLeft(decodeActivityPubEither(ActivityPubPersonSchema, document))).toBe(true)
+      })
+      expect(
+        Either.isLeft(decodeActivityPubEither(ActivityPubOrderedCollectionSchema, invalidDocuments[4]))
+      ).toBe(true)
+      expect(
+        Either.isLeft(decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, invalidDocuments[5]))
+      ).toBe(true)
+      expect(
+        Either.isLeft(decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, invalidDocuments[6]))
+      ).toBe(true)
     }))
 
   it.effect("accepts ActivityPub Person objects with required fields and correct type", () =>
     Effect.sync(() => {
       fc.assert(
         fc.property(activityPubPersonRequiredFieldsArbitrary, (person) => {
-          expect(Either.isRight(Schema.decodeUnknownEither(ActivityPubPersonSchema)(person))).toBe(
-            true
-          )
+          expect(Either.isRight(decodeActivityPubEither(ActivityPubPersonSchema, person))).toBe(true)
         })
       )
     }))
@@ -386,7 +457,7 @@ describe("ActivityPub and ForgeFed schema parity", () => {
       fc.assert(
         fc.property(activityPubPersonRequiredFieldsArbitrary, nonPersonTypeArbitrary, (person, type) => {
           expect(
-            Either.isLeft(Schema.decodeUnknownEither(ActivityPubPersonSchema)({ ...person, type }))
+            Either.isLeft(decodeActivityPubEither(ActivityPubPersonSchema, { ...person, type }))
           ).toBe(true)
         })
       )
@@ -396,9 +467,7 @@ describe("ActivityPub and ForgeFed schema parity", () => {
     Effect.sync(() => {
       fc.assert(
         fc.property(activityPubPersonMissingRequiredFieldsArbitrary, (person) => {
-          expect(Either.isLeft(Schema.decodeUnknownEither(ActivityPubPersonSchema)(person))).toBe(
-            true
-          )
+          expect(Either.isLeft(decodeActivityPubEither(ActivityPubPersonSchema, person))).toBe(true)
         })
       )
     }))
@@ -408,7 +477,7 @@ describe("ActivityPub and ForgeFed schema parity", () => {
       fc.assert(
         fc.property(activityPubOrderedCollectionRequiredFieldsArbitrary, (collection) => {
           expect(
-            Either.isRight(Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)(collection))
+            Either.isRight(decodeActivityPubEither(ActivityPubOrderedCollectionSchema, collection))
           ).toBe(true)
         })
       )
@@ -423,7 +492,7 @@ describe("ActivityPub and ForgeFed schema parity", () => {
           (collection, type) => {
             expect(
               Either.isLeft(
-                Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)({
+                decodeActivityPubEither(ActivityPubOrderedCollectionSchema, {
                   ...collection,
                   type
                 })
@@ -439,7 +508,7 @@ describe("ActivityPub and ForgeFed schema parity", () => {
       fc.assert(
         fc.property(activityPubOrderedCollectionMissingRequiredFieldsArbitrary, (collection) => {
           expect(
-            Either.isLeft(Schema.decodeUnknownEither(ActivityPubOrderedCollectionSchema)(collection))
+            Either.isLeft(decodeActivityPubEither(ActivityPubOrderedCollectionSchema, collection))
           ).toBe(true)
         })
       )
@@ -450,7 +519,7 @@ describe("ActivityPub and ForgeFed schema parity", () => {
       fc.assert(
         fc.property(activityPubOrderedCollectionPageRequiredFieldsArbitrary, (page) => {
           expect(
-            Either.isRight(Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)(page))
+            Either.isRight(decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, page))
           ).toBe(true)
         })
       )
@@ -465,7 +534,7 @@ describe("ActivityPub and ForgeFed schema parity", () => {
           (page, type) => {
             expect(
               Either.isLeft(
-                Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)({
+                decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, {
                   ...page,
                   type
                 })
@@ -481,7 +550,7 @@ describe("ActivityPub and ForgeFed schema parity", () => {
       fc.assert(
         fc.property(activityPubOrderedCollectionPageMissingRequiredFieldsArbitrary, (page) => {
           expect(
-            Either.isLeft(Schema.decodeUnknownEither(ActivityPubOrderedCollectionPageSchema)(page))
+            Either.isLeft(decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, page))
           ).toBe(true)
         })
       )

--- a/packages/api/tests/http-config.test.ts
+++ b/packages/api/tests/http-config.test.ts
@@ -132,6 +132,11 @@ const parseJsonObject = (raw: string): object | null => {
 const readField = (value: object | null, key: string): unknown =>
   value === null ? undefined : Reflect.get(value, key)
 
+const readNestedField = (value: object | null, parent: string, key: string): unknown => {
+  const nested = readField(value, parent)
+  return typeof nested === "object" && nested !== null ? Reflect.get(nested, key) : undefined
+}
+
 const decodeOrThrow = <A, I>(schema: Schema.Schema<A, I, never>, value: unknown): A =>
   Either.match(Schema.decodeUnknownEither(schema)(value), {
     onLeft: (error) => {
@@ -279,5 +284,17 @@ describe("api http config", () => {
       expect(readField(payload, "id")).toBe("https://public.example.test/federation/followers?page=1")
       expect(readField(payload, "partOf")).toBe("https://public.example.test/federation/followers")
       decodeOrThrow(ActivityPubOrderedCollectionPageSchema, payload)
+    }))
+
+  it.effect("rejects unsupported followers pages", () =>
+    Effect.gen(function*(_) {
+      yield* _(Effect.sync(() => clearFederationState()))
+
+      const document = yield* _(readFederationDocumentRoute("/federation/followers?page=2"))
+      const payload = parseJsonObject(document.body)
+
+      expect(document.status).toBe(400)
+      expect(readNestedField(payload, "error", "type")).toBe("ApiBadRequestError")
+      expect(readNestedField(payload, "error", "message")).toBe("Unsupported followers page: 2")
     }))
 })

--- a/packages/api/tests/http-config.test.ts
+++ b/packages/api/tests/http-config.test.ts
@@ -1,7 +1,7 @@
 import * as HttpApp from "@effect/platform/HttpApp"
 import * as HttpRouter from "@effect/platform/HttpRouter"
 import { describe, expect, it } from "@effect/vitest"
-import { Effect } from "effect"
+import { Effect, Either, ParseResult, Schema } from "effect"
 import fc from "fast-check"
 
 import {
@@ -9,6 +9,11 @@ import {
   actorJsonLdContext,
   federationJsonLdResponseContentType
 } from "../src/api/contracts.js"
+import {
+  ActivityPubOrderedCollectionPageSchema,
+  ActivityPubOrderedCollectionSchema,
+  ActivityPubPersonSchema
+} from "../src/api/schema.js"
 import {
   federationActorDocumentResponse,
   federationExchangeStatusResponse,
@@ -127,6 +132,22 @@ const parseJsonObject = (raw: string): object | null => {
 const readField = (value: object | null, key: string): unknown =>
   value === null ? undefined : Reflect.get(value, key)
 
+const decodeOrThrow = <A, I>(schema: Schema.Schema<A, I, never>, value: unknown): A =>
+  Either.match(Schema.decodeUnknownEither(schema)(value), {
+    onLeft: (error) => {
+      throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
+    },
+    onRight: (decoded) => decoded
+  })
+
+const decodeFederationDocument = (expectedType: string, payload: object | null): void => {
+  if (expectedType === "Person") {
+    decodeOrThrow(ActivityPubPersonSchema, payload)
+    return
+  }
+  decodeOrThrow(ActivityPubOrderedCollectionSchema, payload)
+}
+
 const federationDocumentCases: ReadonlyArray<{
   readonly path: string
   readonly expectedContext: unknown
@@ -240,6 +261,23 @@ describe("api http config", () => {
         expect(readField(payload, "@context")).toEqual(documentCase.expectedContext)
         expect(readField(payload, "type")).toBe(documentCase.expectedType)
         expect(readField(payload, "id")).toBe(documentCase.expectedId)
+        decodeFederationDocument(documentCase.expectedType, payload)
       }))
   }
+
+  it.effect("serves followers page as typed ActivityPub JSON-LD", () =>
+    Effect.gen(function*(_) {
+      yield* _(Effect.sync(() => clearFederationState()))
+
+      const document = yield* _(readFederationDocumentRoute("/federation/followers?page=1"))
+      const payload = parseJsonObject(document.body)
+
+      expect(document.status).toBe(200)
+      expect(document.contentType).toBe(federationJsonLdResponseContentType)
+      expect(readField(payload, "@context")).toEqual(activityForgeFedJsonLdContext)
+      expect(readField(payload, "type")).toBe("OrderedCollectionPage")
+      expect(readField(payload, "id")).toBe("https://public.example.test/federation/followers?page=1")
+      expect(readField(payload, "partOf")).toBe("https://public.example.test/federation/followers")
+      decodeOrThrow(ActivityPubOrderedCollectionPageSchema, payload)
+    }))
 })

--- a/packages/api/tests/http-config.test.ts
+++ b/packages/api/tests/http-config.test.ts
@@ -12,7 +12,8 @@ import {
 import {
   ActivityPubOrderedCollectionPageSchema,
   ActivityPubOrderedCollectionSchema,
-  ActivityPubPersonSchema
+  ActivityPubPersonSchema,
+  exactActivityPubParseOptions
 } from "../src/api/schema.js"
 import {
   federationActorDocumentResponse,
@@ -138,7 +139,7 @@ const readNestedField = (value: object | null, parent: string, key: string): unk
 }
 
 const decodeOrThrow = <A, I>(schema: Schema.Schema<A, I, never>, value: unknown): A =>
-  Either.match(Schema.decodeUnknownEither(schema)(value), {
+  Either.match(Schema.decodeUnknownEither(schema, exactActivityPubParseOptions)(value), {
     onLeft: (error) => {
       throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
     },


### PR DESCRIPTION
## Summary

- Adds runtime Effect Schema contracts for ActivityPub/ForgeFed documents used by federation.
- Derives federation TypeScript contract types from the schemas instead of unchecked duplicate aliases.
- Validates local JSON-LD actor/collection responses with strict exact decoding before serialization.
- Adds Mastodon-compatible `/federation/followers?page=1` as an exact `OrderedCollectionPage`.
- Tightens CodeRabbit review gaps: actor-specific JSON-LD contexts, JSON-safe boundary values, literal actor extension variants, typed `interactionPolicy`, exact excess-property rejection, property tests, and unsupported followers page rejection.

Closes #334.

## Proof: Exact 1:1 Type Correspondence

### Sources

- Issue #334 JSON: Mastodon `Person` actor example and requested `followers?page=1` shape.
- ForgeFed spec: `https://forgefed.org/spec/`.
- ActivityPub spec: `https://www.w3.org/TR/activitypub/`.
- ActivityStreams collection/page model: `https://www.w3.org/TR/activitystreams-core/`.
- Live Mastodon reference shapes checked during implementation:
  - `https://mastodon.social/users/GordonFreeman`
  - `https://mastodon.social/users/nixCraft/followers`
  - `https://mastodon.social/users/nixCraft/followers?page=1`

### Invariants

- **Schema-as-source-of-truth:** `ActivityPubPerson`, `ActivityPubOrderedCollection`, `ActivityPubOrderedCollectionPage`, `ActivityPubFollowActivity`, `ForgeFedTicket`, and `ActivityPubPublicKey` are `Schema.Schema.Type<typeof ...Schema>`. Therefore the public TypeScript type and runtime decoder are derived from the same schema contract.
- **Exact decode mode:** federation proof paths use `exactActivityPubParseOptions = { onExcessProperty: "error" }`. The HTTP response boundary and parity tests call `Schema.decodeUnknown(..., exactActivityPubParseOptions)`, so extra fields fail instead of being silently dropped.
- **No unchecked public schema values:** public ActivityPub/ForgeFed schema fields do not use `Schema.Unknown`; collection `orderedItems`, ticket `raw`, and ticket `attachment` are bounded by `JsonValue`.
- **Exact actor variants:** `ActivityPubPersonSchema` is a union of exact local actor shape and exact Mastodon issue actor shape. The local actor requires exactly the local protocol fields emitted by docker-git. The Mastodon actor requires exactly the issue fixture fields and rejects top-level extras such as `icon`, `image`, `devices`, `alsoKnownAs`, or any other field not present in the issue JSON.
- **Actor context exactness:** local actors decode only with `[ActivityStreams, Security, ForgeFed]`. Mastodon actors decode only with `[ActivityStreams, Security, SocialWeb WebFinger, extension-object]`; the extension object requires all 22 issue keys, requires mapping objects to contain `@id` and literal `@type: "@id"`, and rejects missing or extra context terms.
- **Actor extension shape proof:** `attachment` requires `{ type: "PropertyValue", name, value }`; `tag` is a discriminated union of `{ type: "Hashtag", name, href }` and `{ type: "Emoji", id, name, icon }`; nested image objects require `{ type: "Image", url }`. Empty actor extension objects and wrong literal variants decode to `Left`.
- **Interaction policy shape proof:** `interactionPolicy` accepts only Mastodon `canFeature`/`canQuote` blocks, and each block must contain `automaticApproval` or `manualApproval`. Empty policy objects, arbitrary policy keys, and arbitrary nested approval objects decode to `Left`.
- **Exact collection/page variants:** `ActivityPubOrderedCollectionSchema` is a union of exact local collection, exact local followers collection, and exact Mastodon followers collection. `ActivityPubOrderedCollectionPageSchema` is a union of exact local followers page and exact Mastodon followers page.
- **Mastodon followers page parity:** Mastodon `followers?page=1` decodes only as `@context: ActivityStreams`, `type: "OrderedCollectionPage"`, `id`, `totalItems`, `partOf`, `next`, and `orderedItems: string[]`. Embedded objects, `prev`, and other unlisted keys decode to `Left`.
- **Outbound validation:** for every local JSON-LD federation response `d` in `{ actor, outbox, followers, followers?page=1, following, liked }`, the HTTP handler returns `200` only after strict `Schema.decodeUnknown(S_d, exactActivityPubParseOptions)(d)` succeeds.
- **Literal and required-field proof:** generated property tests prove that correct literals decode and wrong literals or missing required fields are rejected for `Person`, `OrderedCollection`, and `OrderedCollectionPage`.
- **Exact fixture key proof:** Mastodon fixtures are decoded and tests assert `keys(decoded) = keys(fixture)`, so the schema is not proving success by silently dropping fields.
- **Negative exactness proof:** regression tests reject extra actor fields, missing required context extension keys, missing `@type` mappings, extra context terms, extra collection/page fields, and non-string Mastodon followers page items.
- **Followers pagination:** `/federation/followers` returns `OrderedCollection`; `/federation/followers?page=1` returns `OrderedCollectionPage` with `partOf = /federation/followers`; `/federation/followers?page=2` fails with typed `ApiBadRequestError` and HTTP 400.

### Theorem

Let `DecodeExact(S, x) = Schema.decodeUnknown(S, exactActivityPubParseOptions)(x)`.

For each supported federation document `d`, if the API returns `d` successfully, then there exists a schema `S_d` such that:

```text
HTTP_200(d) -> DecodeExact(S_d, d) = Right(decoded)
             and keys(decoded) = keys(d)
             and required_fields(S_d) = required_fields(d)
             and literal_type(d) = literal_type(S_d)
             and json_boundary_fields(d) subset JsonValue
```

For the issue/Mastodon actor fixture `f_actor`:

```text
DecodeExact(ActivityPubPersonSchema, f_actor) = Right(decoded)
and keys(decoded) = keys(f_actor)
and actor_context(f_actor) = [ActivityStreams, Security, SocialWebWebFinger, Exact22TermContext]
```

For the issue/Mastodon followers page fixture `f_page`:

```text
DecodeExact(ActivityPubOrderedCollectionPageSchema, f_page) = Right(decoded)
and keys(decoded) = keys(f_page)
and forall item in f_page.orderedItems: typeof item = string
```

For invalid payloads `x`:

```text
extra_field(x)
or missing_required_field(x)
or wrong_literal(x)
or missing_context_term(x)
or extra_context_term(x)
or arbitrary_interaction_policy(x)
or non_string_mastodon_followers_item(x)
  -> DecodeExact(S, x) = Left(error)
```

So the proof obligation is executable: it is enforced by the HTTP response path, schema-derived TypeScript contracts, exact fixture parity tests, property tests, actor-extension counterexample tests, collection/page exactness tests, and negative HTTP tests.

## Verification

Latest local verification on commit `a5bcc9b`:

```bash
bun run --cwd packages/api typecheck
bun run --cwd packages/api lint
bun run --cwd packages/api test
```

Full API test result: 24 test files, 177 tests passed.