### PR TITLE
fix(entrypoint): clone into the dev-owned app folder

### DIFF
--- a/.changeset/entrypoint-clone-app-folder.md
+++ b/.changeset/entrypoint-clone-app-folder.md
@@ -1,0 +1,12 @@
+---
+"@prover-coder-ai/docker-git": patch
+---
+
+Fix the standalone base image cloning the repo outside the prepared `app` folder.
+
+The Dockerfile prepares and chowns `/home/dev/app` to the unprivileged `dev`
+user, but `entrypoint.sh` defaulted `TARGET_DIR` to `/work/app`. Because the
+auto-clone runs as `su - dev`, cloning into the root-created `/work/app` failed
+with permission denied, so the repository never landed in the `app` folder.
+The default now points at `/home/dev/app`, and the resolved `TARGET_DIR` is
+chowned to `dev` so overrides outside `/home/dev` keep working too.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-06-16T10:48:20.295Z for PR creation at branch issue-408-5d575dc8d85e for issue https://github.com/ProverCoderAI/docker-git/issues/408

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-06-16T10:48:20.295Z for PR creation at branch issue-408-5d575dc8d85e for issue https://github.com/ProverCoderAI/docker-git/issues/408

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ docker_git_repair_dns || true
 
 REPO_URL="${REPO_URL:-}"
 REPO_REF="${REPO_REF:-}"
-TARGET_DIR="${TARGET_DIR:-/work/app}"
+TARGET_DIR="${TARGET_DIR:-/home/dev/app}"
 
 # 1) Authorized keys are mounted from host at /authorized_keys
 mkdir -p /home/dev/.ssh
@@ -70,6 +70,11 @@ chown -R dev:dev /home/dev/.codex
 if [[ -n "$REPO_URL" && ! -d "$TARGET_DIR/.git" ]]; then
   mkdir -p "$TARGET_DIR"
   chown -R dev:dev /home/dev
+  # git clone runs as `su - dev`, so the target must be writable by dev even when
+  # TARGET_DIR is overridden to a path outside /home/dev (otherwise clone fails silently).
+  if [[ "$TARGET_DIR" != "/" ]]; then
+    chown -R dev:dev "$TARGET_DIR"
+  fi
 
   if [[ -n "$REPO_REF" ]]; then
     su - dev -c "git clone --branch '$REPO_REF' '$REPO_URL' '$TARGET_DIR'"

