### PR TITLE
fix(app): pin React and stabilize E2E builds

### DIFF
--- a/.changeset/fix-gridland-react-singleton.md
+++ b/.changeset/fix-gridland-react-singleton.md
@@ -1,0 +1,5 @@
+---
+"@prover-coder-ai/docker-git": patch
+---
+
+Pin React and React DOM to the Gridland renderer-compatible 19.2.4 release so the CLI menu keeps a single valid React hook dispatcher.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-08T07:16:05.142Z for PR creation at branch issue-385-c985e1f92a8e for issue https://github.com/ProverCoderAI/docker-git/issues/385

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-08T07:16:05.142Z for PR creation at branch issue-385-c985e1f92a8e for issue https://github.com/ProverCoderAI/docker-git/issues/385

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
  && apt-get install -y --no-install-recommends nodejs \
  && curl -fsSL https://bun.sh/install | bash \
- && npm i -g node-gyp @openai/codex
+ && npm i -g node-gyp@12.4.0 @openai/codex
 
 # Create non-root user for SSH
 RUN useradd -m -s /bin/bash dev

--- a/bun.lock
+++ b/bun.lock
@@ -41,7 +41,7 @@
     },
     "packages/app": {
       "name": "@prover-coder-ai/docker-git",
-      "version": "1.1.50",
+      "version": "1.1.54",
       "bin": {
         "docker-git": "dist/src/docker-git/main.js",
       },
@@ -62,8 +62,8 @@
         "@gridland/web": "0.4.3",
         "@prover-coder-ai/docker-git-session-sync": "workspace:*",
         "effect": "^3.21.2",
-        "react": "^19.2.7",
-        "react-dom": "^19.2.7",
+        "react": "19.2.4",
+        "react-dom": "19.2.4",
         "react-reconciler": "^0.33.0",
         "ts-morph": "^28.0.0",
       },
@@ -110,7 +110,7 @@
     },
     "packages/docker-git-session-sync": {
       "name": "@prover-coder-ai/docker-git-session-sync",
-      "version": "1.0.53",
+      "version": "1.0.57",
       "bin": {
         "docker-git-session-sync": "dist/docker-git-session-sync.js",
       },
@@ -184,7 +184,7 @@
         "@effect/platform-node": "^0.107.0",
         "@effect/schema": "^0.75.5",
         "effect": "^3.21.2",
-        "react": "^19.2.7",
+        "react": "19.2.4",
         "xterm": "^5.3.0",
         "xterm-addon-fit": "^0.8.0",
       },
@@ -217,7 +217,7 @@
         "fast-check": "^4.8.0",
         "globals": "^17.6.0",
         "jscpd": "^4.2.4",
-        "react-dom": "^19.2.7",
+        "react-dom": "19.2.4",
         "typescript": "^6.0.3",
         "typescript-eslint": "^8.60.1",
         "vite": "^8.0.16",
@@ -233,7 +233,8 @@
     "@parcel/watcher",
   ],
   "overrides": {
-    "react": "19.2.7",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
   },
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.27.1", "", { "dependencies": { "@babel/helper-validator-identifier": "7.28.5", "js-tokens": "4.0.0", "picocolors": "1.1.1" } }, "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg=="],
@@ -1566,9 +1567,9 @@
 
     "rdf-canonize": ["rdf-canonize@5.0.0", "", { "dependencies": { "setimmediate": "^1.0.5" } }, "sha512-g8OUrgMXAR9ys/ZuJVfBr05sPPoMA7nHIVs8VEvg9QwM5W4GR2qSFEEHjsyHF1eWlBaf8Ev40WNjQFQ+nJTO3w=="],
 
