### PR TITLE
fix(api): use Fedify for ActivityPub protocol documents

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -18,6 +18,8 @@
         "@effect/platform": "^0.96.1",
         "@effect/platform-node": "^0.106.0",
         "@effect/schema": "^0.75.5",
+        "@fedify/fedify": "^2.2.3",
+        "@fedify/vocab": "^2.2.3",
         "effect": "^3.21.2",
         "node-pty": "^1.1.0",
         "ws": "^8.20.1",
@@ -38,7 +40,7 @@
     },
     "packages/app": {
       "name": "@prover-coder-ai/docker-git",
-      "version": "1.1.27",
+      "version": "1.1.31",
       "bin": {
         "docker-git": "dist/src/docker-git/main.js",
       },
@@ -108,7 +110,7 @@
     },
     "packages/docker-git-session-sync": {
       "name": "@prover-coder-ai/docker-git-session-sync",
-      "version": "1.0.30",
+      "version": "1.0.34",
       "bin": {
         "docker-git-session-sync": "dist/docker-git-session-sync.js",
       },
@@ -236,6 +238,8 @@
 
     "@biomejs/cli-win32-x64": ["@biomejs/cli-win32-x64@2.4.15", "", { "os": "win32", "cpu": "x64" }, "sha512-zBrGq5mx5wwpnow4+2BxUvleDM+GNd4sLbPaMapsSLQLD0NGRCquqPBTgN+7XkUteHvj7M+BstuI8tmnV7+HgQ=="],
 
+    "@cfworker/json-schema": ["@cfworker/json-schema@4.1.1", "", {}, "sha512-gAmrUZSGtKc3AiBL71iNWxDsyUC5uMaKKGdvzYsBoTW/xi42JQHl7eKV2OYzCUqvc+D2RCcf7EXY2iCyFIk6og=="],
+
     "@changesets/apply-release-plan": ["@changesets/apply-release-plan@7.1.1", "", { "dependencies": { "@changesets/config": "^3.1.4", "@changesets/get-version-range-type": "^0.4.0", "@changesets/git": "^3.0.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "detect-indent": "^6.0.0", "fs-extra": "^7.0.1", "lodash.startcase": "^4.4.0", "outdent": "^0.5.0", "prettier": "^2.7.1", "resolve-from": "^5.0.0", "semver": "^7.5.3" } }, "sha512-9qPCm/rLx/xoOFXIHGB229+4GOL76S4MC+7tyOuTsR6+1jYlfFDQORdvwR5hDA6y4FL2BPt3qpbcQIS+dW85LA=="],
 
     "@changesets/assemble-release-plan": ["@changesets/assemble-release-plan@6.0.10", "", { "dependencies": { "@changesets/errors": "^0.2.0", "@changesets/get-dependents-graph": "^2.1.4", "@changesets/should-skip-package": "^0.1.2", "@changesets/types": "^6.1.0", "@manypkg/get-packages": "^1.1.3", "semver": "^7.5.3" } }, "sha512-rSDcqdJ9KbVyjpBIuCidhvZNIiVt1XaIYp73ycVQRIA5n/j6wQaEk0ChRLMUQ1vkxZe51PTQ9OIhbg6HQMW45A=="],
@@ -276,6 +280,8 @@
 
     "@colors/colors": ["@colors/colors@1.5.0", "", {}, "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ=="],
 
+    "@digitalbazaar/http-client": ["@digitalbazaar/http-client@4.3.0", "", { "dependencies": { "ky": "^1.14.2", "undici": "^6.23.0" } }, "sha512-6lMpxpt9BOmqHKGs9Xm6DP4LlZTBFer/ZjHvP3FcW3IaUWYIWC7dw5RFZnvw4fP57kAVcm1dp3IF+Y50qhBvAw=="],
+
     "@dprint/formatter": ["@dprint/formatter@0.4.1", "", {}, "sha512-IB/GXdlMOvi0UhQQ9mcY15Fxcrc2JPadmo6tqefCNV0bptFq7YBpggzpqYXldBXDa04CbKJ+rDwO2eNRPE2+/g=="],
 
     "@dprint/typescript": ["@dprint/typescript@0.91.8", "", {}, "sha512-tuKn4leCPItox1O4uunHcQF0QllDCvPWklnNQIh2PiWWVtRAGltJJnM4Cwj5AciplosD1Hiz7vAY3ew3crLb3A=="],
@@ -292,7 +298,7 @@
 
     "@effect/experimental": ["@effect/experimental@0.60.0", "", { "dependencies": { "uuid": "11.1.0" }, "peerDependencies": { "@effect/platform": "0.96.0", "effect": "3.21.0" } }, "sha512-i5zIg7Xup2KgHyqHlYtkgqSE1bNzCL0GbbTQxrpIzKF0q/ebknOk/ox8B/gIq2vImjoEE81h/oxU+6i1NH210g=="],
 
-    "@effect/language-service": ["@effect/language-service@0.86.1", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-jfUuFdtNPKRZ4ZSrgTnfMHPIVq8L9cM+YGEylQ1lhIgNY23ZvfdPg0cUlWESd4q9aGvOWSA8E79AS0qe3j4ROw=="],
+    "@effect/language-service": ["@effect/language-service@0.86.2", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-SaPln+8srOqDJDUwNTDmP5e+IYpEDr9+1epGznnsLqu8xvo6VnxyWARdeLpqvZJlb0Pgy9ca7ppqvvdWbHPXAg=="],
 
     "@effect/platform": ["@effect/platform@0.96.1", "", { "dependencies": { "find-my-way-ts": "^0.1.6", "msgpackr": "^1.11.10", "multipasta": "^0.2.7" }, "peerDependencies": { "effect": "^3.21.2" } }, "sha512-cjB1QZZYEP8JXCFNGvBLVi0T6YUBQTmOVEUA3SDbiQ6RUO+p6CE3eyD2vMWmrz5nE8yY5QSAuOV9v0boEcUv+A=="],
 
@@ -396,6 +402,16 @@
 
     "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.1", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-rZAP3aVgB9ds9KOeUSL+zZ21hPmo8dh6fnIFwRQj5EAZl9gzR7wxYbYXYysAM8CTqGmUGyp2S4kUdV17MnGuWQ=="],
 
+    "@fedify/fedify": ["@fedify/fedify@2.2.3", "", { "dependencies": { "@fedify/vocab": "2.2.3", "@fedify/vocab-runtime": "2.2.3", "@fedify/webfinger": "2.2.3", "@js-temporal/polyfill": "^0.5.1", "@logtape/logtape": "^2.0.5", "@opentelemetry/api": "^1.9.0", "@opentelemetry/core": "^2.5.0", "@opentelemetry/sdk-trace-base": "^2.5.0", "@opentelemetry/semantic-conventions": "^1.39.0", "byte-encodings": "^1.0.11", "es-toolkit": "1.43.0", "json-canon": "^1.0.1", "jsonld": "^9.0.0", "structured-field-values": "^2.0.4", "uri-template-router": "^1.0.0", "url-template": "^3.1.1", "urlpattern-polyfill": "^10.1.0" } }, "sha512-mEczGCZVZsgQQj8gCKZizOJsOuV3kOBpMVPJrhmOkE+RKh8XjnZwtzPwN2UWp4Yt2E9YsKg3fSxNJmJW/o4uDQ=="],
+
+    "@fedify/vocab": ["@fedify/vocab@2.2.3", "", { "dependencies": { "@fedify/vocab-runtime": "2.2.3", "@fedify/vocab-tools": "2.2.3", "@fedify/webfinger": "2.2.3", "@js-temporal/polyfill": "^0.5.1", "@logtape/logtape": "^2.0.5", "@multiformats/base-x": "^4.0.1", "@opentelemetry/api": "^1.9.0", "asn1js": "^3.0.6", "es-toolkit": "1.43.0", "jsonld": "^9.0.0", "pkijs": "^3.3.3" } }, "sha512-a5llEaCj3f9UGIY+t1PadGdfhMt0tY1TnpMTtx2Ulw+U8ONKAbRTz9Wnq2QWAF7Yp7JOqyy/EluZ2w/AIUNSGw=="],
+
+    "@fedify/vocab-runtime": ["@fedify/vocab-runtime@2.2.3", "", { "dependencies": { "@js-temporal/polyfill": "^0.5.1", "@logtape/logtape": "^2.0.5", "@multiformats/base-x": "^4.0.1", "@opentelemetry/api": "^1.9.0", "asn1js": "^3.0.6", "byte-encodings": "^1.0.11", "jsonld": "^9.0.0", "pkijs": "^3.3.3" } }, "sha512-MDAW28KooWhj9z3HQY3nDhVJ15HkgD4TOCK8vHCoARy1Q4HmTUGXZZzUdGiSuefQkm5mW7VckImCDNj05dIAPA=="],
+
+    "@fedify/vocab-tools": ["@fedify/vocab-tools@2.2.3", "", { "dependencies": { "@cfworker/json-schema": "^4.1.1", "byte-encodings": "^1.0.11", "es-toolkit": "^1.39.10", "yaml": "^2.8.1" } }, "sha512-zmaRKeJk+7wC7kgiiQNX6PpGgNaQTwjEBCREqXdZuY0Zw2lYeoyzL3F8PEIttOUIxdBdBxGOC9/HE6AVMndN6Q=="],
+
+    "@fedify/webfinger": ["@fedify/webfinger@2.2.3", "", { "dependencies": { "@fedify/vocab-runtime": "2.2.3", "@logtape/logtape": "^2.0.5", "@opentelemetry/api": "^1.9.0", "es-toolkit": "1.43.0" } }, "sha512-WJQw0cKkSfK4IbdPc+z9ODspYDO+t0q5dIRo7eR/oO31yqVGjwLYJsDL0dlyXQ0WF/Q+Qrfw2fQOvTs9Xarc9g=="],
+
     "@gridland/bun": ["@gridland/bun@0.4.3", "", { "dependencies": { "@gridland/utils": "0.4.3", "react": "^19.0.0", "react-reconciler": "0.33.0", "yoga-layout": "^3.2.1" }, "optionalDependencies": { "@opentui/core-darwin-arm64": "0.1.86", "@opentui/core-darwin-x64": "0.1.86", "@opentui/core-linux-arm64": "0.1.86", "@opentui/core-linux-x64": "0.1.86" } }, "sha512-pNOK9ncUJKLDiR84E61qHFRW1SG6IrmZNuSRjSmWgzS4rzXhgCPUesQOKz0dBk7dk8c1qcilyV2kEvUD9f1QnA=="],
 
     "@gridland/utils": ["@gridland/utils@0.4.3", "", { "dependencies": { "react": "^19.0.0" } }, "sha512-FPBw1dPPWyFXpSG/ygsZExc6c0u35HnfXnRpZz+ZUDyezcVDaMIDpdbDlOccmLSt33qGVOTh+pEx9HuS0061vA=="],
@@ -430,6 +446,8 @@
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "3.1.2", "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
+    "@js-temporal/polyfill": ["@js-temporal/polyfill@0.5.1", "", { "dependencies": { "jsbi": "^4.3.0" } }, "sha512-hloP58zRVCRSpgDxmqCWJNlizAlUgJFqG2ypq79DCvyv9tHjRYMDOcPFjzfl/A1/YxDvRCZz8wvZvmapQnKwFQ=="],
+
     "@jscpd/badge-reporter": ["@jscpd/badge-reporter@4.2.3", "", { "dependencies": { "badgen": "^3.2.3", "colors": "^1.4.0", "fs-extra": "^11.2.0" } }, "sha512-yNvbwWl/NwogHT5XrHyqXgF9yVZeLWA2QOhGqYTopvgi7LsSbDumpOqOcJMHP9Z4RalhMfahh+dVXFSI7tMcaA=="],
 
     "@jscpd/core": ["@jscpd/core@4.2.3", "", { "dependencies": { "eventemitter3": "^5.0.1" } }, "sha512-VQ2gH+tiI51ty3PBRD4HClNNgyX/VH9cs0dcFKuywxDzLQ64jYp7vhJPcqnyiVX9tVEIAa12sucRHQP/VHwugA=="],
@@ -439,6 +457,8 @@
     "@jscpd/html-reporter": ["@jscpd/html-reporter@4.2.3", "", { "dependencies": { "colors": "1.4.0", "fs-extra": "^11.2.0", "pug": "^3.0.3" } }, "sha512-kp1pqJXCKwyRu5mJK5IvXdFQEDHWQDb7svLFlbVXGI0dVH1y1XNl8mrIrSoRw+0AySxhDkuSyIlQOSDC2GRwQg=="],
 
     "@jscpd/tokenizer": ["@jscpd/tokenizer@4.2.3", "", { "dependencies": { "@jscpd/core": "4.2.3", "spark-md5": "^3.0.2" } }, "sha512-RvjD7/hwqtcQC9MWOl31odTti6kGCFxZ77DKEhwyMn+r6oVEUFbXgcGvzn0GC/wuTl7f3j5MF9JNMeTneOFwYA=="],
+
+    "@logtape/logtape": ["@logtape/logtape@2.1.1", "", {}, "sha512-aULbCqUQGerfOsZ3CMvcKtueKzmdchluXYUd3bIHKmOIS93fx1ko0+hyRQ4flloGZ8EiyRPydZXiy8n1J/eAQA=="],
 
     "@manypkg/find-root": ["@manypkg/find-root@1.1.0", "", { "dependencies": { "@babel/runtime": "7.28.4", "@types/node": "12.20.55", "find-up": "4.1.0", "fs-extra": "8.1.0" } }, "sha512-mki5uBvhHzO8kYYix/WRy2WX8S3B5wdVSc9D6KcU5lQNglP2yt58/VfLuAK49glRXChosY8ap2oJ1qgma3GUVA=="],
 
@@ -456,13 +476,27 @@
 
     "@msgpackr-extract/msgpackr-extract-win32-x64": ["@msgpackr-extract/msgpackr-extract-win32-x64@3.0.3", "", { "os": "win32", "cpu": "x64" }, "sha512-x0fWaQtYp4E6sktbsdAqnehxDgEc/VwM7uLsRCYWaiGu0ykYdZPiS8zCWdnjHwyiumousxfBm4SO31eXqwEZhQ=="],
 
+    "@multiformats/base-x": ["@multiformats/base-x@4.0.1", "", {}, "sha512-eMk0b9ReBbV23xXU693TAIrLyeO5iTgBZGSJfpqriG8UkYvr/hC9u9pyMlAakDNHWmbhMZCDs6KQO0jzKD8OTw=="],
+
     "@napi-rs/wasm-runtime": ["@napi-rs/wasm-runtime@0.2.12", "", { "dependencies": { "@emnapi/core": "1.7.1", "@emnapi/runtime": "1.7.1", "@tybys/wasm-util": "0.10.1" } }, "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ=="],
+
+    "@noble/hashes": ["@noble/hashes@1.4.0", "", {}, "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg=="],
 
     "@nodelib/fs.scandir": ["@nodelib/fs.scandir@2.1.5", "", { "dependencies": { "@nodelib/fs.stat": "2.0.5", "run-parallel": "1.2.0" } }, "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g=="],
 
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "1.19.1" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
+
+    "@opentelemetry/core": ["@opentelemetry/core@2.7.1", "", { "dependencies": { "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-QAqIj32AtK6+pEVNG7EOVxHdE06RP+FM5qpiEJ4RtDcFIqKUZHYhl7/7UY5efhwmwNAg7j8QbJVBLxMerc0+gw=="],
+
+    "@opentelemetry/resources": ["@opentelemetry/resources@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-DeT6KKolmC4e/dRQvMQ/RwlnzhaqeiFOXY5ngoOPJ07GgVVKxZOg9EcrNZb5aTzUn+iCrJldAgOfQm1O/QfPAQ=="],
+
+    "@opentelemetry/sdk-trace-base": ["@opentelemetry/sdk-trace-base@2.7.1", "", { "dependencies": { "@opentelemetry/core": "2.7.1", "@opentelemetry/resources": "2.7.1", "@opentelemetry/semantic-conventions": "^1.29.0" }, "peerDependencies": { "@opentelemetry/api": ">=1.3.0 <1.10.0" } }, "sha512-NAYIlsF8MPUsKqJMiDQJTMPOmlbawC1Iz/omMLygZ1C9am8fTKYjTaI+OZM+WTY3t3Glo0wnOg/6/pac6RGPPw=="],
+
+    "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.41.1", "", {}, "sha512-/UhIkaZgPutTFmQ7RnIJGgDXZmtEJ7Dvi86xNTFWcnRxVRNk/aotsqDJYeEvDP+FSMB2SdW+pQzNMcWP0rwuNA=="],
 
     "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.86", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Zp7q64+d+Dcx6YrH3mRcnHq8EOBnrfc1RvjgSWLhpXr49hY6LzuhqpfZM57aGErPYlR+ff8QM6e5FUkFnDfyjw=="],
 
@@ -726,6 +760,8 @@
 
     "asap": ["asap@2.0.6", "", {}, "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="],
 
+    "asn1js": ["asn1js@3.0.10", "", { "dependencies": { "pvtsutils": "^1.3.6", "pvutils": "^1.1.5", "tslib": "^2.8.1" } }, "sha512-S2s3aOytiKdFRdulw2qPE51MzjzVOisppcVv7jVFR+Kw0kxwvFrDcYA0h7Ndqbmj0HkMIXYWaoj7fli8kgx1eg=="],
+
     "assert-never": ["assert-never@1.4.0", "", {}, "sha512-5oJg84os6NMQNl27T9LnZkvvqzvAnHu03ShCnoj6bsJwS7L8AO4lf+C/XjK/nvzEqQB744moC6V128RucQd1jA=="],
 
     "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
@@ -762,7 +798,11 @@
 
     "builtin-modules": ["builtin-modules@3.3.0", "", {}, "sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw=="],
 
+    "byte-encodings": ["byte-encodings@1.0.11", "", {}, "sha512-+/xR2+ySc2yKGtud3DGkGSH1DNwHfRVK0KTnMhoeH36/KwG+tHQ4d9B3jxJFq7dW27YcfudkywaYJRPA2dmxzg=="],
+
     "bytes": ["bytes@3.1.2", "", {}, "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="],
+
+    "bytestreamjs": ["bytestreamjs@2.0.1", "", {}, "sha512-U1Z/ob71V/bXfVABvNr/Kumf5VyeQRBEm6Txb0PQ6S7V5GpBM3w4Cbqz/xPDicR5tN0uvDifng8C+5qECeGwyQ=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "1.0.2", "es-define-property": "1.0.1", "get-intrinsic": "1.3.0", "set-function-length": "1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 
@@ -773,6 +813,8 @@
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
     "caniuse-lite": ["caniuse-lite@1.0.30001792", "", {}, "sha512-hVLMUZFgR4JJ6ACt1uEESvQN1/dBVqPAKY0hgrV70eN3391K6juAfTjKZLKvOMsx8PxA7gsY1/tLMMTcfFLLpw=="],
+
+    "canonicalize": ["canonicalize@2.1.0", "", { "bin": { "canonicalize": "bin/canonicalize.js" } }, "sha512-F705O3xrsUtgt98j7leetNhTWPe+5S72rlL5O4jA1pKqBVQ/dT1O1D6PFxmSXvc0SUOinWS57DKx0I3CHrXJHQ=="],
 
     "chai": ["chai@6.2.2", "", {}, "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg=="],
 
@@ -903,6 +945,8 @@
     "es-shim-unscopables": ["es-shim-unscopables@1.1.0", "", { "dependencies": { "hasown": "2.0.2" } }, "sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw=="],
 
     "es-to-primitive": ["es-to-primitive@1.3.0", "", { "dependencies": { "is-callable": "1.2.7", "is-date-object": "1.1.0", "is-symbol": "1.1.1" } }, "sha512-w+5mJ3GuFL+NjVtJlvydShqE1eN3h3PbI7/5LAsYJP/2qtuMXjfL2LpHSRqo4b4eSF5K/DH1JXKUAHSB2UW50g=="],
+
+    "es-toolkit": ["es-toolkit@1.43.0", "", {}, "sha512-SKCT8AsWvYzBBuUqMk4NPwFlSdqLpJwmy6AP322ERn8W2YLIB6JBXnwMI2Qsh2gfphT3q7EKAxKb23cvFHFwKA=="],
 
     "esbuild": ["esbuild@0.27.2", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.2", "@esbuild/android-arm": "0.27.2", "@esbuild/android-arm64": "0.27.2", "@esbuild/android-x64": "0.27.2", "@esbuild/darwin-arm64": "0.27.2", "@esbuild/darwin-x64": "0.27.2", "@esbuild/freebsd-arm64": "0.27.2", "@esbuild/freebsd-x64": "0.27.2", "@esbuild/linux-arm": "0.27.2", "@esbuild/linux-arm64": "0.27.2", "@esbuild/linux-ia32": "0.27.2", "@esbuild/linux-loong64": "0.27.2", "@esbuild/linux-mips64el": "0.27.2", "@esbuild/linux-ppc64": "0.27.2", "@esbuild/linux-riscv64": "0.27.2", "@esbuild/linux-s390x": "0.27.2", "@esbuild/linux-x64": "0.27.2", "@esbuild/netbsd-arm64": "0.27.2", "@esbuild/netbsd-x64": "0.27.2", "@esbuild/openbsd-arm64": "0.27.2", "@esbuild/openbsd-x64": "0.27.2", "@esbuild/openharmony-arm64": "0.27.2", "@esbuild/sunos-x64": "0.27.2", "@esbuild/win32-arm64": "0.27.2", "@esbuild/win32-ia32": "0.27.2", "@esbuild/win32-x64": "0.27.2" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-HyNQImnsOC7X9PMNaCIeAm4ISCQXs5a5YasTXVliKv4uuBo1dKrG0A+uQS8M5eXjVMnLg3WgXaKvprHlFJQffw=="],
 
@@ -1192,6 +1236,8 @@
 
     "js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
 
+    "jsbi": ["jsbi@4.3.2", "", {}, "sha512-9fqMSQbhJykSeii05nxKl4m6Eqn2P6rOlYiS+C5Dr/HPIU/7yZxu5qzbs40tgaFORiw2Amd0mirjxatXYMkIew=="],
+
     "jscpd": ["jscpd@4.2.3", "", { "dependencies": { "@jscpd/badge-reporter": "4.2.3", "@jscpd/core": "4.2.3", "@jscpd/finder": "4.2.3", "@jscpd/html-reporter": "4.2.3", "@jscpd/tokenizer": "4.2.3", "colors": "^1.4.0", "commander": "^5.0.0", "fs-extra": "^11.2.0", "jscpd-sarif-reporter": "4.2.3" }, "bin": { "jscpd": "bin/jscpd" } }, "sha512-/1BEga1E1cY56/sdQOzU/PFtnea+n1beqG8/Xx4HopG9c5rkUO8ptnu9En8Xf1ILGW6KSWidV4vLQTm2FGYvpw=="],
 
     "jscpd-sarif-reporter": ["jscpd-sarif-reporter@4.0.5", "", { "dependencies": { "colors": "1.4.0", "fs-extra": "11.3.2", "node-sarif-builder": "3.4.0" } }, "sha512-cD1MtUdpomUPM5C0YD0vKZmdj+Gyr0KD5Bk47yGMrPCtwtgsK+7v59OzBIUjYOL8AuxNAt6hvPFo0PH+PYJh0Q=="],
@@ -1199,6 +1245,8 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-canon": ["json-canon@1.0.1", "", {}, "sha512-PQcj4PFOTAQxE8PgoQ4KrM0DcKWZd7S3ELOON8rmysl9I8JuFMgxu1H9v+oZsTPjjkpeS3IHPwLjr7d+gKygnw=="],
 
     "json-parse-even-better-errors": ["json-parse-even-better-errors@2.3.1", "", {}, "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="],
 
@@ -1210,6 +1258,8 @@
 
     "jsonfile": ["jsonfile@4.0.0", "", { "optionalDependencies": { "graceful-fs": "4.2.11" } }, "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg=="],
 
+    "jsonld": ["jsonld@9.0.0", "", { "dependencies": { "@digitalbazaar/http-client": "^4.2.0", "canonicalize": "^2.1.0", "lru-cache": "^6.0.0", "rdf-canonize": "^5.0.0" } }, "sha512-pjMIdkXfC1T2wrX9B9i2uXhGdyCmgec3qgMht+TDj+S0qX3bjWMQUfL7NeqEhuRTi8G5ESzmL9uGlST7nzSEWg=="],
+
     "jstransformer": ["jstransformer@1.0.0", "", { "dependencies": { "is-promise": "2.2.2", "promise": "7.3.1" } }, "sha512-C9YK3Rf8q6VAPDCCU9fnqo3mAfOH6vUGnMcP4AQAYIEpWtfGLpwOTmZ+igtdK5y+VvI2n3CyYSzy4Qh34eq24A=="],
 
     "jsx-ast-utils-x": ["jsx-ast-utils-x@0.1.0", "", {}, "sha512-eQQBjBnsVtGacsG9uJNB8qOr3yA8rga4wAaGG1qRcBzSIvfhERLrWxMAM1hp5fcS6Abo8M4+bUBTekYR0qTPQw=="],
@@ -1217,6 +1267,8 @@
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kubernetes-types": ["kubernetes-types@1.30.0", "", {}, "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q=="],
+
+    "ky": ["ky@1.14.3", "", {}, "sha512-9zy9lkjac+TR1c2tG+mkNSVlyOpInnWdSMiue4F+kq8TwJSgv6o8jhLRg8Ho6SnZ9wOYUq/yozts9qQCfk7bIw=="],
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "1.2.1", "type-check": "0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
@@ -1256,7 +1308,7 @@
 
     "loop-controls": ["loop-controls@1.1.0", "", {}, "sha512-otnxF3ngIuLecg99p7On7nJF6ws1mT2kNOiGOPFykEHQfhJtdsjcQMxM4LEHsUi3LeMrm2Ic0hFdykJcG0N1YQ=="],
 
-    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "3.1.1" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+    "lru-cache": ["lru-cache@6.0.0", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
@@ -1400,6 +1452,8 @@
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
+    "pkijs": ["pkijs@3.4.0", "", { "dependencies": { "@noble/hashes": "1.4.0", "asn1js": "^3.0.6", "bytestreamjs": "^2.0.1", "pvtsutils": "^1.3.6", "pvutils": "^1.1.3", "tslib": "^2.8.1" } }, "sha512-emEcLuomt2j03vxD54giVB4SxTjnsqkU692xZOZXHDVoYyypEm+b3jpiTcc+Cf+myooc+/Ly0z01jqeNHVgJGw=="],
+
     "pluralize": ["pluralize@8.0.0", "", {}, "sha512-Nc3IT5yHzflTfbjgqWcCPpo7DaKy4FnpB0l/zCAW0Tc7jxAiuqSxHasntB3D7887LSrA93kDJ9IXovxJYxyLCA=="],
 
     "possible-typed-array-names": ["possible-typed-array-names@1.1.0", "", {}, "sha512-/+5VFTchJDoVj3bhoqi6UeymcD00DAwb1nJwamzPvHEszJ4FpF6SNNbUbOS8yI56qHzdV8eK0qEfOSiodkTdxg=="],
@@ -1446,9 +1500,15 @@
 
     "pure-rand": ["pure-rand@8.4.0", "", {}, "sha512-IoM8YF/jY0hiugFo/wOWqfmarlE6J0wc6fDK1PhftMk7MGhVZl88sZimmqBBFomLOCSmcCCpsfj7wXASCpvK9A=="],
 
+    "pvtsutils": ["pvtsutils@1.3.6", "", { "dependencies": { "tslib": "^2.8.1" } }, "sha512-PLgQXQ6H2FWCaeRak8vvk1GW462lMxB5s3Jm673N82zI4vqtVUPuZdffdZbPDFRoU8kAhItWFtPCWiPpp4/EDg=="],
+
+    "pvutils": ["pvutils@1.1.5", "", {}, "sha512-KTqnxsgGiQ6ZAzZCVlJH5eOjSnvlyEgx1m8bkRJfOhmGRqfo5KLvmAlACQkrjEtOQ4B7wF9TdSLIs9O90MX9xA=="],
+
     "quansync": ["quansync@0.2.11", "", {}, "sha512-AifT7QEbW9Nri4tAwR5M/uzpBuqfZf+zwaEM/QkzEjj7NBuFD2rBuy0K3dE+8wltbezDV7JMA0WfnCPYRSYbXA=="],
 
     "queue-microtask": ["queue-microtask@1.2.3", "", {}, "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="],
+
+    "rdf-canonize": ["rdf-canonize@5.0.0", "", { "dependencies": { "setimmediate": "^1.0.5" } }, "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w=="],
 
     "react": ["react@19.2.6", "", {}, "sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q=="],
 
@@ -1518,6 +1578,8 @@
 
     "set-proto": ["set-proto@1.0.0", "", { "dependencies": { "dunder-proto": "1.0.1", "es-errors": "1.3.0", "es-object-atoms": "1.1.1" } }, "sha512-RJRdvCo6IAnPdsvP/7m6bsQqNnn1FCBX5ZNtFL98MmFF/4xAIJTIg1YbHW5DC2W5SKZanrC6i4HsJqlajw/dZw=="],
 
+    "setimmediate": ["setimmediate@1.0.5", "", {}, "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="],
+
     "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
 
     "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
@@ -1585,6 +1647,8 @@
     "strip-indent": ["strip-indent@4.1.1", "", {}, "sha512-SlyRoSkdh1dYP0PzclLE7r0M9sgbFKKMFXpFRUMNuKhQSbC6VQIGzq3E0qsfvGJaUFJPGv6Ws1NZ/haTAjfbMA=="],
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
+
+    "structured-field-values": ["structured-field-values@2.0.4", "", {}, "sha512-5zpJXYLPwW3WYUD/D58tQjIBs10l3Yx64jZfcKGs/RH79E2t9Xm/b9+ydwdMNVSksnsIY+HR/2IlQmgo0AcTAg=="],
 
     "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
 
@@ -1654,6 +1718,12 @@
 
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "2.3.1" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
+    "uri-template-router": ["uri-template-router@1.0.0", "", {}, "sha512-WKcL9ZSIEhHE3f5P4Z47Tf0nWbcgV1ISb/OBuF8YKEYi0SQOyTLCzM6B/gAKFWZhRhqA+C/Ks8UXe2qU5W0FVg=="],
+
+    "url-template": ["url-template@3.1.1", "", {}, "sha512-4oszoaEKE/mQOtAmdMWqIRHmkxWkUZMnXFnjQ5i01CuRSK3uluxcH1MRVVVWmhlnzT1SCDfKxxficm2G37qzCA=="],
+
+    "urlpattern-polyfill": ["urlpattern-polyfill@10.1.0", "", {}, "sha512-IGjKp/o0NL3Bso1PymYURCJxMPNAf/ILOpendP9f5B6e1rTJgdgiOvgfoT8VxCAdY+Wisb9uhGaJJf3yZ2V9nw=="],
+
     "uuid": ["uuid@11.1.0", "", { "bin": { "uuid": "dist/esm/bin/uuid" } }, "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "3.2.0", "spdx-expression-parse": "3.0.1" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
@@ -1700,7 +1770,7 @@
 
     "xterm-addon-fit": ["xterm-addon-fit@0.8.0", "", { "peerDependencies": { "xterm": "5.3.0" } }, "sha512-yj3Np7XlvxxhYF/EJ7p3KHaMt6OdwQ+HDu573Vx1lRXsVxOcnVJs51RgjZOouIZOczTsskaS+CpXspK81/DLqw=="],
 
-    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+    "yallist": ["yallist@4.0.0", "", {}, "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="],
 
     "yaml": ["yaml@2.8.2", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-mplynKqc1C2hTVYxd0PU2xQAc22TI1vShAYGksCCfxbn/dFwnHTNi1bvYsBTkhdUNtGIf5xNOg938rrSSYvS9A=="],
 
@@ -1718,7 +1788,11 @@
 
     "@babel/helper-compilation-targets/browserslist": ["browserslist@4.28.0", "", { "dependencies": { "baseline-browser-mapping": "2.8.32", "caniuse-lite": "1.0.30001759", "electron-to-chromium": "1.5.263", "node-releases": "2.0.27", "update-browserslist-db": "1.1.4" }, "bin": { "browserslist": "cli.js" } }, "sha512-tbydkR/CxfMwelN0vwdP/pLkDwyAASZ+VfWm4EOwlB6SWhx1sYnWLqo8N5j0rAzPfzfRaxt0mM/4wPU/Su84RQ=="],
 
+    "@babel/helper-compilation-targets/lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "3.1.1" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
     "@babel/helper-compilation-targets/semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "@digitalbazaar/http-client/undici": ["undici@6.25.0", "", {}, "sha512-ZgpWDC5gmNiuY9CnLVXEH8rl50xhRCuLNA97fAUnKi8RRuV4E6KG31pDTsLVUKnohJE0I3XDrTeEydAXRw47xg=="],
 
     "@effect/experimental/@effect/platform": ["@effect/platform@0.96.0", "", { "dependencies": { "find-my-way-ts": "0.1.6", "msgpackr": "1.11.5", "multipasta": "0.2.7" }, "peerDependencies": { "effect": "3.21.0" } }, "sha512-U7PLhkVzg7zzrgFvyWATOzD6reL87KG/fcdOxgLWBQ/J5CCU6qdPAVG+0o6o+IxcsLoqGwxs+rFxaFzrdtDV1A=="],
 
@@ -1817,6 +1891,8 @@
     "@prover-coder-ai/dist-deps-prune/effect": ["effect@3.21.0", "", { "dependencies": { "@standard-schema/spec": "1.1.0", "fast-check": "3.23.2" } }, "sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ=="],
 
     "@prover-coder-ai/dist-deps-prune/typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "@prover-coder-ai/docker-git/@effect/language-service": ["@effect/language-service@0.86.1", "", { "bin": { "effect-language-service": "cli.js" } }, "sha512-jfUuFdtNPKRZ4ZSrgTnfMHPIVq8L9cM+YGEylQ1lhIgNY23ZvfdPg0cUlWESd4q9aGvOWSA8E79AS0qe3j4ROw=="],
 
     "@prover-coder-ai/eslint-plugin-suggest-members/@typescript-eslint/utils": ["@typescript-eslint/utils@8.57.2", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.57.2", "@typescript-eslint/types": "8.57.2", "@typescript-eslint/typescript-estree": "8.57.2" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.0.0" } }, "sha512-krRIbvPK1ju1WBKIefiX+bngPs+odIQUtR7kymzPfo1POVw3jlF+nLkmexdSSd4UCbDcQn+wMBATOOmpBbqgKg=="],
 
@@ -1951,6 +2027,8 @@
     "@babel/helper-compilation-targets/browserslist/node-releases": ["node-releases@2.0.27", "", {}, "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA=="],
 
     "@babel/helper-compilation-targets/browserslist/update-browserslist-db": ["update-browserslist-db@1.1.4", "", { "dependencies": { "escalade": "3.2.0", "picocolors": "1.1.1" }, "peerDependencies": { "browserslist": "4.28.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-q0SPT4xyU84saUX+tomz1WLkxUbuaJnR1xWt17M7fJtEJigJeWUNGUqrauFXsHnqev9y9JTRGwk13tFBuKby4A=="],
+
+    "@babel/helper-compilation-targets/lru-cache/yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
     "@effect/experimental/@effect/platform/msgpackr": ["msgpackr@1.11.5", "", { "optionalDependencies": { "msgpackr-extract": "3.0.3" } }, "sha512-UjkUHN0yqp9RWKy0Lplhh+wlpdt9oQBYgULZOiFhV3VclSF1JnSQWZ5r9gORQlNYaUKQoR8itv7g7z1xDDuACA=="],
 

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -82,6 +82,7 @@ Optional env:
 
 - `GET /health`
 - `POST /federation/inbox` (ForgeFed `Ticket` / `Offer(Ticket)`, ActivityPub `Accept` / `Reject`)
+- `GET /.well-known/webfinger` (Fedify WebFinger document for the local federation actor)
 - `GET /federation/issues`
 - `GET /federation/actor` (ActivityPub `Person`)
 - `GET /federation/outbox`
@@ -115,6 +116,14 @@ Optional env:
 ## Subscription workflow (ActivityPub Follow + ForgeFed issues)
 
 Exchange targets must be explicit. Use `https://exchange.lefine.pro`, an actor URL, or a handle like `code@exchange.lefine.pro`; the API resolves the code actor document, stores its `inbox/outbox/followers/publicKey`, sends `Follow`, and polls the stored `outbox`.
+
+Local ActivityPub documents are serialized with Fedify and use only the supported ActivityStreams and security JSON-LD contexts. Mastodon-specific extension contexts and keys such as `https://purl.archive.org/socialweb/webfinger`, `toot`, `featured`, `featuredTags`, `alsoKnownAs`, `movedTo`, and `interactionPolicy` are not emitted by docker-git.
+
+The local actor is discoverable through WebFinger:
+
+```bash
+./ctl request GET '/.well-known/webfinger?resource=acct:docker-git@social.provercoder.ai'
+```
 
 ```bash
 ./ctl request POST /federation/exchange/subscriptions '{

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -23,6 +23,8 @@
     "@effect/platform": "^0.96.1",
     "@effect/platform-node": "^0.106.0",
     "@effect/schema": "^0.75.5",
+    "@fedify/fedify": "^2.2.3",
+    "@fedify/vocab": "^2.2.3",
     "effect": "^3.21.2",
     "node-pty": "^1.1.0",
     "ws": "^8.20.1"

--- a/packages/api/src/api/activitypub-schema.ts
+++ b/packages/api/src/api/activitypub-schema.ts
@@ -1,20 +1,13 @@
 import * as Schema from "effect/Schema"
-import type * as SchemaAST from "effect/SchemaAST"
 
 import {
   activityStreamsJsonLdContext,
-  forgeFedJsonLdContext,
-  securityJsonLdContext,
-  socialWebWebfingerJsonLdContext
+  forgeFedJsonLdContext
 } from "./contracts.js"
 
 export type JsonPrimitive = boolean | number | string | null
 export type JsonValue = JsonPrimitive | JsonObject | ReadonlyArray<JsonValue>
 export type JsonObject = Readonly<{ [key: string]: JsonValue }>
-
-export const exactActivityPubParseOptions: SchemaAST.ParseOptions = {
-  onExcessProperty: "error"
-}
 
 export const JsonValueSchema: Schema.Schema<JsonValue> = Schema.suspend(() =>
   Schema.Union(
@@ -28,65 +21,10 @@ export const JsonValueSchema: Schema.Schema<JsonValue> = Schema.suspend(() =>
 )
 
 const OptionalString = Schema.optional(Schema.String)
-const JsonObjectSchema = Schema.Record({ key: Schema.String, value: JsonValueSchema })
-const JsonLdContextEntrySchema = Schema.Union(Schema.String, JsonObjectSchema)
-const JsonLdIdMappingSchema = Schema.Struct({
-  "@id": Schema.String,
-  "@type": Schema.Literal("@id")
-})
 
 export const ActivityForgeFedJsonLdContextSchema = Schema.Tuple(
   Schema.Literal(activityStreamsJsonLdContext),
   Schema.Literal(forgeFedJsonLdContext)
-)
-
-export const LocalActorJsonLdContextSchema = Schema.Tuple(
-  Schema.Literal(activityStreamsJsonLdContext),
-  Schema.Literal(securityJsonLdContext),
-  Schema.Literal(forgeFedJsonLdContext)
-)
-
-export const MastodonActorContextExtensionsSchema = Schema.Struct({
-  manuallyApprovesFollowers: Schema.String,
-  toot: Schema.String,
-  featured: JsonLdIdMappingSchema,
-  featuredTags: JsonLdIdMappingSchema,
-  alsoKnownAs: JsonLdIdMappingSchema,
-  movedTo: JsonLdIdMappingSchema,
-  schema: Schema.String,
-  PropertyValue: Schema.String,
-  value: Schema.String,
-  discoverable: Schema.String,
-  suspended: Schema.String,
-  memorial: Schema.String,
-  indexable: Schema.String,
-  attributionDomains: JsonLdIdMappingSchema,
-  showFeatured: Schema.String,
-  showMedia: Schema.String,
-  showRepliesInMedia: Schema.String,
-  gts: Schema.String,
-  interactionPolicy: JsonLdIdMappingSchema,
-  canQuote: JsonLdIdMappingSchema,
-  automaticApproval: JsonLdIdMappingSchema,
-  manualApproval: JsonLdIdMappingSchema
-})
-
-export const MastodonActorJsonLdContextSchema = Schema.Tuple(
-  Schema.Literal(activityStreamsJsonLdContext),
-  Schema.Literal(securityJsonLdContext),
-  Schema.Literal(socialWebWebfingerJsonLdContext),
-  MastodonActorContextExtensionsSchema
-)
-
-export const ActorJsonLdContextSchema = Schema.Union(
-  LocalActorJsonLdContextSchema,
-  MastodonActorJsonLdContextSchema
-)
-
-export const JsonLdContextSchema = Schema.Union(
-  Schema.String,
-  JsonObjectSchema,
-  Schema.Array(JsonLdContextEntrySchema)
 )
 
 export const ForgeFedTicketSourceSchema = Schema.Struct({
@@ -110,118 +48,6 @@ export const ForgeFedTicketSchema = Schema.Struct({
   raw: Schema.optional(JsonValueSchema)
 })
 
-export const ActivityPubPublicKeySchema = Schema.Struct({
-  id: Schema.String,
-  owner: Schema.String,
-  publicKeyPem: Schema.String
-})
-
-const ActivityPubEndpointsSchema = Schema.Struct({
-  sharedInbox: Schema.String
-})
-
-const ActivityPubImageSchema = Schema.Struct({
-  type: Schema.Literal("Image"),
-  mediaType: OptionalString,
-  url: Schema.String,
-  name: OptionalString
-})
-
-const ActivityPubActorAttachmentSchema = Schema.Struct({
-  type: Schema.Literal("PropertyValue"),
-  name: Schema.String,
-  value: Schema.String
-})
-
-const ActivityPubHashtagTagSchema = Schema.Struct({
-  type: Schema.Literal("Hashtag"),
-  name: Schema.String,
-  href: Schema.String
-})
-
-const ActivityPubEmojiTagSchema = Schema.Struct({
-  type: Schema.Literal("Emoji"),
-  id: Schema.String,
-  name: Schema.String,
-  icon: ActivityPubImageSchema,
-  updated: OptionalString
-})
-
-const ActivityPubActorTagSchema = Schema.Union(
-  ActivityPubHashtagTagSchema,
-  ActivityPubEmojiTagSchema
-)
-
-const ActivityPubInteractionApprovalSchema = Schema.Struct({
-  automaticApproval: Schema.optional(Schema.Array(Schema.String)),
-  manualApproval: Schema.optional(Schema.Array(Schema.String))
-}).pipe(
-  Schema.filter((approval) =>
-    approval.automaticApproval !== undefined ||
-    approval.manualApproval !== undefined)
-)
-
-const MastodonInteractionPolicySchema = Schema.Struct({
-  canFeature: Schema.optional(ActivityPubInteractionApprovalSchema),
-  canQuote: Schema.optional(ActivityPubInteractionApprovalSchema)
-}).pipe(
-  Schema.filter((policy) =>
-    policy.canFeature !== undefined ||
-    policy.canQuote !== undefined)
-)
-
-export const LocalActivityPubPersonSchema = Schema.Struct({
-  "@context": LocalActorJsonLdContextSchema,
-  type: Schema.Literal("Person"),
-  id: Schema.String,
-  name: Schema.String,
-  preferredUsername: Schema.String,
-  summary: Schema.String,
-  inbox: Schema.String,
-  outbox: Schema.String,
-  followers: Schema.String,
-  following: Schema.String,
-  liked: Schema.String,
-  publicKey: ActivityPubPublicKeySchema,
-  endpoints: ActivityPubEndpointsSchema
-})
-
-export const MastodonIssueActivityPubPersonSchema = Schema.Struct({
-  "@context": MastodonActorJsonLdContextSchema,
-  id: Schema.String,
-  webfinger: Schema.String,
-  type: Schema.Literal("Person"),
-  following: Schema.String,
-  followers: Schema.String,
-  inbox: Schema.String,
-  outbox: Schema.String,
-  featured: Schema.String,
-  featuredTags: Schema.String,
-  preferredUsername: Schema.String,
-  name: Schema.String,
-  summary: Schema.String,
-  url: Schema.String,
-  manuallyApprovesFollowers: Schema.Boolean,
-  discoverable: Schema.Boolean,
-  indexable: Schema.Boolean,
-  published: Schema.String,
-  memorial: Schema.Boolean,
-  showFeatured: Schema.Boolean,
-  showMedia: Schema.Boolean,
-  showRepliesInMedia: Schema.Boolean,
-  interactionPolicy: MastodonInteractionPolicySchema,
-  featuredCollections: Schema.String,
-  publicKey: ActivityPubPublicKeySchema,
-  tag: Schema.Array(ActivityPubActorTagSchema),
-  attachment: Schema.Array(ActivityPubActorAttachmentSchema),
-  endpoints: ActivityPubEndpointsSchema
-})
-
-export const ActivityPubPersonSchema = Schema.Union(
-  LocalActivityPubPersonSchema,
-  MastodonIssueActivityPubPersonSchema
-)
-
 export const ActivityPubFollowActivitySchema = Schema.Struct({
   "@context": ActivityForgeFedJsonLdContextSchema,
   id: Schema.String,
@@ -239,50 +65,3 @@ export const LocalActivityPubOrderedCollectionSchema = Schema.Struct({
   totalItems: Schema.Number,
   orderedItems: Schema.Array(JsonValueSchema)
 })
-
-export const LocalActivityPubFollowersCollectionSchema = Schema.Struct({
-  "@context": ActivityForgeFedJsonLdContextSchema,
-  type: Schema.Literal("OrderedCollection"),
-  id: Schema.String,
-  totalItems: Schema.Number,
-  first: Schema.String,
-  orderedItems: Schema.Array(JsonValueSchema)
-})
-
-export const MastodonFollowersOrderedCollectionSchema = Schema.Struct({
-  "@context": Schema.Literal(activityStreamsJsonLdContext),
-  id: Schema.String,
-  type: Schema.Literal("OrderedCollection"),
-  totalItems: Schema.Number,
-  first: Schema.String
-})
-
-export const ActivityPubOrderedCollectionSchema = Schema.Union(
-  LocalActivityPubOrderedCollectionSchema,
-  LocalActivityPubFollowersCollectionSchema,
-  MastodonFollowersOrderedCollectionSchema
-)
-
-export const LocalActivityPubOrderedCollectionPageSchema = Schema.Struct({
-  "@context": ActivityForgeFedJsonLdContextSchema,
-  type: Schema.Literal("OrderedCollectionPage"),
-  id: Schema.String,
-  totalItems: Schema.Number,
-  partOf: Schema.String,
-  orderedItems: Schema.Array(JsonValueSchema)
-})
-
-export const MastodonFollowersOrderedCollectionPageSchema = Schema.Struct({
-  "@context": Schema.Literal(activityStreamsJsonLdContext),
-  id: Schema.String,
-  type: Schema.Literal("OrderedCollectionPage"),
-  totalItems: Schema.Number,
-  partOf: Schema.String,
-  next: Schema.String,
-  orderedItems: Schema.Array(Schema.String)
-})
-
-export const ActivityPubOrderedCollectionPageSchema = Schema.Union(
-  LocalActivityPubOrderedCollectionPageSchema,
-  MastodonFollowersOrderedCollectionPageSchema
-)

--- a/packages/api/src/api/contracts.ts
+++ b/packages/api/src/api/contracts.ts
@@ -3,17 +3,9 @@ import type * as Schema from "effect/Schema"
 import type {
   ActivityForgeFedJsonLdContextSchema,
   ActivityPubFollowActivitySchema,
-  ActivityPubOrderedCollectionPageSchema,
-  ActivityPubOrderedCollectionSchema,
-  ActivityPubPersonSchema,
-  ActivityPubPublicKeySchema,
-  ActorJsonLdContextSchema,
   ForgeFedTicketSchema,
   ForgeFedTicketSourceSchema,
-  LocalActivityPubFollowersCollectionSchema,
-  LocalActivityPubOrderedCollectionPageSchema,
-  LocalActivityPubOrderedCollectionSchema,
-  LocalActivityPubPersonSchema
+  LocalActivityPubOrderedCollectionSchema
 } from "./activitypub-schema.js"
 
 export type ProjectStatus = "running" | "stopped" | "unknown"
@@ -560,15 +552,13 @@ export type ContainerTaskSnapshot = {
 export const activityStreamsJsonLdContext = "https://www.w3.org/ns/activitystreams" as const
 export const forgeFedJsonLdContext = "https://forgefed.org/ns" as const
 export const securityJsonLdContext = "https://w3id.org/security/v1" as const
-export const socialWebWebfingerJsonLdContext = "https://purl.archive.org/socialweb/webfinger" as const
 export const activityForgeFedJsonLdContext = [
   activityStreamsJsonLdContext,
   forgeFedJsonLdContext
 ] as const
 export const actorJsonLdContext = [
   activityStreamsJsonLdContext,
-  securityJsonLdContext,
-  forgeFedJsonLdContext
+  securityJsonLdContext
 ] as const
 export const federationJsonLdContentType =
   `application/ld+json; profile="${activityStreamsJsonLdContext}"` as const
@@ -576,7 +566,6 @@ export const federationJsonLdResponseContentType =
   `${federationJsonLdContentType}; charset=utf-8` as const
 
 export type ActivityForgeFedJsonLdContext = Schema.Schema.Type<typeof ActivityForgeFedJsonLdContextSchema>
-export type ActorJsonLdContext = Schema.Schema.Type<typeof ActorJsonLdContextSchema>
 
 export type ForgeFedTicket = Schema.Schema.Type<typeof ForgeFedTicketSchema>
 
@@ -622,22 +611,7 @@ export type FollowStatus = "pending" | "accepted" | "rejected"
 
 export type ActivityPubFollowActivity = Schema.Schema.Type<typeof ActivityPubFollowActivitySchema>
 
-export type ActivityPubPublicKey = Schema.Schema.Type<typeof ActivityPubPublicKeySchema>
-
-export type ActivityPubPerson = Schema.Schema.Type<typeof ActivityPubPersonSchema>
-
-export type LocalActivityPubPerson = Schema.Schema.Type<typeof LocalActivityPubPersonSchema>
-
-export type ActivityPubOrderedCollection = Schema.Schema.Type<typeof ActivityPubOrderedCollectionSchema>
-
-export type LocalActivityPubOrderedCollection =
-  | Schema.Schema.Type<typeof LocalActivityPubOrderedCollectionSchema>
-  | Schema.Schema.Type<typeof LocalActivityPubFollowersCollectionSchema>
-
-export type ActivityPubOrderedCollectionPage = Schema.Schema.Type<typeof ActivityPubOrderedCollectionPageSchema>
-
-export type LocalActivityPubOrderedCollectionPage =
-  Schema.Schema.Type<typeof LocalActivityPubOrderedCollectionPageSchema>
+export type LocalActivityPubOrderedCollection = Schema.Schema.Type<typeof LocalActivityPubOrderedCollectionSchema>
 
 export type FollowSubscription = {
   readonly id: string

--- a/packages/api/src/api/schema.ts
+++ b/packages/api/src/api/schema.ts
@@ -3,23 +3,10 @@ import * as Schema from "effect/Schema"
 export {
   ActivityForgeFedJsonLdContextSchema,
   ActivityPubFollowActivitySchema,
-  ActivityPubOrderedCollectionPageSchema,
-  ActivityPubOrderedCollectionSchema,
-  ActivityPubPersonSchema,
-  ActivityPubPublicKeySchema,
-  ActorJsonLdContextSchema,
   ForgeFedTicketSchema,
   ForgeFedTicketSourceSchema,
-  JsonLdContextSchema,
   JsonValueSchema,
-  LocalActivityPubFollowersCollectionSchema,
-  LocalActivityPubOrderedCollectionPageSchema,
-  LocalActivityPubOrderedCollectionSchema,
-  LocalActivityPubPersonSchema,
-  MastodonFollowersOrderedCollectionPageSchema,
-  MastodonFollowersOrderedCollectionSchema,
-  MastodonIssueActivityPubPersonSchema,
-  exactActivityPubParseOptions
+  LocalActivityPubOrderedCollectionSchema
 } from "./activitypub-schema.js"
 
 const OptionalString = Schema.optional(Schema.String)

--- a/packages/api/src/http.ts
+++ b/packages/api/src/http.ts
@@ -13,9 +13,6 @@ import { renderError, type AppError } from "@effect-template/lib/usecases/errors
 import { ApiAuthRequiredError, ApiBadRequestError, ApiConflictError, ApiInternalError, ApiNotFoundError, describeUnknown } from "./api/errors.js"
 import { federationJsonLdResponseContentType, type ApplyProjectRequest } from "./api/contracts.js"
 import {
-  ActivityPubOrderedCollectionPageSchema,
-  ActivityPubOrderedCollectionSchema,
-  ActivityPubPersonSchema,
   AuthMenuRequestSchema,
   AuthTerminalSessionRequestSchema,
   ActiveProjectTerminalSessionRequestSchema,
@@ -44,8 +41,7 @@ import {
   StateCommitRequestSchema,
   StateInitRequestSchema,
   StateSyncRequestSchema,
-  UpProjectRequestSchema,
-  exactActivityPubParseOptions
+  UpProjectRequestSchema
 } from "./api/schema.js"
 import type { UpProjectRequestInput } from "./api/schema.js"
 import { defaultProjectsRoot } from "@effect-template/lib/usecases/menu-helpers"
@@ -78,16 +74,19 @@ import {
   listExchangeSubscriptions,
   listFederationIssues,
   listFollowSubscriptions,
-  makeFederationActorDocument,
   makeFederationContext,
   makeFederationExchangeStatus,
-  makeFederationFollowersCollection,
-  makeFederationFollowersPageCollection,
-  makeFederationFollowingCollection,
-  makeFederationLikedCollection,
-  makeFederationOutboxCollection,
   pollExchangeOutboxes
 } from "./services/federation.js"
+import {
+  fetchFedifyWebFinger,
+  makeFedifyActorJsonLd,
+  makeFedifyFollowersJsonLd,
+  makeFedifyFollowersPageJsonLd,
+  makeFedifyFollowingJsonLd,
+  makeFedifyLikedJsonLd,
+  makeFedifyOutboxJsonLd
+} from "./services/fedify-federation.js"
 import {
   applyAllProjects,
   applyProjectById,
@@ -310,24 +309,6 @@ const binaryResponse = (data: Uint8Array, contentType: string, status = 200) =>
  */
 const jsonLdResponse = (data: unknown, status: number) =>
   textResponse(JSON.stringify(data), federationJsonLdResponseContentType, status)
-
-const validatedJsonLdResponse = <A, I>(
-  schema: Schema.Schema<A, I, never>,
-  data: unknown,
-  label: string,
-  status: number
-) =>
-  Schema.decodeUnknown(schema, exactActivityPubParseOptions)(data).pipe(
-    Effect.mapError((error) =>
-      new ApiInternalError({
-        message: `${label} does not satisfy its ActivityPub JSON-LD schema: ${
-          ParseResult.TreeFormatter.formatIssueSync(error.issue)
-        }`,
-        cause: error
-      })
-    ),
-    Effect.flatMap((payload) => jsonLdResponse(payload, status))
-  )
 
 const parseQueryInt = (url: string, key: string, fallback: number): number => {
   const parsed = Number(new URL(url, "http://localhost").searchParams.get(key) ?? "")
@@ -655,7 +636,7 @@ export const federationExchangeStatusResponse = () =>
  * @returns Effect that yields the local ActivityPub actor document response.
  *
  * @pure false
- * @effect Reads HttpServerRequest, resolves federation context, renders makeFederationActorDocument, serializes with jsonLdResponse, and maps failures through errorResponse.
+ * @effect Reads HttpServerRequest, resolves federation context, renders a Fedify Person, serializes with jsonLdResponse, and maps failures through errorResponse.
  * @invariant successful responses contain the actor id derived from the resolved federation context.
  * @precondition request headers or configured env provide a non-empty public origin.
  * @postcondition successful responses contain a JSON-LD Person document with HTTP 200.
@@ -666,14 +647,8 @@ export const federationActorDocumentResponse = () =>
   Effect.gen(function*(_) {
     const request = yield* _(HttpServerRequest.HttpServerRequest)
     const context = yield* _(resolveFederationContext(request))
-    return yield* _(
-      validatedJsonLdResponse(
-        ActivityPubPersonSchema,
-        makeFederationActorDocument(context),
-        "Federation actor document",
-        200
-      )
-    )
+    const document = yield* _(makeFedifyActorJsonLd(context))
+    return yield* _(jsonLdResponse(document, 200))
   }).pipe(Effect.catchAll(errorResponse))
 
 /**
@@ -682,7 +657,7 @@ export const federationActorDocumentResponse = () =>
  * @returns Effect that yields the local ActivityPub outbox collection response.
  *
  * @pure false
- * @effect Reads HttpServerRequest, resolves federation context, renders makeFederationOutboxCollection, serializes with jsonLdResponse, and maps failures through errorResponse.
+ * @effect Reads HttpServerRequest, resolves federation context, renders a Fedify OrderedCollection, serializes with jsonLdResponse, and maps failures through errorResponse.
  * @invariant successful responses contain the outbox id derived from the resolved federation context.
  * @precondition request headers or configured env provide a non-empty public origin.
  * @postcondition successful responses contain a JSON-LD OrderedCollection document with HTTP 200.
@@ -693,14 +668,8 @@ export const federationOutboxDocumentResponse = () =>
   Effect.gen(function*(_) {
     const request = yield* _(HttpServerRequest.HttpServerRequest)
     const context = yield* _(resolveFederationContext(request))
-    return yield* _(
-      validatedJsonLdResponse(
-        ActivityPubOrderedCollectionSchema,
-        makeFederationOutboxCollection(context),
-        "Federation outbox collection",
-        200
-      )
-    )
+    const document = yield* _(makeFedifyOutboxJsonLd(context))
+    return yield* _(jsonLdResponse(document, 200))
   }).pipe(Effect.catchAll(errorResponse))
 
 /**
@@ -709,7 +678,7 @@ export const federationOutboxDocumentResponse = () =>
  * @returns Effect that yields the local ActivityPub followers collection response.
  *
  * @pure false
- * @effect Reads HttpServerRequest, resolves federation context, renders makeFederationFollowersCollection, serializes with jsonLdResponse, and maps failures through errorResponse.
+ * @effect Reads HttpServerRequest, resolves federation context, renders a Fedify OrderedCollection/Page, serializes with jsonLdResponse, and maps failures through errorResponse.
  * @invariant successful responses contain the followers id derived from the resolved federation context.
  * @precondition request headers or configured env provide a non-empty public origin.
  * @postcondition successful responses contain a JSON-LD OrderedCollection document with HTTP 200.
@@ -721,21 +690,12 @@ export const federationFollowersDocumentResponse = () =>
     const request = yield* _(HttpServerRequest.HttpServerRequest)
     const context = yield* _(resolveFederationContext(request))
     const mode = yield* _(readFollowersPageMode(request.url))
-    return yield* _(
+    const document = yield* _(
       mode === "page"
-        ? validatedJsonLdResponse(
-          ActivityPubOrderedCollectionPageSchema,
-          makeFederationFollowersPageCollection(context),
-          "Federation followers page",
-          200
-        )
-        : validatedJsonLdResponse(
-          ActivityPubOrderedCollectionSchema,
-          makeFederationFollowersCollection(context),
-          "Federation followers collection",
-          200
-        )
+        ? makeFedifyFollowersPageJsonLd(context)
+        : makeFedifyFollowersJsonLd(context)
     )
+    return yield* _(jsonLdResponse(document, 200))
   }).pipe(Effect.catchAll(errorResponse))
 
 /**
@@ -744,7 +704,7 @@ export const federationFollowersDocumentResponse = () =>
  * @returns Effect that yields the local ActivityPub following collection response.
  *
  * @pure false
- * @effect Reads HttpServerRequest, resolves federation context, renders makeFederationFollowingCollection, serializes with jsonLdResponse, and maps failures through errorResponse.
+ * @effect Reads HttpServerRequest, resolves federation context, renders a Fedify OrderedCollection, serializes with jsonLdResponse, and maps failures through errorResponse.
  * @invariant successful responses contain the following id derived from the resolved federation context.
  * @precondition request headers or configured env provide a non-empty public origin.
  * @postcondition successful responses contain a JSON-LD OrderedCollection document with HTTP 200.
@@ -755,14 +715,8 @@ export const federationFollowingDocumentResponse = () =>
   Effect.gen(function*(_) {
     const request = yield* _(HttpServerRequest.HttpServerRequest)
     const context = yield* _(resolveFederationContext(request))
-    return yield* _(
-      validatedJsonLdResponse(
-        ActivityPubOrderedCollectionSchema,
-        makeFederationFollowingCollection(context),
-        "Federation following collection",
-        200
-      )
-    )
+    const document = yield* _(makeFedifyFollowingJsonLd(context))
+    return yield* _(jsonLdResponse(document, 200))
   }).pipe(Effect.catchAll(errorResponse))
 
 /**
@@ -771,7 +725,7 @@ export const federationFollowingDocumentResponse = () =>
  * @returns Effect that yields the local ActivityPub liked collection response.
  *
  * @pure false
- * @effect Reads HttpServerRequest, resolves federation context, renders makeFederationLikedCollection, serializes with jsonLdResponse, and maps failures through errorResponse.
+ * @effect Reads HttpServerRequest, resolves federation context, renders a Fedify OrderedCollection, serializes with jsonLdResponse, and maps failures through errorResponse.
  * @invariant successful responses contain the liked collection id derived from the resolved federation context.
  * @precondition request headers or configured env provide a non-empty public origin.
  * @postcondition successful responses contain a JSON-LD OrderedCollection document with HTTP 200.
@@ -782,14 +736,17 @@ export const federationLikedDocumentResponse = () =>
   Effect.gen(function*(_) {
     const request = yield* _(HttpServerRequest.HttpServerRequest)
     const context = yield* _(resolveFederationContext(request))
-    return yield* _(
-      validatedJsonLdResponse(
-        ActivityPubOrderedCollectionSchema,
-        makeFederationLikedCollection(context),
-        "Federation liked collection",
-        200
-      )
-    )
+    const document = yield* _(makeFedifyLikedJsonLd(context))
+    return yield* _(jsonLdResponse(document, 200))
+  }).pipe(Effect.catchAll(errorResponse))
+
+export const federationWebFingerResponse = () =>
+  Effect.gen(function*(_) {
+    const request = yield* _(HttpServerRequest.HttpServerRequest)
+    const context = yield* _(resolveFederationContext(request))
+    const webRequest = yield* _(HttpServerRequest.toWeb(request))
+    const response = yield* _(fetchFedifyWebFinger(webRequest, context))
+    return HttpServerResponse.fromWeb(response)
   }).pipe(Effect.catchAll(errorResponse))
 
 const terminalWebSocketUpgradeResponse = Effect.gen(function*(_) {
@@ -1083,6 +1040,10 @@ export const makeRouter = () => {
         Effect.flatMap((payload) => jsonResponse(payload, 200)),
         Effect.catchAll(errorResponse)
       )
+    ),
+    HttpRouter.get(
+      "/.well-known/webfinger",
+      federationWebFingerResponse()
     ),
     HttpRouter.get(
       "/federation/actor",

--- a/packages/api/src/services/federation.ts
+++ b/packages/api/src/services/federation.ts
@@ -13,7 +13,6 @@ import { dirname, join } from "node:path"
 import type { JsonValue } from "../api/activitypub-schema.js"
 import type {
   ActivityPubFollowActivity,
-  ActivityPubPublicKey,
   AgentProvider,
   AgentSession,
   CreateFollowRequest,
@@ -31,14 +30,11 @@ import type {
   ForgeFedTicket,
   ForgeFedTicketSource,
   LocalActivityPubOrderedCollection,
-  LocalActivityPubOrderedCollectionPage,
-  LocalActivityPubPerson,
   ProjectDetails
 } from "../api/contracts.js"
 import {
   activityForgeFedJsonLdContext,
   activityStreamsJsonLdContext,
-  actorJsonLdContext,
   federationJsonLdContentType,
   forgeFedJsonLdContext
 } from "../api/contracts.js"
@@ -48,7 +44,7 @@ import { createProjectFromRequest } from "./projects.js"
 
 type JsonRecord = { readonly [key: string]: unknown }
 
-type LocalActorKeys = {
+export type LocalActorKeys = {
   readonly publicKeyPem: string
   readonly privateKeyPem: string
 }
@@ -581,6 +577,9 @@ export const initializeFederationState = () =>
 const ensureStateLoaded = () =>
   stateLoaded ? Effect.void : initializeFederationState()
 
+export const readLocalActorKeys = (): Effect.Effect<LocalActorKeys, never> =>
+  ensureStateLoaded().pipe(Effect.map(() => ensureLocalActorKeys()))
+
 export const makeFederationContext = (
   input: FederationContextInput
 ): Effect.Effect<FederationContext, ApiBadRequestError> =>
@@ -610,103 +609,6 @@ const defaultFederationContext = () =>
       "http://localhost:3334",
     actorUsername: process.env["DOCKER_GIT_FEDERATION_ACTOR"] ?? defaultActorUsername
   })
-
-const publicKeyForContext = (context: FederationContext): ActivityPubPublicKey => ({
-  id: `${context.actorId}#main-key`,
-  owner: context.actorId,
-  publicKeyPem: ensureLocalActorKeys().publicKeyPem
-})
-
-const followActivityJson = (activity: ActivityPubFollowActivity): JsonValue => ({
-  "@context": [...activity["@context"]],
-  id: activity.id,
-  type: activity.type,
-  actor: activity.actor,
-  object: activity.object,
-  ...(activity.to === undefined ? {} : { to: [...activity.to] }),
-  ...(activity.capability === undefined ? {} : { capability: activity.capability })
-})
-
-export const makeFederationActorDocument = (
-  context: FederationContext
-): LocalActivityPubPerson => ({
-  "@context": actorJsonLdContext,
-  type: "Person",
-  id: context.actorId,
-  name: "docker-git task feed",
-  preferredUsername: context.actorUsername,
-  summary: "docker-git ActivityPub actor for task and issue stream subscriptions.",
-  inbox: context.inbox,
-  outbox: context.outbox,
-  followers: context.followers,
-  following: context.following,
-  liked: context.liked,
-  publicKey: publicKeyForContext(context),
-  endpoints: {
-    sharedInbox: context.inbox
-  }
-})
-
-export const makeFederationOutboxCollection = (
-  context: FederationContext
-): LocalActivityPubOrderedCollection => {
-  const orderedItems = listFollowSubscriptions().map((subscription) => followActivityJson(subscription.activity))
-  return {
-    "@context": activityForgeFedJsonLdContext,
-    type: "OrderedCollection",
-    id: context.outbox,
-    totalItems: orderedItems.length,
-    orderedItems
-  }
-}
-
-export const makeFederationFollowersCollection = (
-  context: FederationContext
-): LocalActivityPubOrderedCollection => ({
-  "@context": activityForgeFedJsonLdContext,
-  type: "OrderedCollection",
-  id: context.followers,
-  totalItems: 0,
-  first: `${context.followers}?page=1`,
-  orderedItems: []
-})
-
-export const makeFederationFollowersPageCollection = (
-  context: FederationContext
-): LocalActivityPubOrderedCollectionPage => ({
-  "@context": activityForgeFedJsonLdContext,
-  type: "OrderedCollectionPage",
-  id: `${context.followers}?page=1`,
-  totalItems: 0,
-  partOf: context.followers,
-  orderedItems: []
-})
-
-export const makeFederationFollowingCollection = (
-  context: FederationContext
-): LocalActivityPubOrderedCollection => {
-  const orderedItems = listFollowSubscriptions()
-    .filter((subscription) => subscription.status === "accepted")
-    .map((subscription) => subscription.object)
-
-  return {
-    "@context": activityForgeFedJsonLdContext,
-    type: "OrderedCollection",
-    id: context.following,
-    totalItems: orderedItems.length,
-    orderedItems
-  }
-}
-
-export const makeFederationLikedCollection = (
-  context: FederationContext
-): LocalActivityPubOrderedCollection => ({
-  "@context": activityForgeFedJsonLdContext,
-  type: "OrderedCollection",
-  id: context.liked,
-  totalItems: 0,
-  orderedItems: []
-})
 
 const readTicketSource = (payload: JsonRecord): string | ForgeFedTicketSource | undefined => {
   const raw = payload["source"]

--- a/packages/api/src/services/fedify-federation.ts
+++ b/packages/api/src/services/fedify-federation.ts
@@ -1,0 +1,247 @@
+import { createFederation, MemoryKvStore } from "@fedify/fedify"
+import {
+  CryptographicKey,
+  Endpoints,
+  Follow,
+  Object as ActivityObject,
+  OrderedCollection,
+  OrderedCollectionPage,
+  Person
+} from "@fedify/vocab"
+import { Effect } from "effect"
+import { createPublicKey, webcrypto } from "node:crypto"
+
+import {
+  activityStreamsJsonLdContext,
+  actorJsonLdContext,
+  type ActivityPubFollowActivity
+} from "../api/contracts.js"
+import { ApiInternalError } from "../api/errors.js"
+import {
+  listFollowSubscriptions,
+  readLocalActorKeys,
+  type FederationContext
+} from "./federation.js"
+
+const actorIdentifier = "actor"
+
+type FedifyContextData = {
+  readonly context: FederationContext
+}
+
+const url = (value: string): URL => new URL(value)
+
+const importPublicKey = (publicKeyPem: string): Effect.Effect<CryptoKey, ApiInternalError> =>
+  Effect.tryPromise({
+    try: async () => {
+      const jwk = createPublicKey(publicKeyPem).export({ format: "jwk" })
+      return await webcrypto.subtle.importKey(
+        "jwk",
+        jwk,
+        {
+          name: "RSASSA-PKCS1-v1_5",
+          hash: "SHA-256"
+        },
+        true,
+        ["verify"]
+      )
+    },
+    catch: (cause) =>
+      new ApiInternalError({
+        message: "Failed to import federation public key for Fedify serialization.",
+        cause
+      })
+  })
+
+const makeFedifyPublicKey = (
+  context: FederationContext
+): Effect.Effect<CryptographicKey, ApiInternalError> =>
+  Effect.gen(function*(_) {
+    const keys = yield* _(readLocalActorKeys())
+    const publicKey = yield* _(importPublicKey(keys.publicKeyPem))
+    return new CryptographicKey({
+      id: url(`${context.actorId}#main-key`),
+      owner: url(context.actorId),
+      publicKey
+    })
+  })
+
+export const makeFedifyActor = (
+  context: FederationContext
+): Effect.Effect<Person, ApiInternalError> =>
+  Effect.gen(function*(_) {
+    const publicKey = yield* _(makeFedifyPublicKey(context))
+    return new Person({
+      id: url(context.actorId),
+      name: "docker-git task feed",
+      preferredUsername: context.actorUsername,
+      summary: "docker-git ActivityPub actor for task and issue stream subscriptions.",
+      inbox: url(context.inbox),
+      outbox: url(context.outbox),
+      followers: url(context.followers),
+      following: url(context.following),
+      liked: url(context.liked),
+      publicKey,
+      endpoints: new Endpoints({
+        sharedInbox: url(context.inbox)
+      })
+    })
+  })
+
+const makeFedifyFollowActivity = (activity: ActivityPubFollowActivity): Follow =>
+  new Follow({
+    id: url(activity.id),
+    actor: url(activity.actor),
+    object: url(activity.object),
+    tos: activity.to?.map(url) ?? []
+  })
+
+export const makeFedifyOutboxCollection = (
+  context: FederationContext
+): OrderedCollection => {
+  const items = listFollowSubscriptions().map((subscription) =>
+    makeFedifyFollowActivity(subscription.activity)
+  )
+  return new OrderedCollection({
+    id: url(context.outbox),
+    totalItems: items.length,
+    items
+  })
+}
+
+export const makeFedifyFollowersCollection = (
+  context: FederationContext
+): OrderedCollection =>
+  new OrderedCollection({
+    id: url(context.followers),
+    totalItems: 0,
+    first: url(`${context.followers}?page=1`),
+    items: []
+  })
+
+export const makeFedifyFollowersPageCollection = (
+  context: FederationContext
+): OrderedCollectionPage =>
+  new OrderedCollectionPage({
+    id: url(`${context.followers}?page=1`),
+    totalItems: 0,
+    partOf: url(context.followers),
+    items: []
+  })
+
+export const makeFedifyFollowingCollection = (
+  context: FederationContext
+): OrderedCollection => {
+  const items = listFollowSubscriptions()
+    .filter((subscription) => subscription.status === "accepted")
+    .map((subscription) => url(subscription.object))
+
+  return new OrderedCollection({
+    id: url(context.following),
+    totalItems: items.length,
+    items
+  })
+}
+
+export const makeFedifyLikedCollection = (
+  context: FederationContext
+): OrderedCollection =>
+  new OrderedCollection({
+    id: url(context.liked),
+    totalItems: 0,
+    items: []
+  })
+
+const serializeFedifyObject = (
+  object: ActivityObject,
+  context: string | ReadonlyArray<string>
+): Effect.Effect<unknown, ApiInternalError> =>
+  Effect.tryPromise({
+    try: () => {
+      const jsonLdContext: string | string[] =
+        typeof context === "string" ? context : Array.from(context)
+      return object.toJsonLd({
+        format: "compact",
+        context: jsonLdContext
+      })
+    },
+    catch: (cause) =>
+      new ApiInternalError({
+        message: "Failed to serialize ActivityPub document with Fedify.",
+        cause
+      })
+  })
+
+export const makeFedifyActorJsonLd = (
+  context: FederationContext
+): Effect.Effect<unknown, ApiInternalError> =>
+  makeFedifyActor(context).pipe(
+    Effect.flatMap((actor) => serializeFedifyObject(actor, actorJsonLdContext))
+  )
+
+export const makeFedifyOutboxJsonLd = (
+  context: FederationContext
+): Effect.Effect<unknown, ApiInternalError> =>
+  serializeFedifyObject(makeFedifyOutboxCollection(context), activityStreamsJsonLdContext)
+
+export const makeFedifyFollowersJsonLd = (
+  context: FederationContext
+): Effect.Effect<unknown, ApiInternalError> =>
+  serializeFedifyObject(makeFedifyFollowersCollection(context), activityStreamsJsonLdContext)
+
+export const makeFedifyFollowersPageJsonLd = (
+  context: FederationContext
+): Effect.Effect<unknown, ApiInternalError> =>
+  serializeFedifyObject(makeFedifyFollowersPageCollection(context), activityStreamsJsonLdContext)
+
+export const makeFedifyFollowingJsonLd = (
+  context: FederationContext
+): Effect.Effect<unknown, ApiInternalError> =>
+  serializeFedifyObject(makeFedifyFollowingCollection(context), activityStreamsJsonLdContext)
+
+export const makeFedifyLikedJsonLd = (
+  context: FederationContext
+): Effect.Effect<unknown, ApiInternalError> =>
+  serializeFedifyObject(makeFedifyLikedCollection(context), activityStreamsJsonLdContext)
+
+const createWebFingerFederation = (context: FederationContext) => {
+  const federation = createFederation<FedifyContextData>({
+    kv: new MemoryKvStore(),
+    manuallyStartQueue: true,
+    origin: context.publicOrigin
+  })
+
+  federation
+    .setActorDispatcher("/federation/{identifier}", (_ctx, identifier) =>
+      identifier === actorIdentifier
+        ? Effect.runPromise(makeFedifyActor(context))
+        : null
+    )
+    .mapHandle((_ctx, username) =>
+      username === context.actorUsername ? actorIdentifier : null
+    )
+    .mapAlias((_ctx, resource) =>
+      resource.href === context.actorId
+        ? { identifier: actorIdentifier }
+        : null
+    )
+
+  return federation
+}
+
+export const fetchFedifyWebFinger = (
+  request: Request,
+  context: FederationContext
+): Effect.Effect<Response, ApiInternalError> =>
+  Effect.tryPromise({
+    try: () =>
+      createWebFingerFederation(context).fetch(request, {
+        contextData: { context },
+        onNotFound: () => new Response("Not found", { status: 404 })
+      }),
+    catch: (cause) =>
+      new ApiInternalError({
+        message: "Fedify WebFinger request failed.",
+        cause
+      })
+  })

--- a/packages/api/tests/activitypub-schema-parity.test.ts
+++ b/packages/api/tests/activitypub-schema-parity.test.ts
@@ -23,6 +23,9 @@ import {
 
 type JsonRecord = Record<string, unknown>
 
+const isJsonRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
 const unsupportedMastodonTerms = [
   "https://purl.archive.org/socialweb/webfinger",
   "http://joinmastodon.org/ns#",
@@ -45,10 +48,10 @@ const unsupportedMastodonTerms = [
 ] as const
 
 const asRecord = (value: unknown): JsonRecord => {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+  if (!isJsonRecord(value)) {
     throw new Error("Expected JSON object.")
   }
-  return value as JsonRecord
+  return value
 }
 
 const readField = (record: JsonRecord, key: string): unknown =>

--- a/packages/api/tests/activitypub-schema-parity.test.ts
+++ b/packages/api/tests/activitypub-schema-parity.test.ts
@@ -1,558 +1,224 @@
+import { Follow, OrderedCollection, OrderedCollectionPage, Person } from "@fedify/vocab"
 import { describe, expect, it } from "@effect/vitest"
-import { Effect, Either, ParseResult, Schema } from "effect"
-import fc from "fast-check"
+import { Effect, Either, Schema } from "effect"
 
 import {
-  ActivityPubOrderedCollectionPageSchema,
-  ActivityPubOrderedCollectionSchema,
-  ActivityPubPersonSchema,
-  exactActivityPubParseOptions
-} from "../src/api/schema.js"
+  activityStreamsJsonLdContext,
+  actorJsonLdContext
+} from "../src/api/contracts.js"
+import { ForgeFedTicketSchema } from "../src/api/schema.js"
+import {
+  clearFederationState,
+  createFollowSubscription,
+  ingestFederationInbox,
+  makeFederationContext
+} from "../src/services/federation.js"
+import {
+  makeFedifyActorJsonLd,
+  makeFedifyFollowersJsonLd,
+  makeFedifyFollowersPageJsonLd,
+  makeFedifyFollowingJsonLd,
+  makeFedifyOutboxJsonLd
+} from "../src/services/fedify-federation.js"
 
-const decodeActivityPubEither = <A, I>(schema: Schema.Schema<A, I, never>, value: unknown) =>
-  Schema.decodeUnknownEither(schema, exactActivityPubParseOptions)(value)
+type JsonRecord = Record<string, unknown>
 
-const isRecord = (value: unknown): value is Record<string, unknown> =>
-  typeof value === "object" && value !== null && !Array.isArray(value)
-
-const expectDecodedMatchesFixtureKeys = (decoded: object, fixture: object): void => {
-  expect(Object.keys(decoded).sort()).toEqual(Object.keys(fixture).sort())
-}
-
-const activityForgeFedContextArbitrary = fc.constant([
-  "https://www.w3.org/ns/activitystreams",
-  "https://forgefed.org/ns"
-] as const)
-
-const activityPubActorContextArbitrary = fc.constant([
-  "https://www.w3.org/ns/activitystreams",
-  "https://w3id.org/security/v1",
-  "https://forgefed.org/ns"
-] as const)
-
-const schemaStringArbitrary = fc.string()
-
-const nonPersonTypeArbitrary = fc.string().filter((value) => value !== "Person")
-
-const nonOrderedCollectionTypeArbitrary = fc
-  .string()
-  .filter((value) => value !== "OrderedCollection")
-
-const nonOrderedCollectionPageTypeArbitrary = fc
-  .string()
-  .filter((value) => value !== "OrderedCollectionPage")
-
-const activityPubPublicKeyArbitrary = fc.record({
-  id: schemaStringArbitrary,
-  owner: schemaStringArbitrary,
-  publicKeyPem: schemaStringArbitrary
-})
-
-const activityPubEndpointsArbitrary = fc.record({
-  sharedInbox: schemaStringArbitrary
-})
-
-const activityPubPersonRequiredFieldsArbitrary = fc.record({
-  "@context": activityPubActorContextArbitrary,
-  type: fc.constant("Person"),
-  id: schemaStringArbitrary,
-  name: schemaStringArbitrary,
-  preferredUsername: schemaStringArbitrary,
-  summary: schemaStringArbitrary,
-  inbox: schemaStringArbitrary,
-  outbox: schemaStringArbitrary,
-  followers: schemaStringArbitrary,
-  following: schemaStringArbitrary,
-  liked: schemaStringArbitrary,
-  publicKey: activityPubPublicKeyArbitrary,
-  endpoints: activityPubEndpointsArbitrary
-})
-
-const activityPubPersonMissingRequiredFieldsArbitrary = fc.record({
-  "@context": activityPubActorContextArbitrary,
-  type: fc.constant("Person"),
-  id: schemaStringArbitrary
-})
-
-const activityPubOrderedCollectionRequiredFieldsArbitrary = fc.record({
-  "@context": activityForgeFedContextArbitrary,
-  type: fc.constant("OrderedCollection"),
-  id: schemaStringArbitrary,
-  totalItems: fc.integer({ min: 0 }),
-  orderedItems: fc.array(fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null)))
-})
-
-const activityPubOrderedCollectionMissingRequiredFieldsArbitrary = fc.record({
-  "@context": activityForgeFedContextArbitrary,
-  type: fc.constant("OrderedCollection"),
-  id: schemaStringArbitrary,
-  totalItems: fc.integer({ min: 0 })
-})
-
-const activityPubOrderedCollectionPageRequiredFieldsArbitrary = fc.record({
-  "@context": activityForgeFedContextArbitrary,
-  type: fc.constant("OrderedCollectionPage"),
-  id: schemaStringArbitrary,
-  totalItems: fc.integer({ min: 0 }),
-  partOf: schemaStringArbitrary,
-  orderedItems: fc.array(fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null)))
-})
-
-const activityPubOrderedCollectionPageMissingRequiredFieldsArbitrary = fc.record({
-  "@context": activityForgeFedContextArbitrary,
-  type: fc.constant("OrderedCollectionPage"),
-  id: schemaStringArbitrary,
-  totalItems: fc.integer({ min: 0 }),
-  orderedItems: fc.array(fc.oneof(fc.string(), fc.integer(), fc.boolean(), fc.constant(null)))
-})
-
-const mastodonActorContextExtensionsFixture = {
-  manuallyApprovesFollowers: "as:manuallyApprovesFollowers",
-  toot: "http://joinmastodon.org/ns#",
-  featured: {
-    "@id": "toot:featured",
-    "@type": "@id"
-  },
-  featuredTags: {
-    "@id": "toot:featuredTags",
-    "@type": "@id"
-  },
-  alsoKnownAs: {
-    "@id": "as:alsoKnownAs",
-    "@type": "@id"
-  },
-  movedTo: {
-    "@id": "as:movedTo",
-    "@type": "@id"
-  },
-  schema: "http://schema.org/#",
-  PropertyValue: "schema:PropertyValue",
-  value: "schema:value",
-  discoverable: "toot:discoverable",
-  suspended: "toot:suspended",
-  memorial: "toot:memorial",
-  indexable: "toot:indexable",
-  attributionDomains: {
-    "@id": "toot:attributionDomains",
-    "@type": "@id"
-  },
-  showFeatured: "toot:showFeatured",
-  showMedia: "toot:showMedia",
-  showRepliesInMedia: "toot:showRepliesInMedia",
-  gts: "https://gotosocial.org/ns#",
-  interactionPolicy: {
-    "@id": "gts:interactionPolicy",
-    "@type": "@id"
-  },
-  canQuote: {
-    "@id": "gts:canQuote",
-    "@type": "@id"
-  },
-  automaticApproval: {
-    "@id": "gts:automaticApproval",
-    "@type": "@id"
-  },
-  manualApproval: {
-    "@id": "gts:manualApproval",
-    "@type": "@id"
-  }
-}
-
-const mastodonActorContextFixture = [
-  "https://www.w3.org/ns/activitystreams",
-  "https://w3id.org/security/v1",
+const unsupportedMastodonTerms = [
   "https://purl.archive.org/socialweb/webfinger",
-  mastodonActorContextExtensionsFixture
+  "http://joinmastodon.org/ns#",
+  "toot:",
+  "featuredTags",
+  "alsoKnownAs",
+  "movedTo",
+  "manuallyApprovesFollowers",
+  "discoverable",
+  "suspended",
+  "memorial",
+  "indexable",
+  "interactionPolicy",
+  "canQuote",
+  "automaticApproval",
+  "manualApproval",
+  "showFeatured",
+  "showMedia",
+  "showRepliesInMedia"
 ] as const
 
-const mastodonActorFixture = {
-  "@context": mastodonActorContextFixture,
-  id: "https://mastodon.social/users/GordonFreeman",
-  webfinger: "GordonFreeman@mastodon.social",
-  type: "Person",
-  following: "https://mastodon.social/users/GordonFreeman/following",
-  followers: "https://mastodon.social/users/GordonFreeman/followers",
-  inbox: "https://mastodon.social/users/GordonFreeman/inbox",
-  outbox: "https://mastodon.social/users/GordonFreeman/outbox",
-  featured: "https://mastodon.social/users/GordonFreeman/collections/featured",
-  featuredTags: "https://mastodon.social/users/GordonFreeman/collections/tags",
-  preferredUsername: "GordonFreeman",
-  name: "GordonFreeman",
-  summary: "",
-  url: "https://mastodon.social/@GordonFreeman",
-  manuallyApprovesFollowers: false,
-  discoverable: false,
-  indexable: false,
-  published: "2022-05-11T00:00:00Z",
-  memorial: false,
-  showFeatured: true,
-  showMedia: true,
-  showRepliesInMedia: true,
-  interactionPolicy: {
-    canFeature: {
-      automaticApproval: ["https://mastodon.social/users/GordonFreeman"]
-    }
-  },
-  featuredCollections: "https://mastodon.social/ap/users/108283196203417442/featured_collections",
-  publicKey: {
-    id: "https://mastodon.social/users/GordonFreeman#main-key",
-    owner: "https://mastodon.social/users/GordonFreeman",
-    publicKeyPem:
-      "-----BEGIN PUBLIC KEY-----\nMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAtest\n-----END PUBLIC KEY-----\n"
-  },
-  tag: [],
-  attachment: [],
-  endpoints: {
-    sharedInbox: "https://mastodon.social/inbox"
+const asRecord = (value: unknown): JsonRecord => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Expected JSON object.")
+  }
+  return value as JsonRecord
+}
+
+const readField = (record: JsonRecord, key: string): unknown =>
+  Reflect.get(record, key)
+
+const assertNoMastodonTerms = (value: unknown): void => {
+  const serialized = JSON.stringify(value)
+  for (const term of unsupportedMastodonTerms) {
+    expect(serialized.includes(term)).toBe(false)
   }
 }
 
-const mastodonFollowersCollectionFixture = {
-  "@context": "https://www.w3.org/ns/activitystreams",
-  id: "https://mastodon.social/users/nixCraft/followers",
-  type: "OrderedCollection",
-  totalItems: 114133,
-  first: "https://mastodon.social/users/nixCraft/followers?page=1"
-}
+const parsePerson = (payload: unknown) =>
+  Effect.tryPromise({
+    try: () => Person.fromJsonLd(payload),
+    catch: (cause) => new Error(String(cause))
+  })
 
-const mastodonFollowersPageFixture = {
-  "@context": "https://www.w3.org/ns/activitystreams",
-  id: "https://mastodon.social/users/nixCraft/followers?page=1",
-  type: "OrderedCollectionPage",
-  totalItems: 114133,
-  partOf: "https://mastodon.social/users/nixCraft/followers",
-  next: "https://mastodon.social/users/nixCraft/followers?max_id=123&page=1",
-  orderedItems: [
-    "https://mastodon.social/users/GordonFreeman",
-    "https://mastodon.social/users/example"
-  ]
-}
+const parseOrderedCollection = (payload: unknown) =>
+  Effect.tryPromise({
+    try: () => OrderedCollection.fromJsonLd(payload),
+    catch: (cause) => new Error(String(cause))
+  })
 
-const mastodonActorWithContextExtensions = (
-  extensions: unknown
-): object => ({
-  ...mastodonActorFixture,
-  "@context": [
-    "https://www.w3.org/ns/activitystreams",
-    "https://w3id.org/security/v1",
-    "https://purl.archive.org/socialweb/webfinger",
-    extensions
-  ]
-})
+const parseOrderedCollectionPage = (payload: unknown) =>
+  Effect.tryPromise({
+    try: () => OrderedCollectionPage.fromJsonLd(payload),
+    catch: (cause) => new Error(String(cause))
+  })
 
-describe("ActivityPub and ForgeFed schema parity", () => {
-  it.effect("decodes a Mastodon actor Person fixture", () =>
-    Effect.sync(() => {
-      const result = decodeActivityPubEither(ActivityPubPersonSchema, mastodonActorFixture)
+const parseFollow = (payload: unknown) =>
+  Effect.tryPromise({
+    try: () => Follow.fromJsonLd(payload),
+    catch: (cause) => new Error(String(cause))
+  })
 
-      Either.match(result, {
-        onLeft: (error) => {
-          throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
-        },
-        onRight: (decoded) => {
-          expectDecodedMatchesFixtureKeys(decoded, mastodonActorFixture)
-          const decodedContext = Reflect.get(decoded, "@context")
-          expect(Array.isArray(decodedContext)).toBe(true)
-          if (!Array.isArray(decodedContext)) {
-            throw new Error("Decoded Mastodon actor context is not an array.")
-          }
-          const decodedExtensions = decodedContext[3]
-          expect(isRecord(decodedExtensions)).toBe(true)
-          if (!isRecord(decodedExtensions)) {
-            throw new Error("Decoded Mastodon actor context extensions are not an object.")
-          }
-          expect(Object.keys(decodedExtensions).sort()).toEqual(
-            Object.keys(mastodonActorContextExtensionsFixture).sort()
-          )
-        }
-      })
-    }))
-
-  it.effect("decodes a Mastodon followers OrderedCollection fixture", () =>
-    Effect.sync(() => {
-      const result = decodeActivityPubEither(
-        ActivityPubOrderedCollectionSchema,
-        mastodonFollowersCollectionFixture
+describe("ActivityPub and ForgeFed protocol parity", () => {
+  it.effect("serializes the local actor through Fedify without Mastodon extension context", () =>
+    Effect.gen(function*(_) {
+      clearFederationState()
+      const context = yield* _(
+        makeFederationContext({
+          publicOrigin: "https://social.provercoder.ai",
+          actorUsername: "tasks"
+        })
       )
 
-      Either.match(result, {
-        onLeft: (error) => {
-          throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
-        },
-        onRight: (decoded) => {
-          expectDecodedMatchesFixtureKeys(decoded, mastodonFollowersCollectionFixture)
-        }
-      })
+      const payload = yield* _(makeFedifyActorJsonLd(context))
+      const actor = asRecord(payload)
+      const publicKey = asRecord(readField(actor, "publicKey"))
+
+      expect(readField(actor, "@context")).toEqual(actorJsonLdContext)
+      expect(readField(actor, "type")).toBe("Person")
+      expect(readField(actor, "id")).toBe("https://social.provercoder.ai/federation/actor")
+      expect(readField(actor, "preferredUsername")).toBe("tasks")
+      expect(readField(actor, "followers")).toBe("https://social.provercoder.ai/federation/followers")
+      expect(readField(publicKey, "owner")).toBe("https://social.provercoder.ai/federation/actor")
+      expect(typeof readField(publicKey, "publicKeyPem")).toBe("string")
+      assertNoMastodonTerms(payload)
+
+      const parsed = yield* _(parsePerson(payload))
+      expect(parsed.id?.href).toBe("https://social.provercoder.ai/federation/actor")
+      expect(parsed.preferredUsername).toBe("tasks")
     }))
 
-  it.effect("decodes a Mastodon followers OrderedCollectionPage fixture", () =>
-    Effect.sync(() => {
-      const result = decodeActivityPubEither(
-        ActivityPubOrderedCollectionPageSchema,
-        mastodonFollowersPageFixture
+  it.effect("serializes followers collection and page through Fedify ActivityStreams objects", () =>
+    Effect.gen(function*(_) {
+      clearFederationState()
+      const context = yield* _(
+        makeFederationContext({
+          publicOrigin: "https://social.provercoder.ai",
+          actorUsername: "tasks"
+        })
       )
 
-      Either.match(result, {
-        onLeft: (error) => {
-          throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
-        },
-        onRight: (decoded) => {
-          expectDecodedMatchesFixtureKeys(decoded, mastodonFollowersPageFixture)
-        }
-      })
+      const collectionPayload = yield* _(makeFedifyFollowersJsonLd(context))
+      const collection = asRecord(collectionPayload)
+      expect(readField(collection, "@context")).toBe(activityStreamsJsonLdContext)
+      expect(readField(collection, "type")).toBe("OrderedCollection")
+      expect(readField(collection, "id")).toBe("https://social.provercoder.ai/federation/followers")
+      expect(readField(collection, "first")).toBe("https://social.provercoder.ai/federation/followers?page=1")
+      assertNoMastodonTerms(collectionPayload)
+      yield* _(parseOrderedCollection(collectionPayload))
+
+      const pagePayload = yield* _(makeFedifyFollowersPageJsonLd(context))
+      const page = asRecord(pagePayload)
+      expect(readField(page, "@context")).toBe(activityStreamsJsonLdContext)
+      expect(readField(page, "type")).toBe("OrderedCollectionPage")
+      expect(readField(page, "id")).toBe("https://social.provercoder.ai/federation/followers?page=1")
+      expect(readField(page, "partOf")).toBe("https://social.provercoder.ai/federation/followers")
+      assertNoMastodonTerms(pagePayload)
+      yield* _(parseOrderedCollectionPage(pagePayload))
     }))
 
-  it.effect("rejects ActivityPub objects with wrong literal types", () =>
-    Effect.sync(() => {
-      const personResult = decodeActivityPubEither(ActivityPubPersonSchema, {
-        ...mastodonActorFixture,
-        type: "Service"
-      })
-      const collectionResult = decodeActivityPubEither(ActivityPubOrderedCollectionSchema, {
-        ...mastodonFollowersCollectionFixture,
-        type: "Collection"
-      })
-      const pageResult = decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, {
-        ...mastodonFollowersPageFixture,
-        type: "OrderedCollection"
-      })
+  it.effect("serializes follow activities and accepted following state through Fedify", () =>
+    Effect.gen(function*(_) {
+      clearFederationState()
+      const context = yield* _(
+        makeFederationContext({
+          publicOrigin: "https://social.provercoder.ai",
+          actorUsername: "tasks"
+        })
+      )
 
-      expect(Either.isLeft(personResult)).toBe(true)
-      expect(Either.isLeft(collectionResult)).toBe(true)
-      expect(Either.isLeft(pageResult)).toBe(true)
-    }))
-
-  it.effect("rejects ActivityPub objects missing required fields", () =>
-    Effect.sync(() => {
-      const personResult = decodeActivityPubEither(ActivityPubPersonSchema, {
-        type: "Person",
-        id: "https://mastodon.social/users/missing"
-      })
-      const collectionResult = decodeActivityPubEither(ActivityPubOrderedCollectionSchema, {
-        type: "OrderedCollection",
-        id: "https://mastodon.social/users/nixCraft/followers"
-      })
-      const pageResult = decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, {
-        type: "OrderedCollectionPage",
-        id: "https://mastodon.social/users/nixCraft/followers?page=1",
-        orderedItems: []
-      })
-
-      expect(Either.isLeft(personResult)).toBe(true)
-      expect(Either.isLeft(collectionResult)).toBe(true)
-      expect(Either.isLeft(pageResult)).toBe(true)
-    }))
-
-  it.effect("accepts structured ActivityPub Person actor tag and attachment values", () =>
-    Effect.sync(() => {
-      const result = decodeActivityPubEither(ActivityPubPersonSchema, {
-        ...mastodonActorFixture,
-        tag: [
+      const created = yield* _(
+        createFollowSubscription(
           {
-            type: "Hashtag",
-            name: "#activitypub",
-            href: "https://mastodon.social/tags/activitypub"
+            object: "https://tracker.provercoder.ai/issues/followers"
           },
-          {
-            type: "Emoji",
-            id: "https://mastodon.social/emojis/party",
-            name: ":party:",
-            updated: "2026-05-21T00:00:00Z",
-            icon: {
-              type: "Image",
-              mediaType: "image/png",
-              url: "https://mastodon.social/system/custom_emojis/images/party.png"
-            }
-          }
-        ],
+          context
+        )
+      )
+
+      const outboxPayload = yield* _(makeFedifyOutboxJsonLd(context))
+      const outbox = asRecord(outboxPayload)
+      const orderedItems = readField(outbox, "orderedItems")
+      expect(readField(outbox, "@context")).toBe(activityStreamsJsonLdContext)
+      expect(readField(outbox, "type")).toBe("OrderedCollection")
+      expect(Array.isArray(orderedItems)).toBe(true)
+      if (!Array.isArray(orderedItems)) {
+        throw new Error("Expected outbox orderedItems.")
+      }
+      const follow = asRecord(orderedItems[0])
+      expect(readField(follow, "type")).toBe("Follow")
+      expect(readField(follow, "id")).toBe(created.activity.id)
+      expect(readField(follow, "actor")).toBe("https://social.provercoder.ai/federation/actor")
+      expect(readField(follow, "object")).toBe("https://tracker.provercoder.ai/issues/followers")
+      assertNoMastodonTerms(outboxPayload)
+      yield* _(parseFollow(follow))
+
+      yield* _(
+        ingestFederationInbox({
+          "@context": [
+            "https://www.w3.org/ns/activitystreams",
+            "https://forgefed.org/ns"
+          ],
+          type: "Accept",
+          object: created.activity.id
+        })
+      )
+
+      const followingPayload = yield* _(makeFedifyFollowingJsonLd(context))
+      const following = asRecord(followingPayload)
+      expect(readField(following, "type")).toBe("OrderedCollection")
+      expect(readField(following, "totalItems")).toBe(1)
+      expect(readField(following, "orderedItems")).toEqual([
+        "https://tracker.provercoder.ai/issues/followers"
+      ])
+      assertNoMastodonTerms(followingPayload)
+      yield* _(parseOrderedCollection(followingPayload))
+    }))
+
+  it.effect("keeps ForgeFed Ticket validation at the JSON boundary", () =>
+    Effect.sync(() => {
+      const decoded = Schema.decodeUnknownEither(ForgeFedTicketSchema)({
+        id: "https://tracker.example/issues/42",
+        attributedTo: "https://tracker.example/users/alice",
+        summary: "Implement protocol proof",
+        content: "Use ActivityPub and ForgeFed boundary validation.",
         attachment: [
           {
-            type: "PropertyValue",
-            name: "Website",
-            value: "<a href=\"https://example.com\">https://example.com</a>"
+            type: "Document",
+            url: "https://tracker.example/issues/42/log"
           }
-        ]
-      })
-
-      expect(Either.isRight(result)).toBe(true)
-    }))
-
-  it.effect("rejects structurally invalid ActivityPub Person actor extensions", () =>
-    Effect.sync(() => {
-      const invalidActors = [
-        { ...mastodonActorFixture, icon: {} },
-        { ...mastodonActorFixture, image: { type: "Image" } },
-        { ...mastodonActorFixture, tag: [{}] },
-        {
-          ...mastodonActorFixture,
-          tag: [{ type: "Emoji", id: "https://mastodon.social/emojis/party", name: ":party:" }]
-        },
-        { ...mastodonActorFixture, attachment: [{}] },
-        {
-          ...mastodonActorFixture,
-          attachment: [{ type: "Note", name: "Website", value: "https://example.com" }]
-        },
-        { ...mastodonActorFixture, interactionPolicy: {} },
-        { ...mastodonActorFixture, interactionPolicy: { arbitrary: true } },
-        { ...mastodonActorFixture, interactionPolicy: { canFeature: { arbitrary: true } } }
-      ]
-
-      invalidActors.forEach((actor) => {
-        expect(Either.isLeft(decodeActivityPubEither(ActivityPubPersonSchema, actor))).toBe(true)
-      })
-    }))
-
-  it.effect("rejects non-exact ActivityPub fixture shapes", () =>
-    Effect.sync(() => {
-      const contextWithoutManualApproval = Object.fromEntries(
-        Object.entries(mastodonActorContextExtensionsFixture).filter(
-          ([key]) => key !== "manualApproval"
-        )
-      )
-      const contextWithFeaturedWithoutType = {
-        ...mastodonActorContextExtensionsFixture,
-        featured: {
-          "@id": mastodonActorContextExtensionsFixture.featured["@id"]
+        ],
+        raw: {
+          type: "Ticket"
         }
-      }
-      const contextWithExtraKey = {
-        ...mastodonActorContextExtensionsFixture,
-        extraContextTerm: "toot:extraContextTerm"
-      }
-      const invalidDocuments = [
-        { ...mastodonActorFixture, extraField: "not in the issue fixture" },
-        mastodonActorWithContextExtensions(contextWithoutManualApproval),
-        mastodonActorWithContextExtensions(contextWithFeaturedWithoutType),
-        mastodonActorWithContextExtensions(contextWithExtraKey),
-        { ...mastodonFollowersCollectionFixture, orderedItems: [] },
-        { ...mastodonFollowersPageFixture, prev: "https://mastodon.social/users/nixCraft/followers" },
-        { ...mastodonFollowersPageFixture, orderedItems: ["ok", { id: "not-a-link" }] }
-      ]
-
-      invalidDocuments.slice(0, 4).forEach((document) => {
-        expect(Either.isLeft(decodeActivityPubEither(ActivityPubPersonSchema, document))).toBe(true)
       })
-      expect(
-        Either.isLeft(decodeActivityPubEither(ActivityPubOrderedCollectionSchema, invalidDocuments[4]))
-      ).toBe(true)
-      expect(
-        Either.isLeft(decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, invalidDocuments[5]))
-      ).toBe(true)
-      expect(
-        Either.isLeft(decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, invalidDocuments[6]))
-      ).toBe(true)
-    }))
 
-  it.effect("accepts ActivityPub Person objects with required fields and correct type", () =>
-    Effect.sync(() => {
-      fc.assert(
-        fc.property(activityPubPersonRequiredFieldsArbitrary, (person) => {
-          expect(Either.isRight(decodeActivityPubEither(ActivityPubPersonSchema, person))).toBe(true)
-        })
-      )
-    }))
-
-  it.effect("rejects ActivityPub Person objects with wrong type", () =>
-    Effect.sync(() => {
-      fc.assert(
-        fc.property(activityPubPersonRequiredFieldsArbitrary, nonPersonTypeArbitrary, (person, type) => {
-          expect(
-            Either.isLeft(decodeActivityPubEither(ActivityPubPersonSchema, { ...person, type }))
-          ).toBe(true)
-        })
-      )
-    }))
-
-  it.effect("rejects ActivityPub Person objects missing required fields", () =>
-    Effect.sync(() => {
-      fc.assert(
-        fc.property(activityPubPersonMissingRequiredFieldsArbitrary, (person) => {
-          expect(Either.isLeft(decodeActivityPubEither(ActivityPubPersonSchema, person))).toBe(true)
-        })
-      )
-    }))
-
-  it.effect("accepts ActivityPub OrderedCollection objects with required fields and correct type", () =>
-    Effect.sync(() => {
-      fc.assert(
-        fc.property(activityPubOrderedCollectionRequiredFieldsArbitrary, (collection) => {
-          expect(
-            Either.isRight(decodeActivityPubEither(ActivityPubOrderedCollectionSchema, collection))
-          ).toBe(true)
-        })
-      )
-    }))
-
-  it.effect("rejects ActivityPub OrderedCollection objects with wrong type", () =>
-    Effect.sync(() => {
-      fc.assert(
-        fc.property(
-          activityPubOrderedCollectionRequiredFieldsArbitrary,
-          nonOrderedCollectionTypeArbitrary,
-          (collection, type) => {
-            expect(
-              Either.isLeft(
-                decodeActivityPubEither(ActivityPubOrderedCollectionSchema, {
-                  ...collection,
-                  type
-                })
-              )
-            ).toBe(true)
-          }
-        )
-      )
-    }))
-
-  it.effect("rejects ActivityPub OrderedCollection objects missing required fields", () =>
-    Effect.sync(() => {
-      fc.assert(
-        fc.property(activityPubOrderedCollectionMissingRequiredFieldsArbitrary, (collection) => {
-          expect(
-            Either.isLeft(decodeActivityPubEither(ActivityPubOrderedCollectionSchema, collection))
-          ).toBe(true)
-        })
-      )
-    }))
-
-  it.effect("accepts ActivityPub OrderedCollectionPage objects with required fields and correct type", () =>
-    Effect.sync(() => {
-      fc.assert(
-        fc.property(activityPubOrderedCollectionPageRequiredFieldsArbitrary, (page) => {
-          expect(
-            Either.isRight(decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, page))
-          ).toBe(true)
-        })
-      )
-    }))
-
-  it.effect("rejects ActivityPub OrderedCollectionPage objects with wrong type", () =>
-    Effect.sync(() => {
-      fc.assert(
-        fc.property(
-          activityPubOrderedCollectionPageRequiredFieldsArbitrary,
-          nonOrderedCollectionPageTypeArbitrary,
-          (page, type) => {
-            expect(
-              Either.isLeft(
-                decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, {
-                  ...page,
-                  type
-                })
-              )
-            ).toBe(true)
-          }
-        )
-      )
-    }))
-
-  it.effect("rejects ActivityPub OrderedCollectionPage objects missing required fields", () =>
-    Effect.sync(() => {
-      fc.assert(
-        fc.property(activityPubOrderedCollectionPageMissingRequiredFieldsArbitrary, (page) => {
-          expect(
-            Either.isLeft(decodeActivityPubEither(ActivityPubOrderedCollectionPageSchema, page))
-          ).toBe(true)
-        })
-      )
+      expect(Either.isRight(decoded)).toBe(true)
     }))
 })

--- a/packages/api/tests/federation.test.ts
+++ b/packages/api/tests/federation.test.ts
@@ -4,9 +4,12 @@ import { vi } from "vitest"
 
 import {
   activityForgeFedJsonLdContext,
-  actorJsonLdContext,
   federationJsonLdContentType
 } from "../src/api/contracts.js"
+import {
+  makeFedifyActorJsonLd,
+  makeFedifyFollowingJsonLd
+} from "../src/services/fedify-federation.js"
 import {
   clearFederationState,
   createFollowSubscription,
@@ -15,12 +18,20 @@ import {
   listFederationIssues,
   listExchangeSubscriptions,
   listFollowSubscriptions,
-  makeFederationActorDocument,
   makeFederationContext,
   makeFederationExchangeStatus,
-  makeFederationFollowingCollection,
   pollExchangeOutboxes
 } from "../src/services/federation.js"
+
+const asRecord = (value: unknown): Record<string, unknown> => {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    throw new Error("Expected JSON object.")
+  }
+  return value as Record<string, unknown>
+}
+
+const readField = (record: Record<string, unknown>, key: string): unknown =>
+  Reflect.get(record, key)
 
 describe("federation service", () => {
   it.effect("ingests ForgeFed Offer with Ticket payload", () =>
@@ -130,7 +141,7 @@ describe("federation service", () => {
       expect(created.subscription.inbox).toBe("https://social.provercoder.ai/federation/inbox")
     }))
 
-  it.effect("builds person and following collections in activitypub shape", () =>
+  it.effect("builds person and following collections through Fedify", () =>
     Effect.gen(function*(_) {
       clearFederationState()
 
@@ -141,12 +152,11 @@ describe("federation service", () => {
         })
       )
 
-      const person = makeFederationActorDocument(context)
-      expect(person.type).toBe("Person")
-      expect(person["@context"]).toEqual(actorJsonLdContext)
-      expect(person.id).toBe("https://social.provercoder.ai/federation/actor")
-      expect(person.preferredUsername).toBe("tasks")
-      expect(person.followers).toBe("https://social.provercoder.ai/federation/followers")
+      const person = asRecord(yield* _(makeFedifyActorJsonLd(context)))
+      expect(readField(person, "type")).toBe("Person")
+      expect(readField(person, "id")).toBe("https://social.provercoder.ai/federation/actor")
+      expect(readField(person, "preferredUsername")).toBe("tasks")
+      expect(readField(person, "followers")).toBe("https://social.provercoder.ai/federation/followers")
 
       const created = yield* _(
         createFollowSubscription(
@@ -165,10 +175,12 @@ describe("federation service", () => {
         })
       )
 
-      const following = makeFederationFollowingCollection(context)
-      expect(following.type).toBe("OrderedCollection")
-      expect(following.totalItems).toBe(1)
-      expect(following.orderedItems[0]).toBe("https://tracker.provercoder.ai/issues/followers")
+      const following = asRecord(yield* _(makeFedifyFollowingJsonLd(context)))
+      expect(readField(following, "type")).toBe("OrderedCollection")
+      expect(readField(following, "totalItems")).toBe(1)
+      expect(readField(following, "orderedItems")).toEqual([
+        "https://tracker.provercoder.ai/issues/followers"
+      ])
     }))
 
   it.effect("rejects duplicate pending follow subscription", () =>

--- a/packages/api/tests/federation.test.ts
+++ b/packages/api/tests/federation.test.ts
@@ -1,5 +1,7 @@
+import { Person } from "@fedify/vocab"
 import { describe, expect, it } from "@effect/vitest"
 import { Effect } from "effect"
+import fc from "fast-check"
 import { vi } from "vitest"
 
 import {
@@ -23,15 +25,37 @@ import {
   pollExchangeOutboxes
 } from "../src/services/federation.js"
 
-const asRecord = (value: unknown): Record<string, unknown> => {
-  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+type JsonRecord = Record<string, unknown>
+
+const isJsonRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const asRecord = (value: unknown): JsonRecord => {
+  if (!isJsonRecord(value)) {
     throw new Error("Expected JSON object.")
   }
-  return value as Record<string, unknown>
+  return value
 }
 
-const readField = (record: Record<string, unknown>, key: string): unknown =>
+const readField = (record: JsonRecord, key: string): unknown =>
   Reflect.get(record, key)
+
+const countKey = (value: unknown, key: string): number => {
+  if (Array.isArray(value)) {
+    return value.reduce((count, item) => count + countKey(item, key), 0)
+  }
+  if (!isJsonRecord(value)) {
+    return 0
+  }
+  const current = Reflect.has(value, key) ? 1 : 0
+  return Object.values(value).reduce<number>((count, item) => count + countKey(item, key), current)
+}
+
+const actorUsernameArbitrary = fc
+  .string({ minLength: 1, maxLength: 20 })
+  .filter((value) => /^[a-z0-9_-]+$/i.test(value))
+
+const publicOriginArbitrary = fc.webUrl().map((value) => new URL(value).origin)
 
 describe("federation service", () => {
   it.effect("ingests ForgeFed Offer with Ticket payload", () =>
@@ -181,6 +205,90 @@ describe("federation service", () => {
       expect(readField(following, "orderedItems")).toEqual([
         "https://tracker.provercoder.ai/issues/followers"
       ])
+    }))
+
+  it.effect("satisfies Fedify actor JSON-LD property invariants", () =>
+    Effect.tryPromise({
+      try: () =>
+        fc.assert(
+          fc.asyncProperty(
+            fc.record({
+              publicOrigin: publicOriginArbitrary,
+              actorUsername: actorUsernameArbitrary
+            }),
+            async ({ publicOrigin, actorUsername }) => {
+              clearFederationState()
+              const context = await Effect.runPromise(
+                makeFederationContext({ publicOrigin, actorUsername })
+              )
+              const payload = await Effect.runPromise(makeFedifyActorJsonLd(context))
+              const actor = asRecord(payload)
+              const parsed = await Person.fromJsonLd(payload)
+
+              expect(parsed.id?.href).toBe(`${context.publicOrigin}/federation/actor`)
+              expect(parsed.preferredUsername).toBe(context.actorUsername)
+              expect(countKey(actor, "@context")).toBe(1)
+              expect(readField(actor, "id")).toBe(`${context.publicOrigin}/federation/actor`)
+              expect(readField(actor, "inbox")).toBe(`${context.publicOrigin}/federation/inbox`)
+              expect(readField(actor, "outbox")).toBe(`${context.publicOrigin}/federation/outbox`)
+              expect(readField(actor, "followers")).toBe(`${context.publicOrigin}/federation/followers`)
+              expect(readField(actor, "following")).toBe(`${context.publicOrigin}/federation/following`)
+              expect(readField(actor, "liked")).toBe(`${context.publicOrigin}/federation/liked`)
+            }
+          ),
+          { numRuns: 10 }
+        ),
+      catch: (cause) => cause instanceof Error ? cause : new Error(String(cause))
+    }))
+
+  it.effect("satisfies Fedify following collection property invariants", () =>
+    Effect.tryPromise({
+      try: () =>
+        fc.assert(
+          fc.asyncProperty(
+            fc.record({
+              targetIds: fc.uniqueArray(fc.integer({ min: 1, max: 10_000 }), { maxLength: 5 })
+            }),
+            async ({ targetIds }) => {
+              clearFederationState()
+              const context = await Effect.runPromise(
+                makeFederationContext({
+                  publicOrigin: "https://social.provercoder.ai",
+                  actorUsername: "tasks"
+                })
+              )
+
+              for (const targetId of targetIds) {
+                const created = await Effect.runPromise(
+                  createFollowSubscription(
+                    {
+                      object: `https://tracker${targetId}.example.test/issues/followers`
+                    },
+                    context
+                  )
+                )
+                await Effect.runPromise(
+                  ingestFederationInbox({
+                    "@context": activityForgeFedJsonLdContext,
+                    type: "Accept",
+                    object: created.activity.id
+                  })
+                )
+              }
+
+              const payload = await Effect.runPromise(makeFedifyFollowingJsonLd(context))
+              const following = asRecord(payload)
+              const orderedItems = readField(following, "orderedItems")
+              const items = Array.isArray(orderedItems) ? orderedItems : []
+
+              expect(readField(following, "id")).toBe(`${context.publicOrigin}/federation/following`)
+              expect(readField(following, "totalItems")).toBe(items.length)
+              expect(countKey(following, "@context")).toBe(1)
+            }
+          ),
+          { numRuns: 10 }
+        ),
+      catch: (cause) => cause instanceof Error ? cause : new Error(String(cause))
     }))
 
   it.effect("rejects duplicate pending follow subscription", () =>

--- a/packages/api/tests/federation.test.ts
+++ b/packages/api/tests/federation.test.ts
@@ -57,6 +57,12 @@ const actorUsernameArbitrary = fc
 
 const publicOriginArbitrary = fc.webUrl().map((value) => new URL(value).origin)
 
+const parsePersonJsonLd = (payload: unknown) =>
+  Effect.tryPromise({
+    try: () => Person.fromJsonLd(payload),
+    catch: (cause) => cause instanceof Error ? cause : new Error(String(cause))
+  })
+
 describe("federation service", () => {
   it.effect("ingests ForgeFed Offer with Ticket payload", () =>
     Effect.gen(function*(_) {
@@ -216,25 +222,28 @@ describe("federation service", () => {
               publicOrigin: publicOriginArbitrary,
               actorUsername: actorUsernameArbitrary
             }),
-            async ({ publicOrigin, actorUsername }) => {
-              clearFederationState()
-              const context = await Effect.runPromise(
-                makeFederationContext({ publicOrigin, actorUsername })
-              )
-              const payload = await Effect.runPromise(makeFedifyActorJsonLd(context))
-              const actor = asRecord(payload)
-              const parsed = await Person.fromJsonLd(payload)
+            ({ publicOrigin, actorUsername }) =>
+              Effect.runPromise(
+                Effect.gen(function*(_) {
+                  yield* _(Effect.sync(() => clearFederationState()))
+                  const context = yield* _(
+                    makeFederationContext({ publicOrigin, actorUsername })
+                  )
+                  const payload = yield* _(makeFedifyActorJsonLd(context))
+                  const actor = asRecord(payload)
+                  const parsed = yield* _(parsePersonJsonLd(payload))
 
-              expect(parsed.id?.href).toBe(`${context.publicOrigin}/federation/actor`)
-              expect(parsed.preferredUsername).toBe(context.actorUsername)
-              expect(countKey(actor, "@context")).toBe(1)
-              expect(readField(actor, "id")).toBe(`${context.publicOrigin}/federation/actor`)
-              expect(readField(actor, "inbox")).toBe(`${context.publicOrigin}/federation/inbox`)
-              expect(readField(actor, "outbox")).toBe(`${context.publicOrigin}/federation/outbox`)
-              expect(readField(actor, "followers")).toBe(`${context.publicOrigin}/federation/followers`)
-              expect(readField(actor, "following")).toBe(`${context.publicOrigin}/federation/following`)
-              expect(readField(actor, "liked")).toBe(`${context.publicOrigin}/federation/liked`)
-            }
+                  expect(parsed.id?.href).toBe(`${context.publicOrigin}/federation/actor`)
+                  expect(parsed.preferredUsername).toBe(context.actorUsername)
+                  expect(countKey(actor, "@context")).toBe(1)
+                  expect(readField(actor, "id")).toBe(`${context.publicOrigin}/federation/actor`)
+                  expect(readField(actor, "inbox")).toBe(`${context.publicOrigin}/federation/inbox`)
+                  expect(readField(actor, "outbox")).toBe(`${context.publicOrigin}/federation/outbox`)
+                  expect(readField(actor, "followers")).toBe(`${context.publicOrigin}/federation/followers`)
+                  expect(readField(actor, "following")).toBe(`${context.publicOrigin}/federation/following`)
+                  expect(readField(actor, "liked")).toBe(`${context.publicOrigin}/federation/liked`)
+                })
+              )
           ),
           { numRuns: 10 }
         ),
@@ -249,42 +258,52 @@ describe("federation service", () => {
             fc.record({
               targetIds: fc.uniqueArray(fc.integer({ min: 1, max: 10_000 }), { maxLength: 5 })
             }),
-            async ({ targetIds }) => {
-              clearFederationState()
-              const context = await Effect.runPromise(
-                makeFederationContext({
-                  publicOrigin: "https://social.provercoder.ai",
-                  actorUsername: "tasks"
+            ({ targetIds }) =>
+              Effect.runPromise(
+                Effect.gen(function*(_) {
+                  yield* _(Effect.sync(() => clearFederationState()))
+                  const context = yield* _(
+                    makeFederationContext({
+                      publicOrigin: "https://social.provercoder.ai",
+                      actorUsername: "tasks"
+                    })
+                  )
+
+                  yield* _(
+                    Effect.forEach(
+                      targetIds,
+                      (targetId) =>
+                        Effect.gen(function*(_) {
+                          const created = yield* _(
+                            createFollowSubscription(
+                              {
+                                object: `https://tracker${targetId}.example.test/issues/followers`
+                              },
+                              context
+                            )
+                          )
+                          yield* _(
+                            ingestFederationInbox({
+                              "@context": activityForgeFedJsonLdContext,
+                              type: "Accept",
+                              object: created.activity.id
+                            })
+                          )
+                        }),
+                      { discard: true }
+                    )
+                  )
+
+                  const payload = yield* _(makeFedifyFollowingJsonLd(context))
+                  const following = asRecord(payload)
+                  const orderedItems = readField(following, "orderedItems")
+                  const items = Array.isArray(orderedItems) ? orderedItems : []
+
+                  expect(readField(following, "id")).toBe(`${context.publicOrigin}/federation/following`)
+                  expect(readField(following, "totalItems")).toBe(items.length)
+                  expect(countKey(following, "@context")).toBe(1)
                 })
               )
-
-              for (const targetId of targetIds) {
-                const created = await Effect.runPromise(
-                  createFollowSubscription(
-                    {
-                      object: `https://tracker${targetId}.example.test/issues/followers`
-                    },
-                    context
-                  )
-                )
-                await Effect.runPromise(
-                  ingestFederationInbox({
-                    "@context": activityForgeFedJsonLdContext,
-                    type: "Accept",
-                    object: created.activity.id
-                  })
-                )
-              }
-
-              const payload = await Effect.runPromise(makeFedifyFollowingJsonLd(context))
-              const following = asRecord(payload)
-              const orderedItems = readField(following, "orderedItems")
-              const items = Array.isArray(orderedItems) ? orderedItems : []
-
-              expect(readField(following, "id")).toBe(`${context.publicOrigin}/federation/following`)
-              expect(readField(following, "totalItems")).toBe(items.length)
-              expect(countKey(following, "@context")).toBe(1)
-            }
           ),
           { numRuns: 10 }
         ),

--- a/packages/api/tests/http-config.test.ts
+++ b/packages/api/tests/http-config.test.ts
@@ -382,51 +382,62 @@ describe("api http config", () => {
     Effect.tryPromise({
       try: () =>
         fc.assert(
-          fc.asyncProperty(webFingerResourceArbitrary, async (resource) => {
-            clearFederationState()
-            const document = await Effect.runPromise(
-              readFederationDocumentRoute(
-                `/.well-known/webfinger?resource=${encodeURIComponent(resource)}`
-              )
+          fc.asyncProperty(webFingerResourceArbitrary, (resource) =>
+            Effect.runPromise(
+              Effect.gen(function*(_) {
+                yield* _(Effect.sync(() => clearFederationState()))
+                const document = yield* _(
+                  readFederationDocumentRoute(
+                    `/.well-known/webfinger?resource=${encodeURIComponent(resource)}`
+                  )
+                )
+                const payload = parseJsonObject(document.body)
+                if (payload === null) {
+                  throw new Error("Expected WebFinger JSON object.")
+                }
+                const aliases = readField(payload, "aliases")
+                const links = readField(payload, "links")
+
+                expect(document.status).toBe(200)
+                expect(readField(payload, "subject")).toBe(resource)
+                expect(Array.isArray(aliases)).toBe(true)
+                if (!Array.isArray(aliases)) {
+                  throw new Error("Expected WebFinger aliases.")
+                }
+                yield* _(
+                  Effect.forEach(
+                    aliases,
+                    (alias) =>
+                      Effect.sync(() => {
+                        expect(new URL(String(alias)).href).toBe(String(alias))
+                      }),
+                    { discard: true }
+                  )
+                )
+
+                expect(Array.isArray(links)).toBe(true)
+                if (!Array.isArray(links)) {
+                  throw new Error("Expected WebFinger links.")
+                }
+                const selfLink = links
+                  .filter(isJsonRecord)
+                  .find((link) =>
+                    readField(link, "rel") === "self" &&
+                    readField(link, "type") === "application/activity+json")
+                if (selfLink === undefined) {
+                  throw new Error("Expected WebFinger self link.")
+                }
+                const actorHref = readField(selfLink, "href")
+                expect(actorHref).toBe("https://public.example.test/federation/actor")
+
+                const actor = yield* _(readFederationDocumentRoute("/federation/actor"))
+                const actorPayload = parseJsonObject(actor.body)
+                expect(actor.status).toBe(200)
+                expect(readField(actorPayload, "id")).toBe(actorHref)
+                expect(readField(actorPayload, "type")).toBe("Person")
+              })
             )
-            const payload = parseJsonObject(document.body)
-            if (payload === null) {
-              throw new Error("Expected WebFinger JSON object.")
-            }
-            const aliases = readField(payload, "aliases")
-            const links = readField(payload, "links")
-
-            expect(document.status).toBe(200)
-            expect(readField(payload, "subject")).toBe(resource)
-            expect(Array.isArray(aliases)).toBe(true)
-            if (!Array.isArray(aliases)) {
-              throw new Error("Expected WebFinger aliases.")
-            }
-            for (const alias of aliases) {
-              expect(new URL(String(alias)).href).toBe(String(alias))
-            }
-
-            expect(Array.isArray(links)).toBe(true)
-            if (!Array.isArray(links)) {
-              throw new Error("Expected WebFinger links.")
-            }
-            const selfLink = links
-              .filter(isJsonRecord)
-              .find((link) =>
-                readField(link, "rel") === "self" &&
-                readField(link, "type") === "application/activity+json")
-            if (selfLink === undefined) {
-              throw new Error("Expected WebFinger self link.")
-            }
-            const actorHref = readField(selfLink, "href")
-            expect(actorHref).toBe("https://public.example.test/federation/actor")
-
-            const actor = await Effect.runPromise(readFederationDocumentRoute("/federation/actor"))
-            const actorPayload = parseJsonObject(actor.body)
-            expect(actor.status).toBe(200)
-            expect(readField(actorPayload, "id")).toBe(actorHref)
-            expect(readField(actorPayload, "type")).toBe("Person")
-          }),
+          ),
           { numRuns: 4 }
         ),
       catch: (cause) => cause instanceof Error ? cause : new Error(String(cause))

--- a/packages/api/tests/http-config.test.ts
+++ b/packages/api/tests/http-config.test.ts
@@ -1,5 +1,6 @@
 import * as HttpApp from "@effect/platform/HttpApp"
 import * as HttpRouter from "@effect/platform/HttpRouter"
+import { OrderedCollectionPage } from "@fedify/vocab"
 import { describe, expect, it } from "@effect/vitest"
 import { Effect } from "effect"
 import fc from "fast-check"
@@ -134,25 +135,81 @@ const readNestedField = (value: object | null, parent: string, key: string): unk
   return typeof nested === "object" && nested !== null ? Reflect.get(nested, key) : undefined
 }
 
-const unsupportedMastodonTerms = [
+type JsonRecord = Record<string, unknown>
+
+const isJsonRecord = (value: unknown): value is JsonRecord =>
+  typeof value === "object" && value !== null && !Array.isArray(value)
+
+const unsupportedMastodonContextTerms = [
   "https://purl.archive.org/socialweb/webfinger",
   "http://joinmastodon.org/ns#",
-  "toot:",
+  "toot:"
+] as const
+
+const unsupportedMastodonKeys = [
+  "toot",
+  "featured",
   "featuredTags",
   "alsoKnownAs",
   "movedTo",
   "manuallyApprovesFollowers",
   "discoverable",
   "suspended",
-  "interactionPolicy"
+  "interactionPolicy",
+  "canQuote",
+  "automaticApproval",
+  "manualApproval"
 ] as const
 
-const assertNoMastodonTerms = (payload: object | null): void => {
-  const serialized = JSON.stringify(payload)
-  for (const term of unsupportedMastodonTerms) {
-    expect(serialized.includes(term)).toBe(false)
+const assertNoMastodonContextTerms = (value: unknown): void => {
+  if (typeof value === "string") {
+    for (const term of unsupportedMastodonContextTerms) {
+      expect(value.includes(term)).toBe(false)
+    }
+    return
+  }
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      assertNoMastodonContextTerms(item)
+    }
+    return
+  }
+  if (isJsonRecord(value)) {
+    for (const [key, item] of Object.entries(value)) {
+      expect(unsupportedMastodonKeys.some((unsupportedKey) => unsupportedKey === key)).toBe(false)
+      assertNoMastodonContextTerms(item)
+    }
   }
 }
+
+const assertNoMastodonKeys = (value: unknown): void => {
+  if (Array.isArray(value)) {
+    for (const item of value) {
+      assertNoMastodonKeys(item)
+    }
+    return
+  }
+  if (isJsonRecord(value)) {
+    for (const [key, item] of Object.entries(value)) {
+      expect(unsupportedMastodonKeys.some((unsupportedKey) => unsupportedKey === key)).toBe(false)
+      assertNoMastodonKeys(item)
+    }
+  }
+}
+
+const assertNoMastodonTerms = (payload: object | null): void => {
+  if (payload === null) {
+    return
+  }
+  assertNoMastodonContextTerms(Reflect.get(payload, "@context"))
+  assertNoMastodonKeys(payload)
+}
+
+const parseOrderedCollectionPage = (payload: unknown) =>
+  Effect.tryPromise({
+    try: () => OrderedCollectionPage.fromJsonLd(payload),
+    catch: (cause) => new Error(String(cause))
+  })
 
 const federationDocumentCases: ReadonlyArray<{
   readonly path: string
@@ -191,6 +248,11 @@ const federationDocumentCases: ReadonlyArray<{
     expectedType: "OrderedCollection"
   }
 ]
+
+const webFingerResourceArbitrary = fc.constantFrom(
+  "acct:docker-git@public.example.test",
+  "https://public.example.test/federation/actor"
+)
 
 describe("api http config", () => {
   it.effect("ignores empty federation public origin values", () =>
@@ -280,10 +342,10 @@ describe("api http config", () => {
 
       expect(document.status).toBe(200)
       expect(document.contentType).toBe(federationJsonLdResponseContentType)
-      expect(readField(payload, "@context")).toBe(activityStreamsJsonLdContext)
-      expect(readField(payload, "type")).toBe("OrderedCollectionPage")
-      expect(readField(payload, "id")).toBe("https://public.example.test/federation/followers?page=1")
-      expect(readField(payload, "partOf")).toBe("https://public.example.test/federation/followers")
+      const page = yield* _(parseOrderedCollectionPage(payload))
+      expect(page.id?.href).toBe("https://public.example.test/federation/followers?page=1")
+      expect(page.partOfId?.href).toBe("https://public.example.test/federation/followers")
+      expect(page.totalItems).toBe(0)
       assertNoMastodonTerms(payload)
     }))
 
@@ -314,6 +376,60 @@ describe("api http config", () => {
         href: "https://public.example.test/federation/actor",
         type: "application/activity+json"
       })
+    }))
+
+  it.effect("satisfies WebFinger invariants for supported actor resources", () =>
+    Effect.tryPromise({
+      try: () =>
+        fc.assert(
+          fc.asyncProperty(webFingerResourceArbitrary, async (resource) => {
+            clearFederationState()
+            const document = await Effect.runPromise(
+              readFederationDocumentRoute(
+                `/.well-known/webfinger?resource=${encodeURIComponent(resource)}`
+              )
+            )
+            const payload = parseJsonObject(document.body)
+            if (payload === null) {
+              throw new Error("Expected WebFinger JSON object.")
+            }
+            const aliases = readField(payload, "aliases")
+            const links = readField(payload, "links")
+
+            expect(document.status).toBe(200)
+            expect(readField(payload, "subject")).toBe(resource)
+            expect(Array.isArray(aliases)).toBe(true)
+            if (!Array.isArray(aliases)) {
+              throw new Error("Expected WebFinger aliases.")
+            }
+            for (const alias of aliases) {
+              expect(new URL(String(alias)).href).toBe(String(alias))
+            }
+
+            expect(Array.isArray(links)).toBe(true)
+            if (!Array.isArray(links)) {
+              throw new Error("Expected WebFinger links.")
+            }
+            const selfLink = links
+              .filter(isJsonRecord)
+              .find((link) =>
+                readField(link, "rel") === "self" &&
+                readField(link, "type") === "application/activity+json")
+            if (selfLink === undefined) {
+              throw new Error("Expected WebFinger self link.")
+            }
+            const actorHref = readField(selfLink, "href")
+            expect(actorHref).toBe("https://public.example.test/federation/actor")
+
+            const actor = await Effect.runPromise(readFederationDocumentRoute("/federation/actor"))
+            const actorPayload = parseJsonObject(actor.body)
+            expect(actor.status).toBe(200)
+            expect(readField(actorPayload, "id")).toBe(actorHref)
+            expect(readField(actorPayload, "type")).toBe("Person")
+          }),
+          { numRuns: 4 }
+        ),
+      catch: (cause) => cause instanceof Error ? cause : new Error(String(cause))
     }))
 
   it.effect("rejects unsupported followers pages", () =>

--- a/packages/api/tests/http-config.test.ts
+++ b/packages/api/tests/http-config.test.ts
@@ -1,20 +1,14 @@
 import * as HttpApp from "@effect/platform/HttpApp"
 import * as HttpRouter from "@effect/platform/HttpRouter"
 import { describe, expect, it } from "@effect/vitest"
-import { Effect, Either, ParseResult, Schema } from "effect"
+import { Effect } from "effect"
 import fc from "fast-check"
 
 import {
-  activityForgeFedJsonLdContext,
+  activityStreamsJsonLdContext,
   actorJsonLdContext,
   federationJsonLdResponseContentType
 } from "../src/api/contracts.js"
-import {
-  ActivityPubOrderedCollectionPageSchema,
-  ActivityPubOrderedCollectionSchema,
-  ActivityPubPersonSchema,
-  exactActivityPubParseOptions
-} from "../src/api/schema.js"
 import {
   federationActorDocumentResponse,
   federationExchangeStatusResponse,
@@ -22,6 +16,7 @@ import {
   federationFollowingDocumentResponse,
   federationLikedDocumentResponse,
   federationOutboxDocumentResponse,
+  federationWebFingerResponse,
   resolveConfiguredFederationPublicOrigin
 } from "../src/http.js"
 import { clearFederationState } from "../src/services/federation.js"
@@ -63,6 +58,7 @@ const federationDocumentHandler = HttpApp.toWebHandler(
   Effect.flatten(
     HttpRouter.toHttpApp(
       HttpRouter.empty.pipe(
+        HttpRouter.get("/.well-known/webfinger", federationWebFingerResponse()),
         HttpRouter.get("/federation/actor", federationActorDocumentResponse()),
         HttpRouter.get("/federation/outbox", federationOutboxDocumentResponse()),
         HttpRouter.get("/federation/followers", federationFollowersDocumentResponse()),
@@ -138,20 +134,24 @@ const readNestedField = (value: object | null, parent: string, key: string): unk
   return typeof nested === "object" && nested !== null ? Reflect.get(nested, key) : undefined
 }
 
-const decodeOrThrow = <A, I>(schema: Schema.Schema<A, I, never>, value: unknown): A =>
-  Either.match(Schema.decodeUnknownEither(schema, exactActivityPubParseOptions)(value), {
-    onLeft: (error) => {
-      throw new Error(ParseResult.TreeFormatter.formatIssueSync(error.issue))
-    },
-    onRight: (decoded) => decoded
-  })
+const unsupportedMastodonTerms = [
+  "https://purl.archive.org/socialweb/webfinger",
+  "http://joinmastodon.org/ns#",
+  "toot:",
+  "featuredTags",
+  "alsoKnownAs",
+  "movedTo",
+  "manuallyApprovesFollowers",
+  "discoverable",
+  "suspended",
+  "interactionPolicy"
+] as const
 
-const decodeFederationDocument = (expectedType: string, payload: object | null): void => {
-  if (expectedType === "Person") {
-    decodeOrThrow(ActivityPubPersonSchema, payload)
-    return
+const assertNoMastodonTerms = (payload: object | null): void => {
+  const serialized = JSON.stringify(payload)
+  for (const term of unsupportedMastodonTerms) {
+    expect(serialized.includes(term)).toBe(false)
   }
-  decodeOrThrow(ActivityPubOrderedCollectionSchema, payload)
 }
 
 const federationDocumentCases: ReadonlyArray<{
@@ -168,25 +168,25 @@ const federationDocumentCases: ReadonlyArray<{
   },
   {
     path: "/federation/outbox",
-    expectedContext: activityForgeFedJsonLdContext,
+    expectedContext: activityStreamsJsonLdContext,
     expectedId: "https://public.example.test/federation/outbox",
     expectedType: "OrderedCollection"
   },
   {
     path: "/federation/followers",
-    expectedContext: activityForgeFedJsonLdContext,
+    expectedContext: activityStreamsJsonLdContext,
     expectedId: "https://public.example.test/federation/followers",
     expectedType: "OrderedCollection"
   },
   {
     path: "/federation/following",
-    expectedContext: activityForgeFedJsonLdContext,
+    expectedContext: activityStreamsJsonLdContext,
     expectedId: "https://public.example.test/federation/following",
     expectedType: "OrderedCollection"
   },
   {
     path: "/federation/liked",
-    expectedContext: activityForgeFedJsonLdContext,
+    expectedContext: activityStreamsJsonLdContext,
     expectedId: "https://public.example.test/federation/liked",
     expectedType: "OrderedCollection"
   }
@@ -267,11 +267,11 @@ describe("api http config", () => {
         expect(readField(payload, "@context")).toEqual(documentCase.expectedContext)
         expect(readField(payload, "type")).toBe(documentCase.expectedType)
         expect(readField(payload, "id")).toBe(documentCase.expectedId)
-        decodeFederationDocument(documentCase.expectedType, payload)
+        assertNoMastodonTerms(payload)
       }))
   }
 
-  it.effect("serves followers page as typed ActivityPub JSON-LD", () =>
+  it.effect("serves followers page as Fedify ActivityPub JSON-LD", () =>
     Effect.gen(function*(_) {
       yield* _(Effect.sync(() => clearFederationState()))
 
@@ -280,11 +280,40 @@ describe("api http config", () => {
 
       expect(document.status).toBe(200)
       expect(document.contentType).toBe(federationJsonLdResponseContentType)
-      expect(readField(payload, "@context")).toEqual(activityForgeFedJsonLdContext)
+      expect(readField(payload, "@context")).toBe(activityStreamsJsonLdContext)
       expect(readField(payload, "type")).toBe("OrderedCollectionPage")
       expect(readField(payload, "id")).toBe("https://public.example.test/federation/followers?page=1")
       expect(readField(payload, "partOf")).toBe("https://public.example.test/federation/followers")
-      decodeOrThrow(ActivityPubOrderedCollectionPageSchema, payload)
+      assertNoMastodonTerms(payload)
+    }))
+
+  it.effect("serves WebFinger through Fedify", () =>
+    Effect.gen(function*(_) {
+      yield* _(Effect.sync(() => clearFederationState()))
+
+      const document = yield* _(
+        readFederationDocumentRoute(
+          "/.well-known/webfinger?resource=acct:docker-git@public.example.test"
+        )
+      )
+      const payload = parseJsonObject(document.body)
+      const links = readField(payload, "links")
+
+      expect(document.status).toBe(200)
+      expect(document.contentType).toBe("application/jrd+json")
+      expect(readField(payload, "subject")).toBe("acct:docker-git@public.example.test")
+      expect(readField(payload, "aliases")).toEqual([
+        "https://public.example.test/federation/actor"
+      ])
+      expect(Array.isArray(links)).toBe(true)
+      if (!Array.isArray(links)) {
+        throw new Error("Expected WebFinger links.")
+      }
+      expect(links[0]).toEqual({
+        rel: "self",
+        href: "https://public.example.test/federation/actor",
+        type: "application/activity+json"
+      })
     }))
 
   it.effect("rejects unsupported followers pages", () =>

--- a/packages/app/scripts/serve-dist-web-routing.mjs
+++ b/packages/app/scripts/serve-dist-web-routing.mjs
@@ -1,0 +1,53 @@
+const dbGateOwnedPathPrefixes = [
+  "/admin",
+  "/admin-license",
+  "/build/",
+  "/bulma.css",
+  "/connections",
+  "/database-connections",
+  "/dimensions.css",
+  "/favicon.ico",
+  "/forgot-password",
+  "/global.css",
+  "/icon-colors.css",
+  "/license",
+  "/login",
+  "/manifest.json",
+  "/oauth",
+  "/plugins",
+  "/redirect",
+  "/reset-password",
+  "/runners",
+  "/scheduler",
+  "/set-admin-password",
+  "/storage",
+  "/tokens.css"
+]
+
+const isDbGateOwnedPath = (pathname) =>
+  dbGateOwnedPathPrefixes.some((prefix) => pathname === prefix || pathname.startsWith(prefix))
+
+const isFederationPath = (pathname) =>
+  pathname === "/federation" || pathname.startsWith("/federation/")
+
+// CHANGE: expose the standards-defined WebFinger endpoint at the public root.
+// WHY: ActivityPub discovery queries /.well-known/webfinger on the actor domain, not under /api.
+// QUOTE(ТЗ): "В руте .well-known должен быть"
+// REF: issue-334-webfinger-root-route
+// SOURCE: https://www.rfc-editor.org/rfc/rfc7033
+// FORMAT THEOREM: forall p: p = "/.well-known/webfinger" -> proxyTarget(p) = API(p)
+// PURITY: CORE
+// INVARIANT: only the WebFinger well-known path is claimed by the browser shell.
+// COMPLEXITY: O(1)/O(1)
+const isWellKnownWebFingerPath = (pathname) =>
+  pathname === "/.well-known/webfinger"
+
+export const shouldProxyHttpPath = (pathname) =>
+  pathname === "/api" ||
+  pathname.startsWith("/api/") ||
+  isFederationPath(pathname) ||
+  isWellKnownWebFingerPath(pathname) ||
+  pathname.startsWith("/p/") ||
+  pathname.startsWith("/b/") ||
+  pathname.startsWith("/d/") ||
+  isDbGateOwnedPath(pathname)

--- a/packages/app/scripts/serve-dist-web.mjs
+++ b/packages/app/scripts/serve-dist-web.mjs
@@ -7,6 +7,8 @@ import { fileURLToPath } from "node:url"
 
 import { WebSocket, WebSocketServer } from "ws"
 
+import { shouldProxyHttpPath } from "./serve-dist-web-routing.mjs"
+
 const appRoot = normalize(join(fileURLToPath(new URL(".", import.meta.url)), ".."))
 const staticRoot = join(appRoot, "dist-web")
 const trimTrailingSlashes = (value) => value.replace(/\/+$/u, "")
@@ -63,35 +65,6 @@ const reachableUrls = (host, port) =>
     ? [`http://127.0.0.1:${port}`, ...hostNetworkUrls(port)]
     : [`http://${host}:${port}`]
 
-const dbGateOwnedPathPrefixes = [
-  "/admin",
-  "/admin-license",
-  "/build/",
-  "/bulma.css",
-  "/connections",
-  "/database-connections",
-  "/dimensions.css",
-  "/favicon.ico",
-  "/forgot-password",
-  "/global.css",
-  "/icon-colors.css",
-  "/license",
-  "/login",
-  "/manifest.json",
-  "/oauth",
-  "/plugins",
-  "/redirect",
-  "/reset-password",
-  "/runners",
-  "/scheduler",
-  "/set-admin-password",
-  "/storage",
-  "/tokens.css"
-]
-
-const isDbGateOwnedPath = (pathname) =>
-  dbGateOwnedPathPrefixes.some((prefix) => pathname === prefix || pathname.startsWith(prefix))
-
 const resolveStaticPath = (pathname) => {
   const normalized = normalize(pathname)
   return normalized.startsWith(staticRoot)
@@ -122,9 +95,6 @@ const resolveUpstreamPath = (url) => {
   const pathname = parsed.pathname.replace(/^\/api/u, "") || "/"
   return `${pathname}${parsed.search}`
 }
-
-const isFederationPath = (pathname) =>
-  pathname === "/federation" || pathname.startsWith("/federation/")
 
 const firstHeader = (value) => Array.isArray(value) ? value[0] : value
 
@@ -273,15 +243,7 @@ const bridgeWebSockets = (clientSocket, upstream) => {
 
 const server = createServer((request, response) => {
   const parsed = new URL(request.url ?? "/", "http://localhost")
-  if (
-    parsed.pathname === "/api" ||
-    parsed.pathname.startsWith("/api/") ||
-    isFederationPath(parsed.pathname) ||
-    parsed.pathname.startsWith("/p/") ||
-    parsed.pathname.startsWith("/b/") ||
-    parsed.pathname.startsWith("/d/") ||
-    isDbGateOwnedPath(parsed.pathname)
-  ) {
+  if (shouldProxyHttpPath(parsed.pathname)) {
     proxyHttp(request, response)
     return
   }

--- a/packages/app/tests/docker-git/serve-dist-web.test.ts
+++ b/packages/app/tests/docker-git/serve-dist-web.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from "@effect/vitest"
+import { Effect } from "effect"
+
+import { shouldProxyHttpPath } from "../../scripts/serve-dist-web-routing.mjs"
+
+describe("serve-dist-web routing", () => {
+  it.effect("proxies root WebFinger to API", () =>
+    Effect.sync(() => {
+      expect(shouldProxyHttpPath("/.well-known/webfinger")).toBe(true)
+      expect(shouldProxyHttpPath("/.well-known/webfinger/extra")).toBe(false)
+      expect(shouldProxyHttpPath("/api/.well-known/webfinger")).toBe(true)
+      expect(shouldProxyHttpPath("/federation/actor")).toBe(true)
+      expect(shouldProxyHttpPath("/unknown-route")).toBe(false)
+    }))
+})

--- a/packages/app/vite.web.config.ts
+++ b/packages/app/vite.web.config.ts
@@ -18,6 +18,12 @@ const noStoreHeaders = {
 const webSocketHeartbeatIntervalMs = 25_000
 
 const createProxy = (apiTarget: string) => ({
+  "/.well-known/webfinger": {
+    target: apiTarget,
+    changeOrigin: false,
+    xfwd: true,
+    ws: false
+  },
   "/b": {
     target: apiTarget,
     changeOrigin: false,


### PR DESCRIPTION
## Summary

Fixes #334 by replacing the local ActivityPub document builders with Fedify/@fedify/vocab instead of treating one Mastodon actor response as docker-git's exact contract.

- Local ActivityPub `Person`, `OrderedCollection`, `OrderedCollectionPage`, and `Follow` documents are now constructed through Fedify vocabulary classes.
- Existing `/federation/actor`, `/federation/outbox`, `/federation/followers`, `/federation/followers?page=1`, `/federation/following`, and `/federation/liked` URLs are preserved.
- Root `/.well-known/webfinger` is served through Fedify for the local federation actor and is exposed by the browser frontend, not only the `/api` proxy prefix.
- ForgeFed `Ticket` remains validated at the Effect Schema boundary.
- Mastodon-specific extension fields are intentionally not supported or emitted.

## Corrected Protocol Interpretation

The Mastodon JSON from the discussion is a compatibility example, not the protocol contract for docker-git. docker-git emits only the supported ActivityStreams/security JSON-LD shape needed for its local actor and collections. It does not emit Mastodon extension context terms or keys such as `https://purl.archive.org/socialweb/webfinger`, `toot`, `featured`, `featuredTags`, `alsoKnownAs`, `movedTo`, `discoverable`, or `interactionPolicy`.

WebFinger discovery is different from the API namespace: RFC 7033 requires the path component `/.well-known/webfinger`, so a public browser/tunnel origin must proxy that exact root route to the API. `/api/.well-known/webfinger` can work as an internal alias, but remote ActivityPub servers will query the root route.

## Proof Obligations

### Invariants

- `forall d in LocalActivityPubDocuments: d = FedifyVocabularyObject.toJsonLd(d)` for actor/collections/follow activities.
- `forall d in LocalActivityPubDocuments: unsupported_mastodon_terms(d) = empty`.
- `forall route in LegacyFederationRoutes: HTTP_GET(route) = 200 and content-type(route) = application/activity+json`.
- `GET /federation/followers?page=1` parses as Fedify `OrderedCollectionPage` and has `partOf = /federation/followers`.
- `GET /federation/followers?page=n, n != 1` returns typed `ApiBadRequestError` with HTTP 400.
- `forall f in ForgeFedTickets: accepted(f) -> Decode(ForgeFedTicketSchema, f) = Right(decoded)`.
- `forall r in {acct:docker-git@origin, actorUrl}: WebFinger(r)` returns a JRD self link to the same Fedify actor URL.
- `forall q in QueryString: BrowserGET('/.well-known/webfinger' + q) -> ApiGET('/.well-known/webfinger' + q)` with `x-forwarded-prefix = ''`.
- `BrowserGET('/.well-known/webfinger/extra')` is not claimed as WebFinger, so the browser shell only exposes the standards-defined well-known path.

### Executable Evidence

- Fedify round-trip tests parse local actor/collection/page documents through `Person.fromJsonLd`, `OrderedCollection.fromJsonLd`, `OrderedCollectionPage.fromJsonLd`, and `Follow.fromJsonLd`.
- HTTP tests assert all local federation routes still respond at the existing URLs and reject unsupported followers pages.
- API HTTP tests assert Fedify WebFinger returns `application/jrd+json`, subject `acct:docker-git@origin`, alias actor URL, and self link `application/activity+json`.
- Browser frontend routing tests assert root `/.well-known/webfinger` is proxied to API while `/.well-known/webfinger/extra` is not.
- Structural negative tests recursively reject unsupported Mastodon context terms and keys without stringifying the whole document.
- Property-based tests cover Fedify actor URL/context invariants, following collection item-count invariants, WebFinger JRD invariants, and ForgeFed Ticket boundary decoding.
- Property tests keep async boundaries inside Effect composition and return `Effect.runPromise(Effect.gen(...))` to fast-check.
- README documents the supported WebFinger endpoint and the intentionally unsupported Mastodon extension terms.

## Verification

Latest local verification on commit `3c72a3b64f6b4379a75046ba22e4303ebbce21e2`:

```bash
bun --cwd packages/api typecheck
bun --cwd packages/api lint
bun --cwd packages/api test
bun --cwd packages/api test federation http-config
bun --cwd packages/api test http-config
bun run --cwd packages/app vitest run tests/docker-git/serve-dist-web.test.ts -t "proxies root WebFinger to API"
bun run --cwd packages/app typecheck
bun run --cwd packages/app lint:tests
bun run --cwd packages/app lint:effect
bun run --cwd packages/app build:web
bun run --cwd packages/api vitest run tests/http-config.test.ts -t "serves WebFinger through Fedify"
```

Live tunnel verification after restarting the browser runtime:

```bash
curl -i 'https://speaking-creator-headquarters-nearest.trycloudflare.com/.well-known/webfinger?resource=acct:docker-git@speaking-creator-headquarters-nearest.trycloudflare.com'
# HTTP 200, content-type: application/jrd+json
# self.href = https://speaking-creator-headquarters-nearest.trycloudflare.com/federation/actor
```