--- a/packages/lib/tests/shell/entrypoint-clone-target.test.ts
+++ b/packages/lib/tests/shell/entrypoint-clone-target.test.ts
@@ -1,0 +1,60 @@
+// CHANGE: pin the standalone base-image clone target to the dev-owned app folder
+// WHY: entrypoint runs `git clone` as `su - dev`; cloning into a root-owned dir (e.g. /work/app)
+//      fails with permission denied, so the repo never lands in the prepared `app` folder
+// QUOTE(ТЗ): "Почему-то при docker-git clone не делается git clone в папку app"
+// REF: issue-408
+// SOURCE: n/a
+// FORMAT THEOREM: defaultTargetDir(entrypoint) = appDir(Dockerfile) ∧ appDir ⊂ chown(dev, /home/dev)
+// PURITY: SHELL (reads repository source files)
+// INVARIANT: clone target is owned by the unprivileged clone user
+// COMPLEXITY: O(|file|)
+import { describe, expect, it } from "@effect/vitest"
+import { readFileSync } from "node:fs"
+import path from "node:path"
+import { fileURLToPath } from "node:url"
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+// packages/lib/tests/shell -> repository root
+const repoRoot = path.resolve(__dirname, "..", "..", "..", "..")
+
+const readRepoFile = (relativePath: string): string =>
+  readFileSync(path.join(repoRoot, relativePath), "utf8")
+
+describe("standalone base-image clone target", () => {
+  const entrypoint = readRepoFile("entrypoint.sh")
+  const dockerfile = readRepoFile("Dockerfile")
+
+  // CHANGE: derive the dev home that the Dockerfile recursively chowns to the clone user
+  // WHY: `git clone` runs as `su - dev`, so the target must live under a dev-owned path
+  // PURITY: CORE
+  // INVARIANT: chownedHome captures the `chown -R dev:dev <home>` argument
+  const chownedHome = (() => {
+    const match = dockerfile.match(/chown -R dev:dev (\/home\/dev)\b/)
+    return match?.[1]
+  })()
+
+  // CHANGE: derive the default TARGET_DIR the entrypoint clones into
+  // WHY: the bug is a wrong default that points outside the dev-owned home
+  // PURITY: CORE
+  // INVARIANT: defaultTargetDir captures `TARGET_DIR="${TARGET_DIR:-<default>}"`
+  const defaultTargetDir = (() => {
+    const match = entrypoint.match(/TARGET_DIR="\$\{TARGET_DIR:-([^}]+)\}"/)
+    return match?.[1]
+  })()
+
+  it("prepares an app folder under the dev home in the Dockerfile", () => {
+    expect(dockerfile).toContain("mkdir -p /home/dev/app")
+    expect(chownedHome).toBe("/home/dev")
+  })
+
+  it("defaults the clone target to the prepared app folder", () => {
+    expect(defaultTargetDir).toBe("/home/dev/app")
+  })
+
+  it("keeps the clone target under the dev-owned home so `su - dev` can write into it", () => {
+    expect(defaultTargetDir).toBeDefined()
+    expect(chownedHome).toBeDefined()
+    expect(`${defaultTargetDir}/`.startsWith(`${chownedHome}/`)).toBe(true)
+  })
+})

--- a/packages/lib/tests/shell/entrypoint-clone-target.test.ts
+++ b/packages/lib/tests/shell/entrypoint-clone-target.test.ts
@@ -5,56 +5,65 @@
 // REF: issue-408
 // SOURCE: n/a
 // FORMAT THEOREM: defaultTargetDir(entrypoint) = appDir(Dockerfile) ∧ appDir ⊂ chown(dev, /home/dev)
-// PURITY: SHELL (reads repository source files)
+// PURITY: SHELL (reads repository source files via @effect/platform FileSystem)
 // INVARIANT: clone target is owned by the unprivileged clone user
 // COMPLEXITY: O(|file|)
+import * as FileSystem from "@effect/platform/FileSystem"
+import * as Path from "@effect/platform/Path"
+import { NodeContext } from "@effect/platform-node"
 import { describe, expect, it } from "@effect/vitest"
-import { readFileSync } from "node:fs"
-import path from "node:path"
-import { fileURLToPath } from "node:url"
+import { Effect } from "effect"
 
-const __filename = fileURLToPath(import.meta.url)
-const __dirname = path.dirname(__filename)
-// packages/lib/tests/shell -> repository root
-const repoRoot = path.resolve(__dirname, "..", "..", "..", "..")
+// CHANGE: derive the dev home that the Dockerfile recursively chowns to the clone user
+// WHY: `git clone` runs as `su - dev`, so the target must live under a dev-owned path
+// PURITY: CORE
+// INVARIANT: returns the `chown -R dev:dev <home>` argument, or "" when absent
+const matchChownedHome = (dockerfile: string): string =>
+  dockerfile.match(/chown -R dev:dev (\/home\/dev)\b/)?.[1] ?? ""
 
