### PR TITLE
'Почему-то запущено много сесий с контейнером браузера'

### DIFF
--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-08T07:55:37.526Z for PR creation at branch issue-383-173b143467d9 for issue https://github.com/ProverCoderAI/docker-git/issues/383

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-08T07:55:37.526Z for PR creation at branch issue-383-173b143467d9 for issue https://github.com/ProverCoderAI/docker-git/issues/383

--- a/packages/api/src/services/container-tasks-core.ts
+++ b/packages/api/src/services/container-tasks-core.ts
@@ -27,6 +27,13 @@ const commandSuggestsSsh = (command: string): boolean => command.startsWith("ssh
 const commandSuggestsAgent = (command: string): boolean =>
   interactiveAgentPattern.test(command) || command.includes("docker-git-agent-")
 
+// Rust browser MCP helpers (`browser-connection`, `docker-git-browser-connection`)
+// run on an allocated pty, so without this they would be misclassified as visible
+// `ssh` terminals and flood the task manager (issue #383).
+const browserConnectionPattern = /(?:^|\/)(?:docker-git-browser-connection|browser-connection)\b/u
+
+const commandSuggestsBrowserHelper = (command: string): boolean => browserConnectionPattern.test(command)
+
 const resolveAncestorManagedId = (
   process: RawContainerProcess,
   pidToProcess: ReadonlyMap<number, RawContainerProcess>,
@@ -49,6 +56,9 @@ const classifyProcess = (
   process: RawContainerProcess,
   managedId: string | undefined
 ): ContainerTaskKind => {
+  if (commandSuggestsBrowserHelper(process.command)) {
+    return "system"
+  }
   if (managedId !== undefined || commandSuggestsAgent(process.command)) {
     return "agent"
   }
@@ -78,7 +88,7 @@ const compareTasks = (left: ContainerTask, right: ContainerTask): number => {
 // FORMAT THEOREM: forall p in Processes: classify(p) in ContainerTaskKind
 // PURITY: CORE
 // EFFECT: none
-// INVARIANT: includeDefault=false excludes only baseline system processes
+// INVARIANT: includeDefault=false excludes system processes (baseline + browser helpers)
 // COMPLEXITY: O(n * h) where h is maximum process ancestry depth
 export const buildContainerTasks = (
   processes: ReadonlyArray<RawContainerProcess>,

--- a/packages/api/tests/container-tasks-core.test.ts
+++ b/packages/api/tests/container-tasks-core.test.ts
@@ -31,6 +31,30 @@ describe("container task classification", () => {
       .toHaveLength(1)
   })
 
+  it("hides browser-connection MCP helpers as internal system tasks", () => {
+    const browserCommand =
+      "browser-connection --project dg-docker-git-issue-376 --network container:dg-docker-git-issue-376"
+    const visible = buildContainerTasks(
+      [
+        processOf({ command: browserCommand, pid: 11502, ppid: 5142, tty: "pts/1" }),
+        processOf({ command: "/usr/local/bin/docker-git-browser-connection start", pid: 11600, ppid: 5142, tty: "pts/1" }),
+        processOf({ command: "node server.js", pid: 20, ppid: 1, tty: "pts/2" })
+      ],
+      [],
+      false
+    )
+
+    expect(visible.map((task) => task.pid)).toEqual([20])
+
+    const withSystem = buildContainerTasks(
+      [processOf({ command: browserCommand, pid: 11502, ppid: 5142, tty: "pts/1" })],
+      [],
+      true
+    )
+
+    expect(withSystem.map((task) => [task.pid, task.kind])).toEqual([[11502, "system"]])
+  })
+
   it("marks descendants of managed agent pid as agent tasks", () => {
     const tasks = buildContainerTasks(
       [


### PR DESCRIPTION
## Summary

Fixes ProverCoderAI/docker-git#383 — the container task manager was flooded with many identical sessions for the browser container.

### Root cause
The Rust browser MCP helpers (`browser-connection` / `docker-git-browser-connection`) run on an allocated pty (`pts/N`). In `classifyProcess`, any non-baseline process with an interactive tty falls through to the `ssh` kind, so every helper showed up as a separate visible `ssh` terminal:

```
PID 11502  ssh  pts/1  browser-connection --project dg-docker-git-issue-376 --network container:dg-docker-git-issue-376
PID 14388  ssh  pts/1  browser-connection --project dg-docker-git-issue-376 --network container:dg-docker-git-issue-376
...
```

### Fix
`packages/api/src/services/container-tasks-core.ts` now classifies these helper processes as internal `system` tasks. Since `buildContainerTasks(..., includeDefault=false)` filters out `system` tasks, they no longer clutter the task manager and are only surfaced when system processes are explicitly requested.

### Reproduction & test
`packages/api/tests/container-tasks-core.test.ts` adds a regression test mirroring the command shape from the issue screenshot:
- A `browser-connection ... --network container:...` process on `pts/1` and a `/usr/local/bin/docker-git-browser-connection start` process are now excluded from the default task list.
- With `includeDefault=true` the helper is reported with kind `system` (not `ssh`).

Verified the test **fails** against the old classifier (helper classified as `ssh`) and **passes** with the fix.

### Checks
- `vitest run` for `container-tasks-core` + `project-browser`: passing.
- `tsc --noEmit` (api typecheck): passing.
- `eslint` on changed files: passing.

### Changes
- `packages/api/src/services/container-tasks-core.ts`: classify `browser-connection` / `docker-git-browser-connection` helpers as `system`.
- `packages/api/tests/container-tasks-core.test.ts`: regression test.
- Removed the placeholder `.gitkeep`.

Fixes ProverCoderAI/docker-git#383
