### PR TITLE
feat(shell): add browser daemon mode

### DIFF
--- a/.changeset/browser-daemon-mode.md
+++ b/.changeset/browser-daemon-mode.md
@@ -1,0 +1,5 @@
+---
+"@prover-coder-ai/docker-git": minor
+---
+
+Add daemon mode for `docker-git browser` via `-d` and `--daemon`.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-08T07:55:54.041Z for PR creation at branch issue-373-a0cce22a2f2d for issue https://github.com/ProverCoderAI/docker-git/issues/373

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-08T07:55:54.041Z for PR creation at branch issue-373-a0cce22a2f2d for issue https://github.com/ProverCoderAI/docker-git/issues/373

--- a/packages/app/src/docker-git/browser-frontend.ts
+++ b/packages/app/src/docker-git/browser-frontend.ts
@@ -63,6 +63,23 @@ type BrowserFrontendRuntimeState = {
   readonly webState: BrowserFrontendStateFile | null
 }
 
+export interface BrowserFrontendCommandOptions {
+  readonly daemon: boolean
+}
+
+const browserFrontendForegroundOptions: BrowserFrontendCommandOptions = { daemon: false }
+
+type BrowserFrontendLaunch = {
+  readonly env: Readonly<Record<string, string>>
+  readonly localUrl: string
+}
+
+type BrowserFrontendRunnerEffect = Effect.Effect<
+  void,
+  ControllerBootstrapError | PlatformError,
+  CommandExecutor.CommandExecutor
+>
+
 const browserEnv = (decision: BrowserFrontendStartDecision): Readonly<Record<string, string>> => ({
   ...copyProcessEnv(),
   DOCKER_GIT_API_URL: decision.apiBaseUrl,
@@ -76,18 +93,55 @@ const runStreaming = (
   args: ReadonlyArray<string>,
   env: Readonly<Record<string, string>>
 ): Effect.Effect<number, PlatformError, CommandExecutor.CommandExecutor> =>
-  runCommandExitCodeStreaming({
-    args,
-    command: "bun",
-    cwd: process.cwd(),
-    env
-  })
+  runCommandExitCodeStreaming({ args, command: "bun", cwd: process.cwd(), env })
 
 const parsePids = (output: string): ReadonlyArray<string> =>
   output
     .split(/\s+/u)
     .map((pid) => pid.trim())
     .filter((pid) => /^\d+$/u.test(pid))
+
+// CHANGE: derive a stable daemon log path beside the browser runtime state file.
+// WHY: detached mode must preserve diagnostics after the parent CLI exits.
+// QUOTE(ТЗ): "Run browser with support dameon mode, like a flag -d"
+// REF: issue-373
+// SOURCE: n/a
+// FORMAT THEOREM: suffix(statePath,".json") -> logPath = prefix(statePath,".json") + ".log"
+// PURITY: CORE
+// EFFECT: n/a
+// INVARIANT: every state path maps deterministically to exactly one log path
+// COMPLEXITY: O(n)/O(n) where n = |statePath|
+const browserFrontendLogPath = (statePath: string): string =>
+  statePath.endsWith(".json") ? `${statePath.slice(0, -".json".length)}.log` : `${statePath}.log`
+
+const parseDaemonPid = (output: string): Effect.Effect<string, ControllerBootstrapError> => {
+  const pid = parsePids(output)[0]
+  return pid === undefined
+    ? Effect.fail(browserFrontendError("Browser frontend daemon did not report a pid."))
+    : Effect.succeed(pid)
+}
+
+const startDaemon = (
+  args: ReadonlyArray<string>,
+  env: Readonly<Record<string, string>>,
+  logPath: string
+): Effect.Effect<string, ControllerBootstrapError | PlatformError, CommandExecutor.CommandExecutor> => {
+  const script = [
+    "log_path=\"$1\"",
+    "shift",
+    "command -v nohup >/dev/null 2>&1 || exit 127",
+    "command -v \"$1\" >/dev/null 2>&1 || exit 127",
+    "mkdir -p \"$(dirname \"$log_path\")\"",
+    "nohup \"$@\" >>\"$log_path\" 2>&1 < /dev/null &",
+    String.raw`printf '%s\n' "$!"`
+  ].join("\n")
+
+  return runCommandCapture(
+    { args: ["-c", script, "sh", logPath, "bun", ...args], command: "sh", cwd: process.cwd(), env },
+    [0],
+    () => browserFrontendError("Failed to start browser frontend daemon.")
+  ).pipe(Effect.flatMap((output) => parseDaemonPid(output)))
+}
 
 const findWebServerPids = (): Effect.Effect<ReadonlyArray<string>, never, CommandExecutor.CommandExecutor> => {
   const script = [
@@ -271,13 +325,19 @@ const ensureSuccess = (
     ? Effect.void
     : Effect.fail(browserFrontendError(`${action} failed with exit code ${exitCode}.`))
 
-export const runBrowserFrontend = (
+// CHANGE: share the browser frontend build phase between foreground and daemon modes.
+// WHY: daemon mode must not drift from foreground mode in revision, environment, or build failure semantics.
+// QUOTE(ТЗ): "Run browser with support dameon mode, like a flag -d"
+// REF: issue-373
+// SOURCE: n/a
+// FORMAT THEOREM: forall mode in {foreground,daemon}: launch(mode) -> built(webRevision)
+// PURITY: SHELL
+// EFFECT: Effect<BrowserFrontendLaunch, ControllerBootstrapError | PlatformError, CommandExecutor>
+// INVARIANT: launch env is derived exactly once from BrowserFrontendStartDecision
+// COMPLEXITY: O(build)/O(env)
+const buildBrowserFrontendLaunch = (
   decision: BrowserFrontendStartDecision
-): Effect.Effect<
-  void,
-  ControllerBootstrapError | PlatformError,
-  CommandExecutor.CommandExecutor
-> =>
+): Effect.Effect<BrowserFrontendLaunch, ControllerBootstrapError | PlatformError, CommandExecutor.CommandExecutor> =>
   Effect.gen(function*(_) {
     const env = browserEnv(decision)
     const localUrl = `http://${decision.host}:${decision.port}/`
@@ -285,11 +345,26 @@ export const runBrowserFrontend = (
     yield* _(Effect.log(`Building docker-git browser frontend ${decision.webRevision} for API ${decision.apiBaseUrl}.`))
     const buildExitCode = yield* _(runStreaming(["run", "--cwd", "packages/app", "build:web"], env))
     yield* _(ensureSuccess(buildExitCode, "Browser frontend build"))
+    return { env, localUrl }
+  })
 
-    yield* _(Effect.log(`docker-git browser frontend: ${localUrl}`))
+export const runBrowserFrontend = (decision: BrowserFrontendStartDecision): BrowserFrontendRunnerEffect =>
+  Effect.gen(function*(_) {
+    const launch = yield* _(buildBrowserFrontendLaunch(decision))
+    yield* _(Effect.log(`docker-git browser frontend: ${launch.localUrl}`))
     yield* _(Effect.log("Press Ctrl+C to stop the browser frontend."))
-    const serveExitCode = yield* _(runStreaming(["run", "--cwd", "packages/app", "serve:web"], env))
+    const serveExitCode = yield* _(runStreaming(["run", "--cwd", "packages/app", "serve:web"], launch.env))
     yield* _(ensureSuccess(serveExitCode, "Browser frontend server"))
+  })
+
+export const runBrowserFrontendDaemon = (decision: BrowserFrontendStartDecision): BrowserFrontendRunnerEffect =>
+  Effect.gen(function*(_) {
+    const launch = yield* _(buildBrowserFrontendLaunch(decision))
+    const logPath = browserFrontendLogPath(decision.statePath)
+
+    const pid = yield* _(startDaemon(["run", "--cwd", "packages/app", "serve:web"], launch.env, logPath))
+    yield* _(Effect.log(`docker-git browser frontend daemon: ${launch.localUrl} (pid ${pid})`))
+    yield* _(Effect.log(`docker-git browser frontend daemon log: ${logPath}`))
   })
 
 // CHANGE: make `docker-git browser` idempotent for local development
@@ -302,15 +377,25 @@ export const runBrowserFrontend = (
 // EFFECT: Effect<void, ControllerBootstrapError | PlatformError, ControllerRuntime>
 // INVARIANT: controller readiness is checked independently from browser runtime reuse
 // COMPLEXITY: O(total_bytes(web_inputs) + processes + controller_probe)
+export const runBrowserFrontendCommandWithOptions = (
+  options: BrowserFrontendCommandOptions
+): Effect.Effect<
+  void,
+  ControllerBootstrapError | PlatformError,
+  ControllerRuntime
+> =>
+  pipe(
+    prepareBrowserStack(),
+    Effect.flatMap((decision) => {
+      if (!decision.shouldStartWeb) {
+        return Effect.log(`docker-git browser frontend is already running at http://${decision.host}:${decision.port}/`)
+      }
+      return options.daemon ? runBrowserFrontendDaemon(decision) : runBrowserFrontend(decision)
+    })
+  )
+
 export const runBrowserFrontendCommand: Effect.Effect<
   void,
   ControllerBootstrapError | PlatformError,
   ControllerRuntime
-> = pipe(
-  prepareBrowserStack(),
-  Effect.flatMap((decision) =>
-    decision.shouldStartWeb
-      ? runBrowserFrontend(decision)
-      : Effect.log(`docker-git browser frontend is already running at http://${decision.host}:${decision.port}/`)
-  )
-)
+> = runBrowserFrontendCommandWithOptions(browserFrontendForegroundOptions)

--- a/packages/app/src/docker-git/cli/parser.ts
+++ b/packages/app/src/docker-git/cli/parser.ts
@@ -20,9 +20,22 @@ const isHelpFlag = (token: string): boolean => token === "--help" || token === "
 
 const helpCommand: Command = { _tag: "Help", message: usageText }
 const menuCommand: Command = { _tag: "Menu" }
-const browserCommand: Command = { _tag: "Browser" }
 const statusCommand: Command = { _tag: "Status" }
 const downAllCommand: Command = { _tag: "DownAll" }
+const browserDaemonFlags = new Set(["-d", "--daemon"])
+
+// CHANGE: parse browser daemon mode without side effects.
+// WHY: CLI intent must be a typed pure value before the shell starts web processes.
+// QUOTE(ТЗ): "Run browser with support dameon mode, like a flag -d"
+// REF: issue-373
+// SOURCE: n/a
+// FORMAT THEOREM: forall args: daemon(parseBrowser(args)) <-> exists a in args: a in {"-d","--daemon"}
+// PURITY: CORE
+// EFFECT: n/a
+// INVARIANT: browser foreground mode is the default when no daemon flag is present
+// COMPLEXITY: O(n)/O(1) where n = |args|
+const parseBrowser = (args: ReadonlyArray<string>): Either.Either<Command, ParseError> =>
+  Either.right({ _tag: "Browser", daemon: args.some((arg) => browserDaemonFlags.has(arg)) })
 
 // CHANGE: parse --active flag for apply-all command to restrict to running containers
 // WHY: allow users to apply config only to currently active containers via --active flag
@@ -90,8 +103,8 @@ export const parseArgs = (args: ReadonlyArray<string>): Either.Either<Command, P
       Match.when("ui", () => Either.right(menuCommand))
     )
     .pipe(
-      Match.when("browser", () => Either.right(browserCommand)),
-      Match.when("web", () => Either.right(browserCommand)),
+      Match.when("browser", () => parseBrowser(rest)),
+      Match.when("web", () => parseBrowser(rest)),
       Match.when("apply-all", () => parseApplyAll(rest)),
       Match.when("update-all", () => parseApplyAll(rest)),
       Match.when("auth", () => parseAuth(rest)),

--- a/packages/app/src/docker-git/cli/usage.ts
+++ b/packages/app/src/docker-git/cli/usage.ts
@@ -1,7 +1,7 @@
 export { formatParseError } from "../frontend-lib/core/parse-errors.js"
 
 export const usageText = `docker-git menu
-docker-git browser
+docker-git browser [-d|--daemon]
 docker-git create [--repo-url <url>] [options]
 docker-git clone <url> [options]
 docker-git open [<selector>] [options]
@@ -21,7 +21,7 @@ docker-git state <action> [options]
 
 Commands:
   menu                Interactive menu (default when no args)
-  browser             Build and serve the browser frontend for the docker-git controller
+  browser             Build and serve the browser frontend for the docker-git controller; use -d to run it as a daemon
   create, init        Generate docker development environment (repo URL optional)
   clone               Create + run container and clone repo
   open                Open an existing docker-git project by selector, URL, or path
@@ -79,6 +79,7 @@ Options:
   --ssh | --no-ssh          Auto-open SSH after create/clone (default: clone=--ssh, create=--no-ssh)
   --mcp-playwright | --no-mcp-playwright  Enable Rust browser MCP + noVNC/CDP session (default: --no-mcp-playwright)
   --auto[=claude|codex|gemini|grok]  Auto-execute an agent; without value picks by auth, random if multiple are available
+  -d, --daemon             browser: run the browser frontend server in the background after build
   --active                  apply-all: apply only to currently running containers (skip stopped ones)
   --force                   Overwrite existing files, replace conflicting docker-git projects/containers, and wipe compose volumes
   --force-env               Reset project env defaults only (keep workspace volume/data)

--- a/packages/app/src/docker-git/frontend-lib/core/domain.ts
+++ b/packages/app/src/docker-git/frontend-lib/core/domain.ts
@@ -139,6 +139,7 @@ export interface MenuCommand {
 
 export interface BrowserCommand {
   readonly _tag: "Browser"
+  readonly daemon: boolean
 }
 
 export interface AttachCommand {

--- a/packages/app/src/docker-git/frontend-lib/shell/command-runner.ts
+++ b/packages/app/src/docker-git/frontend-lib/shell/command-runner.ts
@@ -6,7 +6,7 @@ import { Effect, pipe } from "effect"
 import * as Chunk from "effect/Chunk"
 import * as Stream from "effect/Stream"
 
-type RunCommandSpec = {
+export type RunCommandSpec = {
   readonly cwd: string
   readonly command: string
   readonly args: ReadonlyArray<string>

--- a/packages/app/src/docker-git/program.ts
+++ b/packages/app/src/docker-git/program.ts
@@ -21,7 +21,7 @@ import {
   stopContainerTask,
   syncState
 } from "./api-client.js"
-import { runBrowserFrontendCommand } from "./browser-frontend.js"
+import { runBrowserFrontendCommandWithOptions } from "./browser-frontend.js"
 import { readCommand } from "./cli/read-command.js"
 import { usageText } from "./cli/usage.js"
 import { type ControllerRuntime, ensureControllerReady } from "./controller.js"
@@ -209,7 +209,7 @@ const dispatchOperationalCommand = (
 ): Effect.Effect<void, CliError, ControllerRuntime> =>
   Match.value(command).pipe(
     Match.when({ _tag: "Menu" }, () => withControllerReady(runMenu)),
-    Match.when({ _tag: "Browser" }, () => runBrowserFrontendCommand),
+    Match.when({ _tag: "Browser" }, (command) => runBrowserFrontendCommandWithOptions({ daemon: command.daemon })),
     Match.when({ _tag: "Create" }, handleCreateCommand),
     Match.when({ _tag: "Open" }, handleOpenCommand),
     Match.when({ _tag: "Status" }, handleStatusCommand),

--- a/packages/app/tests/docker-git/browser-frontend-daemon.test.ts
+++ b/packages/app/tests/docker-git/browser-frontend-daemon.test.ts
@@ -1,0 +1,99 @@
+import { NodeContext as BrowserFrontendDaemonTestNodeContext } from "@effect/platform-node"
+import { describe, expect, it } from "@effect/vitest"
+import { Effect } from "effect"
+import { beforeEach, type MockInstance, vi } from "vitest"
+
+import type { BrowserFrontendStartDecision } from "../../src/docker-git/browser-frontend-state.js"
+import type { RunCommandSpec } from "../../src/docker-git/frontend-lib/shell/command-runner.js"
+
+type DaemonNumericCommandMock = MockInstance<(spec: RunCommandSpec) => Effect.Effect<number>>
+
+const captureDaemonCommandMock = vi.hoisted(
+  () => vi.fn<(spec: RunCommandSpec) => Effect.Effect<string>>(() => Effect.succeed("456\n"))
+)
+const exitDaemonCommandMock = vi.hoisted(
+  () => vi.fn<(spec: RunCommandSpec) => Effect.Effect<number>>(() => Effect.succeed(0))
+)
+const streamDaemonCommandMock = vi.hoisted(
+  () => vi.fn<(spec: RunCommandSpec) => Effect.Effect<number>>(() => Effect.succeed(0))
+)
+
+vi.mock("../../src/docker-git/frontend-lib/shell/command-runner.js", () => ({
+  runCommandCapture: captureDaemonCommandMock,
+  runCommandExitCode: exitDaemonCommandMock,
+  runCommandExitCodeStreaming: streamDaemonCommandMock
+}))
+
+const decision: BrowserFrontendStartDecision = {
+  apiBaseUrl: "http://127.0.0.1:3334",
+  host: "0.0.0.0",
+  port: "4174",
+  shouldStartWeb: true,
+  statePath: "/home/dev/.docker-git/.orch/state/browser-frontend.json",
+  webRevision: "revision-1"
+}
+
+const runDaemonUnderTest = Effect.gen(function*(_) {
+  const { runBrowserFrontendDaemon } = yield* _(
+    Effect.promise(() => import("../../src/docker-git/browser-frontend.js"))
+  )
+  yield* _(runBrowserFrontendDaemon(decision).pipe(Effect.provide(BrowserFrontendDaemonTestNodeContext.layer)))
+})
+
+const requireDaemonStartSpec = (): RunCommandSpec => {
+  const spec = captureDaemonCommandMock.mock.calls[0]?.[0]
+  if (spec === undefined) {
+    throw new Error("expected daemon start command")
+  }
+  return spec
+}
+
+const resetDaemonCommandMock = (mock: DaemonNumericCommandMock): void => {
+  mock.mockReset()
+  mock.mockImplementation(() => Effect.succeed(0))
+}
+
+const resetDaemonCommandMocks = (): void => {
+  vi.resetModules()
+  captureDaemonCommandMock.mockReset()
+  captureDaemonCommandMock.mockImplementation(() => Effect.succeed("456\n"))
+  resetDaemonCommandMock(exitDaemonCommandMock)
+  resetDaemonCommandMock(streamDaemonCommandMock)
+}
+
+describe("browser frontend daemon mode", () => {
+  beforeEach(resetDaemonCommandMocks)
+
+  it.effect("builds in the foreground and starts serve:web as a daemon", () =>
+    Effect.gen(function*(_) {
+      yield* _(runDaemonUnderTest)
+
+      const daemonStartSpec = requireDaemonStartSpec()
+      expect(streamDaemonCommandMock).toHaveBeenCalledTimes(1)
+      expect(streamDaemonCommandMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          args: ["run", "--cwd", "packages/app", "build:web"],
+          command: "bun"
+        })
+      )
+      expect(daemonStartSpec.command).toBe("sh")
+      expect(daemonStartSpec.args).toEqual([
+        "-c",
+        expect.stringContaining("nohup \"$@\""),
+        "sh",
+        "/home/dev/.docker-git/.orch/state/browser-frontend.log",
+        "bun",
+        "run",
+        "--cwd",
+        "packages/app",
+        "serve:web"
+      ])
+      expect(daemonStartSpec.env).toEqual(
+        expect.objectContaining({
+          DOCKER_GIT_API_URL: "http://127.0.0.1:3334",
+          DOCKER_GIT_WEB_PORT: "4174",
+          DOCKER_GIT_WEB_STATE_PATH: "/home/dev/.docker-git/.orch/state/browser-frontend.json"
+        })
+      )
+    }))
+})

--- a/packages/app/tests/docker-git/browser-frontend.test.ts
+++ b/packages/app/tests/docker-git/browser-frontend.test.ts
@@ -6,14 +6,8 @@ import { describe, expect, it } from "@effect/vitest"
 import { Effect } from "effect"
 import { afterEach, beforeEach, vi } from "vitest"
 
+import type { RunCommandSpec } from "../../src/docker-git/frontend-lib/shell/command-runner.js"
 import type { ControllerBootstrapError } from "../../src/docker-git/host-errors.js"
-
-type CommandSpec = {
-  readonly args: ReadonlyArray<string>
-  readonly command: string
-  readonly cwd: string
-  readonly env?: Readonly<Record<string, string | undefined>>
-}
 
 const ensureControllerReadyMock = vi.hoisted(() => vi.fn<() => Effect.Effect<void>>())
 const resolveApiBaseUrlMock = vi.hoisted(() => vi.fn<() => string>())
@@ -23,9 +17,11 @@ const findReachableApiBaseUrlMock = vi.hoisted(
 const resolveConfiguredApiBaseUrlMock = vi.hoisted(() => vi.fn<() => string>())
 const resolveDefaultLocalApiBaseUrlMock = vi.hoisted(() => vi.fn<() => string | undefined>())
 const resolveExplicitApiBaseUrlMock = vi.hoisted(() => vi.fn<() => string | undefined>())
-const runCommandCaptureMock = vi.hoisted(() => vi.fn<(spec: CommandSpec) => Effect.Effect<string>>())
-const runCommandExitCodeMock = vi.hoisted(() => vi.fn<(spec: CommandSpec) => Effect.Effect<number>>())
-const runCommandExitCodeStreamingMock = vi.hoisted(() => vi.fn<(spec: CommandSpec) => Effect.Effect<number>>())
+const runCommandCaptureMock = vi.hoisted(() => vi.fn<(spec: RunCommandSpec) => Effect.Effect<string>>())
+const runCommandExitCodeMock = vi.hoisted(() => vi.fn<(spec: RunCommandSpec) => Effect.Effect<number>>())
+const runCommandExitCodeStreamingMock = vi.hoisted(
+  () => vi.fn<(spec: RunCommandSpec) => Effect.Effect<number>>()
+)
 
 vi.mock("../../src/docker-git/controller.js", () => ({
   ensureControllerReady: ensureControllerReadyMock,

--- a/packages/app/tests/docker-git/parser-browser.test.ts
+++ b/packages/app/tests/docker-git/parser-browser.test.ts
@@ -6,7 +6,13 @@ import { parseOrThrow } from "./parser-helpers.js"
 describe("parseArgs browser frontend", () => {
   it.effect("parses browser aliases", () =>
     Effect.sync(() => {
-      expect(parseOrThrow(["browser"])._tag).toBe("Browser")
-      expect(parseOrThrow(["web"])._tag).toBe("Browser")
+      expect(parseOrThrow(["browser"])).toEqual({ _tag: "Browser", daemon: false })
+      expect(parseOrThrow(["web"])).toEqual({ _tag: "Browser", daemon: false })
+    }))
+
+  it.effect("parses browser daemon mode", () =>
+    Effect.sync(() => {
+      expect(parseOrThrow(["browser", "-d"])).toEqual({ _tag: "Browser", daemon: true })
+      expect(parseOrThrow(["web", "--daemon"])).toEqual({ _tag: "Browser", daemon: true })
     }))
 })

--- a/packages/app/tests/docker-git/program.test.ts
+++ b/packages/app/tests/docker-git/program.test.ts
@@ -6,7 +6,9 @@ import { beforeEach, vi } from "vitest"
 import type { Command } from "../../src/docker-git/frontend-lib/core/domain.js"
 
 const ensureControllerReadyMock = vi.hoisted(() => vi.fn(() => Effect.void))
-const runBrowserFrontendCommandMock = vi.hoisted(() => vi.fn(() => Effect.void))
+const runBrowserFrontendCommandMock = vi.hoisted(
+  () => vi.fn<(options: { readonly daemon: boolean }) => Effect.Effect<void>>(() => Effect.void)
+)
 const runMenuCallMock = vi.hoisted(() => vi.fn(() => {}))
 const readCommandMock = vi.hoisted(() => vi.fn<() => Command>())
 const codexLoginMock = vi.hoisted(() => vi.fn(() => Effect.void))
@@ -16,7 +18,15 @@ const gitlabLoginMock = vi.hoisted(() => vi.fn(() => Effect.succeed({ ok: true }
 const readStatePullMock = vi.hoisted(() => vi.fn(() => Effect.succeed("State pull completed.")))
 
 const menuCommand: Extract<Command, { readonly _tag: "Menu" }> = { _tag: "Menu" }
-const browserCommand: Extract<Command, { readonly _tag: "Browser" }> = { _tag: "Browser" }
+const browserCommand: Extract<Command, { readonly _tag: "Browser" }> = { _tag: "Browser", daemon: false }
+const browserDaemonCommand: Extract<Command, { readonly _tag: "Browser" }> = { _tag: "Browser", daemon: true }
+const browserRoutingCases: ReadonlyArray<{
+  readonly command: Extract<Command, { readonly _tag: "Browser" }>
+  readonly options: { readonly daemon: boolean }
+}> = [
+  { command: browserCommand, options: { daemon: false } },
+  { command: browserDaemonCommand, options: { daemon: true } }
+]
 const codexLoginCommand: Extract<Command, { readonly _tag: "AuthCodexLogin" }> = {
   _tag: "AuthCodexLogin",
   label: null,
@@ -50,7 +60,8 @@ vi.mock("../../src/docker-git/controller.js", () => ({
 }))
 
 vi.mock("../../src/docker-git/browser-frontend.js", () => ({
-  runBrowserFrontendCommand: Effect.flatMap(Effect.sync(() => runBrowserFrontendCommandMock()), (effect) => effect)
+  runBrowserFrontendCommandWithOptions: (options: { readonly daemon: boolean }) =>
+    Effect.flatMap(Effect.sync(() => runBrowserFrontendCommandMock(options)), (effect) => effect)
 }))
 
 vi.mock("../../src/docker-git/api-client.js", () => ({
@@ -140,15 +151,25 @@ describe("program menu dispatch", () => {
       expect(process.exitCode ?? 0).toBe(0)
     }))
 
-  it.effect("routes browser frontend through the browser command runner", () =>
-    Effect.gen(function*(_) {
-      readCommandMock.mockReturnValue(browserCommand)
-      yield* _(runProgram())
+  it.effect("routes browser frontend modes through the browser command runner", () =>
+    Effect.forEach(
+      browserRoutingCases,
+      ({ command, options }) =>
+        Effect.gen(function*(_) {
+          readCommandMock.mockReturnValue(command)
+          ensureControllerReadyMock.mockClear()
+          runBrowserFrontendCommandMock.mockClear()
+          process.exitCode = 0
 
-      expect(ensureControllerReadyMock).not.toHaveBeenCalled()
-      expect(runBrowserFrontendCommandMock).toHaveBeenCalledTimes(1)
-      expect(process.exitCode ?? 0).toBe(0)
-    }))
+          yield* _(runProgram())
+
+          expect(ensureControllerReadyMock).not.toHaveBeenCalled()
+          expect(runBrowserFrontendCommandMock).toHaveBeenCalledTimes(1)
+          expect(runBrowserFrontendCommandMock).toHaveBeenCalledWith(options)
+          expect(process.exitCode).toBe(0)
+        }),
+      { discard: true }
+    ))
 
   it.effect("routes state pull through the controller API", () =>
     Effect.gen(function*(_) {


### PR DESCRIPTION
Fixes ProverCoderAI/docker-git#373

## Summary
- Parse `docker-git browser -d`, `docker-git browser --daemon`, and the `web` alias variants into a typed `BrowserCommand.daemon` flag.
- Keep foreground browser mode as the default and route daemon intent through the existing program dispatch boundary.
- Build the browser frontend in the foreground, then start `serve:web` detached with `nohup`, preserving daemon diagnostics in a log beside the browser state file.
- Add an explicit minor changeset for `@prover-coder-ai/docker-git`.

## Reproduction
Before this change, a parser-level test for `parseArgs(["browser", "-d"])` could not observe daemon intent because `BrowserCommand` carried only `_tag: "Browser"`.

## Automated Tests
- `bun run --cwd packages/app test -- tests/docker-git/parser-browser.test.ts tests/docker-git/program.test.ts tests/docker-git/browser-frontend-daemon.test.ts tests/docker-git/browser-frontend.test.ts`
- `bun run --cwd packages/app lint`
- `bun run --cwd packages/app typecheck`
- `bun run --cwd packages/app test`
- `bun run check`
- `bun run lint`
- `bun run test`

## Mathematical Guarantees
### Invariants
- `forall args: daemon(parseBrowser(args)) <-> exists a in args: a in {"-d", "--daemon"}`
- `forall mode in {foreground, daemon}: launch(mode) -> built(webRevision)`
- `suffix(statePath, ".json") -> logPath = prefix(statePath, ".json") + ".log"`

### Preconditions
- Browser stack preparation has selected host, port, state path, web revision, and API base URL.
- Daemon mode requires `nohup` and `bun` to be resolvable by the shell command.

### Postconditions
- Foreground mode runs `serve:web` in the parent command as before.
- Daemon mode returns after spawning `serve:web` and logging the detached PID plus log path.
- Existing unchanged-browser reuse behavior remains shared for both modes.

### Complexity
- CLI daemon flag parsing: `O(n)` time and `O(1)` additional space where `n = |args|`.
- Daemon log path derivation: `O(m)` time and `O(m)` space where `m = |statePath|`.