-const readRepoFile = (relativePath: string): string =>
-  readFileSync(path.join(repoRoot, relativePath), "utf8")
+// CHANGE: derive the default TARGET_DIR the entrypoint clones into
+// WHY: the bug is a wrong default that points outside the dev-owned home
+// PURITY: CORE
+// INVARIANT: returns the `TARGET_DIR="${TARGET_DIR:-<default>}"` value, or "" when absent
+const matchDefaultTargetDir = (entrypoint: string): string =>
+  entrypoint.match(/TARGET_DIR="\$\{TARGET_DIR:-([^}]+)\}"/)?.[1] ?? ""
+
+// CHANGE: read the repo-root entrypoint + Dockerfile through the Effect FileSystem service
+// WHY: lint forbids node:* imports; @effect/platform is the sanctioned IO boundary
+// PURITY: SHELL
+// EFFECT: Effect<{ entrypoint, dockerfile }, PlatformError | BadArgument, FileSystem | Path>
+const readRepoSources = Effect.gen(function*(_) {
+  const fs = yield* _(FileSystem.FileSystem)
+  const path = yield* _(Path.Path)
+  const here = yield* _(path.fromFileUrl(new URL(import.meta.url)))
+  // packages/lib/tests/shell -> repository root
+  const repoRoot = path.resolve(path.dirname(here), "..", "..", "..", "..")
+  const entrypoint = yield* _(fs.readFileString(path.join(repoRoot, "entrypoint.sh")))
+  const dockerfile = yield* _(fs.readFileString(path.join(repoRoot, "Dockerfile")))
+  return { dockerfile, entrypoint }
+})
 
 describe("standalone base-image clone target", () => {
-  const entrypoint = readRepoFile("entrypoint.sh")
-  const dockerfile = readRepoFile("Dockerfile")
+  it.effect("prepares an app folder under the dev home in the Dockerfile", () =>
+    Effect.gen(function*(_) {
+      const { dockerfile } = yield* _(readRepoSources)
+      expect(dockerfile).toContain("mkdir -p /home/dev/app")
+      expect(matchChownedHome(dockerfile)).toBe("/home/dev")
+    }).pipe(Effect.provide(NodeContext.layer)))
 
-  // CHANGE: derive the dev home that the Dockerfile recursively chowns to the clone user
-  // WHY: `git clone` runs as `su - dev`, so the target must live under a dev-owned path
-  // PURITY: CORE
-  // INVARIANT: chownedHome captures the `chown -R dev:dev <home>` argument
-  const chownedHome = (() => {
-    const match = dockerfile.match(/chown -R dev:dev (\/home\/dev)\b/)
-    return match?.[1]
-  })()
+  it.effect("defaults the clone target to the prepared app folder", () =>
+    Effect.gen(function*(_) {
+      const { entrypoint } = yield* _(readRepoSources)
+      expect(matchDefaultTargetDir(entrypoint)).toBe("/home/dev/app")
+    }).pipe(Effect.provide(NodeContext.layer)))
 
-  // CHANGE: derive the default TARGET_DIR the entrypoint clones into
-  // WHY: the bug is a wrong default that points outside the dev-owned home
-  // PURITY: CORE
-  // INVARIANT: defaultTargetDir captures `TARGET_DIR="${TARGET_DIR:-<default>}"`
-  const defaultTargetDir = (() => {
-    const match = entrypoint.match(/TARGET_DIR="\$\{TARGET_DIR:-([^}]+)\}"/)
-    return match?.[1]
-  })()
-
-  it("prepares an app folder under the dev home in the Dockerfile", () => {
-    expect(dockerfile).toContain("mkdir -p /home/dev/app")
-    expect(chownedHome).toBe("/home/dev")
-  })
-
-  it("defaults the clone target to the prepared app folder", () => {
-    expect(defaultTargetDir).toBe("/home/dev/app")
-  })
-
-  it("keeps the clone target under the dev-owned home so `su - dev` can write into it", () => {
-    expect(defaultTargetDir).toBeDefined()
-    expect(chownedHome).toBeDefined()
-    expect(`${defaultTargetDir}/`.startsWith(`${chownedHome}/`)).toBe(true)
-  })
+  it.effect("keeps the clone target under the dev-owned home so `su - dev` can write into it", () =>
+    Effect.gen(function*(_) {
+      const { dockerfile, entrypoint } = yield* _(readRepoSources)
+      const chownedHome = matchChownedHome(dockerfile)
+      const defaultTargetDir = matchDefaultTargetDir(entrypoint)
+      expect(chownedHome).not.toBe("")
+      expect(defaultTargetDir).not.toBe("")
+      expect(`${defaultTargetDir}/`.startsWith(`${chownedHome}/`)).toBe(true)
+    }).pipe(Effect.provide(NodeContext.layer)))
 })