-    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+    "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 
-    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
+    "react-dom": ["react-dom@19.2.4", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.4" } }, "sha512-AXJdLo8kgMbimY95O2aKQqsz2iWi9jMgKJhRBAxECE4IFxfcazB2LmzloIoibJI3C12IlY20+KFaLv+71bUJeQ=="],
 
     "react-is": ["react-is@18.3.1", "", {}, "sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg=="],
 

--- a/package.json
+++ b/package.json
@@ -62,7 +62,8 @@
     "unrs-resolver"
   ],
   "overrides": {
-    "react": "19.2.7"
+    "react": "19.2.4",
+    "react-dom": "19.2.4"
   },
   "repository": {
     "type": "git",

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -53,7 +53,7 @@ RUN set -eu; \
       if curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://deb.nodesource.com/setup_24.x -o /tmp/nodesource-setup.sh \
         && bash /tmp/nodesource-setup.sh \
         && apt-get -o Acquire::Retries=3 install -y --no-install-recommends nodejs \
-        && npm install -g --prefix /opt/bun --no-audit --no-fund bun@1.3.11 node-gyp \
+        && npm install -g --prefix /opt/bun --no-audit --no-fund bun@1.3.11 node-gyp@12.4.0 \
         && node -v \
         && npm -v \
         && bun --version \

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -46,11 +46,32 @@ RUN set -eu; \
  && nvidia-ctk runtime configure --runtime=docker \
  && rm -rf /var/lib/apt/lists/*
 
-RUN curl -fsSL https://deb.nodesource.com/setup_24.x | bash - \
- && apt-get install -y --no-install-recommends nodejs \
- && curl -fsSL https://bun.sh/install | bash \
- && npm i -g node-gyp \
- && rm -rf /var/lib/apt/lists/*
+RUN set -eu; \
+    installed=0; \
+    for attempt in 1 2 3 4 5; do \
+      rm -rf /var/lib/apt/lists/* /opt/bun; \
+      if curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 https://deb.nodesource.com/setup_24.x -o /tmp/nodesource-setup.sh \
+        && bash /tmp/nodesource-setup.sh \
+        && apt-get -o Acquire::Retries=3 install -y --no-install-recommends nodejs \
+        && npm install -g --prefix /opt/bun --no-audit --no-fund bun@1.3.11 node-gyp \
+        && node -v \
+        && npm -v \
+        && bun --version \
+        && test "$(bun --version)" = "1.3.11" \
+        && node-gyp --version; then \
+        installed=1; \
+        break; \
+      fi; \
+      echo "controller tooling install attempt ${attempt} failed; retrying..." >&2; \
+      rm -f /tmp/nodesource-setup.sh; \
+      sleep $((attempt * 2)); \
+    done; \
+    if [ "$installed" != "1" ]; then \
+      echo "controller tooling install failed after retries" >&2; \
+      exit 1; \
+    fi; \
+    rm -f /tmp/nodesource-setup.sh; \
+    rm -rf /var/lib/apt/lists/*
 
 FROM controller-base AS workspace-deps
 

--- a/packages/app/package.json
+++ b/packages/app/package.json
@@ -80,8 +80,8 @@
     "@gridland/bun": "0.4.3",
     "@gridland/web": "0.4.3",
     "effect": "^3.21.2",
-    "react": "^19.2.7",
-    "react-dom": "^19.2.7",
+    "react": "19.2.4",
+    "react-dom": "19.2.4",
     "react-reconciler": "^0.33.0",
     "ts-morph": "^28.0.0"
   },

--- a/packages/app/tests/docker-git/controller-resource-limits.test.ts
+++ b/packages/app/tests/docker-git/controller-resource-limits.test.ts
@@ -113,8 +113,9 @@ describe("API Dockerfile controller tooling install", () => {
     Effect.gen(function*(_) {
       const contents = yield* _(readComposeFile("packages/api/Dockerfile"))
       expect(contents).toContain("https://deb.nodesource.com/setup_24.x -o /tmp/nodesource-setup.sh")
-      expect(contents).toContain("npm install -g --prefix /opt/bun --no-audit --no-fund bun@1.3.11 node-gyp")
+      expect(contents).toContain("npm install -g --prefix /opt/bun --no-audit --no-fund bun@1.3.11 node-gyp@12.4.0")
       expect(contents).toContain("curl -fsSL --retry 5 --retry-all-errors --retry-delay 2")
+      expect(contents).toContain("for attempt in 1 2 3 4 5; do")
       expect(contents).toContain("controller tooling install failed after retries")
       expect(contents).toContain("test \"$(bun --version)\" = \"1.3.11\"")
       expect(contents).toContain("node-gyp --version")

--- a/packages/app/tests/docker-git/controller-resource-limits.test.ts
+++ b/packages/app/tests/docker-git/controller-resource-limits.test.ts
@@ -121,6 +121,21 @@ describe("API Dockerfile controller tooling install", () => {
     }))
 })
 
+describe("OpenCode E2E auth bootstrap", () => {
+  it.effect("retries controller auth commands before the clone scenario", () =>
+    Effect.gen(function*(_) {
+      const contents = yield* _(readComposeFile("scripts/e2e/opencode-autoconnect.sh"))
+      expect(contents).toContain("auth_attempts=3")
+      expect(contents).toContain(": > \"$AUTH_LOG\"")
+      expect(contents).toContain("if (")
+      expect(contents).toContain("dg_run_docker_git \"$REPO_ROOT\" auth codex import")
+      expect(contents).toContain("dg_run_docker_git \"$REPO_ROOT\" auth codex status")
+      expect(contents).toContain(") >>\"$AUTH_LOG\" 2>&1")
+      expect(contents).toContain("auth bootstrap attempt $auth_attempt/$auth_attempts failed")
+      expect(contents).toContain("docker-git auth bootstrap failed after $auth_attempts attempts")
+    }))
+})
+
 describe("controller resource limit resolution", () => {
   it.effect("resolves CPU and RAM defaults to 90% of host resources", () =>
     Effect.sync(() => {

--- a/packages/app/tests/docker-git/controller-resource-limits.test.ts
+++ b/packages/app/tests/docker-git/controller-resource-limits.test.ts
@@ -108,6 +108,19 @@ describe("API Dockerfile Electron materialization", () => {
     }))
 })
 
+describe("API Dockerfile controller tooling install", () => {
+  it.effect("retries network-bound controller tooling downloads", () =>
+    Effect.gen(function*(_) {
+      const contents = yield* _(readComposeFile("packages/api/Dockerfile"))
+      expect(contents).toContain("https://deb.nodesource.com/setup_24.x -o /tmp/nodesource-setup.sh")
+      expect(contents).toContain("npm install -g --prefix /opt/bun --no-audit --no-fund bun@1.3.11 node-gyp")
+      expect(contents).toContain("curl -fsSL --retry 5 --retry-all-errors --retry-delay 2")
+      expect(contents).toContain("controller tooling install failed after retries")
+      expect(contents).toContain("test \"$(bun --version)\" = \"1.3.11\"")
+      expect(contents).toContain("node-gyp --version")
+    }))
+})
+
 describe("controller resource limit resolution", () => {
   it.effect("resolves CPU and RAM defaults to 90% of host resources", () =>
     Effect.sync(() => {

--- a/packages/app/tests/docker-git/gridland-react-singleton.test.ts
+++ b/packages/app/tests/docker-git/gridland-react-singleton.test.ts
@@ -19,6 +19,21 @@ const gridlandRendererReactVersion = "19.2.4"
 
 const stripCaret = (value: string): string => value.replace(/^\^/u, "")
 
+// CHANGE: resolve a dependency version from either dependencies or devDependencies.
+// WHY: the terminal package exports React components but never renders to the DOM itself,
+//      so `react-dom` is a devDependency there; the singleton pin must still be enforced
+//      wherever the dependency is declared. REF: PR-386 CodeRabbit review.
+const resolveDepVersion = (
+  pkg: { dependencies?: Record<string, string>; devDependencies?: Record<string, string> },
+  name: string
+): string => {
+  const version = pkg.dependencies?.[name] ?? pkg.devDependencies?.[name]
+  if (version === undefined) {
+    throw new Error(`Expected ${name} to be declared in dependencies or devDependencies`)
+  }
+  return stripCaret(version)
+}
+
 describe("Gridland React singleton contract", () => {
   it.effect("pins React across workspace dependencies for the Gridland renderer", () =>
     Effect.sync(() => {
@@ -26,7 +41,7 @@ describe("Gridland React singleton contract", () => {
       expect(rootPackage.overrides["react-dom"]).toBe(gridlandRendererReactVersion)
       expect(stripCaret(appPackage.dependencies.react)).toBe(gridlandRendererReactVersion)
       expect(stripCaret(appPackage.dependencies["react-dom"])).toBe(gridlandRendererReactVersion)
-      expect(stripCaret(terminalPackage.dependencies.react)).toBe(gridlandRendererReactVersion)
-      expect(stripCaret(terminalPackage.devDependencies["react-dom"])).toBe(gridlandRendererReactVersion)
+      expect(resolveDepVersion(terminalPackage, "react")).toBe(gridlandRendererReactVersion)
+      expect(resolveDepVersion(terminalPackage, "react-dom")).toBe(gridlandRendererReactVersion)
     }))
 })

--- a/packages/app/tests/docker-git/gridland-react-singleton.test.ts
+++ b/packages/app/tests/docker-git/gridland-react-singleton.test.ts
@@ -2,11 +2,31 @@ import { describe, expect, it } from "@effect/vitest"
 import { Effect } from "effect"
 
 import rootPackage from "../../../../package.json" with { type: "json" }
+import terminalPackage from "../../../terminal/package.json" with { type: "json" }
 import appPackage from "../../package.json" with { type: "json" }
+
+// CHANGE: encode the React version resolved for the Gridland Bun renderer.
+// WHY: @gridland/bun embeds react-reconciler@0.33.0; Bun resolves that renderer contract to React 19.2.4.
+// QUOTE(ISSUE): "TypeError: null is not an object (evaluating 'resolveDispatcher().useCallback')"
+// REF: issue-385
+// SOURCE: n/a
+// FORMAT THEOREM: workspaceReactVersion = rendererReactVersion -> dispatcher(hookCall) != null
+// PURITY: CORE
+// EFFECT: n/a
+// INVARIANT: every workspace React entry resolves to the renderer-compatible singleton version.
+// COMPLEXITY: O(1)
+const gridlandRendererReactVersion = "19.2.4"
+
+const stripCaret = (value: string): string => value.replace(/^\^/u, "")
 
 describe("Gridland React singleton contract", () => {
   it.effect("pins React across workspace dependencies for the Gridland renderer", () =>
     Effect.sync(() => {
-      expect(rootPackage.overrides.react).toBe(appPackage.dependencies.react.replace(/^\^/u, ""))
+      expect(rootPackage.overrides.react).toBe(gridlandRendererReactVersion)
+      expect(rootPackage.overrides["react-dom"]).toBe(gridlandRendererReactVersion)
+      expect(stripCaret(appPackage.dependencies.react)).toBe(gridlandRendererReactVersion)
+      expect(stripCaret(appPackage.dependencies["react-dom"])).toBe(gridlandRendererReactVersion)
+      expect(stripCaret(terminalPackage.dependencies.react)).toBe(gridlandRendererReactVersion)
+      expect(stripCaret(terminalPackage.devDependencies["react-dom"])).toBe(gridlandRendererReactVersion)
     }))
 })

--- a/packages/terminal/package.json
+++ b/packages/terminal/package.json
@@ -22,7 +22,7 @@
     "@effect/platform-node": "^0.107.0",
     "@effect/schema": "^0.75.5",
     "effect": "^3.21.2",
-    "react": "^19.2.7",
+    "react": "19.2.4",
     "xterm": "^5.3.0",
     "xterm-addon-fit": "^0.8.0"
   },
@@ -55,7 +55,7 @@
     "fast-check": "^4.8.0",
     "globals": "^17.6.0",
     "jscpd": "^4.2.4",
-    "react-dom": "^19.2.7",
+    "react-dom": "19.2.4",
     "typescript": "^6.0.3",
     "typescript-eslint": "^8.60.1",
     "vite": "^8.0.16",

--- a/scripts/e2e/opencode-autoconnect.sh
+++ b/scripts/e2e/opencode-autoconnect.sh
@@ -124,11 +124,26 @@ OPENCODE_AUTO_CONNECT=1
 EOF_ENV
 
 AUTH_LOG="$ROOT/codex-auth.log"
-(
-  cd "$REPO_ROOT"
-  dg_run_docker_git "$REPO_ROOT" auth codex import --codex-auth "$ROOT/.orch/auth/codex"
-  dg_run_docker_git "$REPO_ROOT" auth codex status --codex-auth "$ROOT/.orch/auth/codex"
-) >"$AUTH_LOG" 2>&1
+auth_attempts=3
+auth_attempt=1
+auth_exit=0
+: > "$AUTH_LOG"
+while [[ "$auth_attempt" -le "$auth_attempts" ]]; do
+  if (
+    cd "$REPO_ROOT"
+    dg_run_docker_git "$REPO_ROOT" auth codex import --codex-auth "$ROOT/.orch/auth/codex"
+    dg_run_docker_git "$REPO_ROOT" auth codex status --codex-auth "$ROOT/.orch/auth/codex"
+  ) >>"$AUTH_LOG" 2>&1; then
+    auth_exit=0
+    break
+  else
+    auth_exit=$?
+  fi
+  echo "e2e/opencode-autoconnect: auth bootstrap attempt $auth_attempt/$auth_attempts failed (exit: $auth_exit); retrying..." >&2
+  auth_attempt="$((auth_attempt + 1))"
+  sleep 2
+done
+[[ "$auth_exit" -eq 0 ]] || fail "docker-git auth bootstrap failed after $auth_attempts attempts (last exit: $auth_exit)"
 
 auth_confirmation_count="$(grep -Fc -- "Codex auth imported into controller state (account: ci@example.com)." "$AUTH_LOG" || true)"
 [[ "$auth_confirmation_count" -ge 2 ]] \


### PR DESCRIPTION
## Summary

- Pin `react` and `react-dom` to `19.2.4` across the app package, terminal workspace, and root overrides so Gridland's Bun renderer uses the React version it resolves for `react-reconciler@0.33.0`.
- Add a regression test for the Gridland React singleton contract.
- Harden the controller image tooling install used by `E2E (Clone cache)`: retry the NodeSource setup, install `bun@1.3.11` from npm under `/opt/bun`, verify the installed Bun version, and keep `node-gyp` installation in the same checked boundary.
- Retry the OpenCode E2E auth bootstrap before the clone scenario, so transient controller image build failures from Docker Hub metadata lookups do not fail the job before the bounded retry budget is exhausted.
- Add regression tests for the controller Dockerfile tooling-install contract and OpenCode auth-bootstrap retry contract.
- Add a patch changeset for `@prover-coder-ai/docker-git` and remove the initial PR placeholder `.gitkeep`.

## Reproduction

Before the React fix, the focused regression test fails with:

```text
expected '19.2.7' to be '19.2.4'
```

This captures the same contract behind the issue stack (`resolveDispatcher().useCallback`): hooks in the TUI must be dispatched by the same React singleton/version that Gridland's renderer expects.

For the original failing CI check, `E2E (Clone cache)` failed while building `packages/api/Dockerfile` at the controller tooling install layer. A local no-cache build reproduced repeated Bun release download failures:

```text
curl: (22) The requested URL returned error: 504
error: Failed to download bun from "https://github.com/oven-sh/bun/releases/latest/download/bun-linux-x64.zip"
```

After the Dockerfile fix, the controller-base build installs Bun from the npm registry and verifies:

```text
v24.16.0
11.13.0
1.3.11
v12.4.0
```

On the next CI run, `E2E (Clone cache)` passed and `E2E (OpenCode)` exposed a separate transient controller build failure during auth bootstrap:

```text
failed to resolve source metadata for docker.io/library/ubuntu:26.04: failed to do request: Head "https://registry-1.docker.io/v2/library/ubuntu/manifests/26.04": dial tcp ...:443: i/o timeout
```

The OpenCode auth bootstrap now retries the controller auth commands before failing the E2E scenario.

## Mathematical Guarantees

### Invariants

- `∀ dep ∈ {root overrides, app react/react-dom, terminal react/react-dom}: version(dep) = 19.2.4`
- `version(react) = version(Gridland renderer peer resolution) -> dispatcher(hookCall) != null`
- `controllerBase.tooling.bun.version = packageManager.bun.version = 1.3.11`
- `controllerBase.tooling.install.success -> node ∧ npm ∧ bun ∧ node-gyp are executable`
- `OpenCode.authBootstrap.transientFailure(k), 1 <= k < 3 -> scenario continues to attempt k + 1`
- `OpenCode.authBootstrap.failureCount = 3 -> typed E2E failure message is emitted before clone assertions`

### Preconditions

- The CLI menu is rendered through `@gridland/bun@0.4.3` and `react-reconciler@0.33.0`.
- The controller image build can reach NodeSource and the npm registry.
- Transient Docker Hub metadata failures may occur during controller startup.

### Postconditions

- Workspace install resolves one `react@19.2.4` and one `react-dom@19.2.4` for the app/terminal packages.
- The focused singleton test fails on the previous `19.2.7` state and passes after the pin.
- The controller image no longer depends on the Bun `github.com/.../latest/download` endpoint during CI.
- The Dockerfile test fails if the retry/version/tooling-install contract is removed.
- The OpenCode E2E script test fails if auth bootstrap loses bounded retry or reintroduces the `ERR` trap path for expected retry failures.

## Verification

- `bun install --frozen-lockfile`
- `npm view bun@1.3.11 version dist.tarball --json`
- `npm install -g --prefix /tmp/bun-npm-global-test bun@1.3.11 node-gyp && /tmp/bun-npm-global-test/bin/bun --version && /tmp/bun-npm-global-test/bin/node-gyp --version`
- `bash -n scripts/e2e/opencode-autoconnect.sh`
- `bun run --cwd packages/app vitest run tests/docker-git/controller-resource-limits.test.ts`
- `docker build --progress plain --target controller-base -f packages/api/Dockerfile -t docker-git-controller-base-e2e-385 .`
- `bun run --cwd packages/app test`
- `bun run --cwd packages/app check`
- `bun run check`
- `bun run test`
- `git diff --check`

SOURCE: GitHub Actions logs for PR 386 and npm registry metadata via `npm view`.

Fixes ProverCoderAI/docker-git#385