### PR DESCRIPTION
## Summary

Fixes ProverCoderAI/docker-git#408 — *"Почему-то при docker-git clone не делается git clone в папку app"*.

The standalone base image (`Dockerfile` + `entrypoint.sh`) prepares the workspace folder `/home/dev/app` and chowns it to the unprivileged `dev` user:

```dockerfile
# Workspace in dev home
RUN mkdir -p /home/dev/app && chown -R dev:dev /home/dev
```

But `entrypoint.sh` defaulted the clone target to a **different, root-owned** path:

```bash
TARGET_DIR="${TARGET_DIR:-/work/app}"
```

The auto-clone runs as the unprivileged user (`su - dev -c "git clone ... '$TARGET_DIR'"`). Since `/work/app` is created by `mkdir -p` while the entrypoint runs as **root** and is never chowned, the `dev` user cannot write into it — so `git clone` fails with *permission denied* and the repository never lands in the prepared `app` folder.

## Root cause

Two coupled problems with the `/work/app` default:
1. **Wrong location** — it is not the `app` folder the Dockerfile prepares (`/home/dev/app`).
2. **Wrong ownership** — it lives outside `/home/dev`, the only tree the entrypoint chowns to `dev`, so the `su - dev` clone has no write permission.

## Fix

- Default `TARGET_DIR` to `/home/dev/app`, matching the Dockerfile's prepared, dev-owned `app` folder.
- Additionally `chown -R dev:dev "$TARGET_DIR"` so an explicit `TARGET_DIR` override pointing outside `/home/dev` also stays writable by the clone user.

```diff
-TARGET_DIR="${TARGET_DIR:-/work/app}"
+TARGET_DIR="${TARGET_DIR:-/home/dev/app}"
```
```diff
 if [[ -n "$REPO_URL" && ! -d "$TARGET_DIR/.git" ]]; then
   mkdir -p "$TARGET_DIR"
   chown -R dev:dev /home/dev
+  # git clone runs as `su - dev`, so the target must be writable by dev even when
+  # TARGET_DIR is overridden to a path outside /home/dev (otherwise clone fails silently).
+  if [[ "$TARGET_DIR" != "/" ]]; then
+    chown -R dev:dev "$TARGET_DIR"
+  fi
```

## How to reproduce

Build and run the standalone base image with a repo URL:

```bash
docker build -t docker-git .
docker run --rm -e REPO_URL=https://github.com/octocat/Hello-World docker-git
```

**Before:** the entrypoint tries `su - dev -c "git clone ... /work/app"`, which fails with `Permission denied` / `could not create work tree dir`, and `/home/dev/app` stays empty.
**After:** the repo is cloned into `/home/dev/app` as expected.

## Tests

Added `packages/lib/tests/shell/entrypoint-clone-target.test.ts`, a regression test that pins the invariant between the two source files:
- the Dockerfile prepares an `app` folder under the dev home and chowns it,
- the entrypoint default clone target equals that prepared folder,
- the default clone target stays under the dev-owned home so `su - dev` can write into it.

The test fails on the old `/work/app` default and passes with the fix.

```
 Test Files  1 passed (1)
      Tests  3 passed (3)
```

(The 24 unrelated `tests/usecases/*` failures are pre-existing in this environment — they depend on Docker/filesystem/git context and are unaffected by this change.)
