### PR TITLE
fix(terminal): skip unavailable inline image previews and dedupe repeated renders

### DIFF
--- a/.changeset/terminal-inline-image-unavailable-dedupe.md
+++ b/.changeset/terminal-inline-image-unavailable-dedupe.md
@@ -1,0 +1,14 @@
+---
+"@prover-coder-ai/docker-git-terminal": patch
+---
+
+Stop rendering "unavailable" placeholder boxes for inline image paths that
+cannot be fetched, and render each image preview at most once per terminal
+session.
+
+Failed image fetches previously produced an "unavailable" placeholder plus
+four spacer rows, and every re-mention or redraw of the same path rendered
+another preview. Unavailable paths are now skipped entirely (the clickable
+path link remains), rendered paths are tracked per session so duplicates are
+suppressed, and the leading line break before previews is written lazily so
+fully skipped segments leave the terminal output untouched.

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,0 +1,1 @@
+# .gitkeep file auto-generated at 2026-07-05T08:15:04.140Z for PR creation at branch issue-445-9a1f5e5f81b6 for issue https://github.com/ProverCoderAI/docker-git/issues/445

--- a/.gitkeep
+++ b/.gitkeep
@@ -1,1 +1,0 @@
-# .gitkeep file auto-generated at 2026-07-05T08:15:04.140Z for PR creation at branch issue-445-9a1f5e5f81b6 for issue https://github.com/ProverCoderAI/docker-git/issues/445

--- a/packages/terminal/src/web/terminal-inline-images-core.ts
+++ b/packages/terminal/src/web/terminal-inline-images-core.ts
@@ -1,4 +1,5 @@
 import { detectTerminalImagePaths } from "./terminal-image-paths.js"
+import type { TerminalInlineImageEntry } from "./terminal-inline-images.js"
 
 export type TerminalInlineImageOutputSegment = {
   readonly endedWithLineBreak: boolean
@@ -9,8 +10,7 @@ export type TerminalInlineImageOutputSegment = {
 export type TerminalInlineImagePreviewsEnabledRef = { readonly current: boolean }
 
 export type TerminalOutputSegmentWriter = {
-  readonly writePreviewLineBreak: (segment: TerminalInlineImageOutputSegment, onComplete: () => void) => void
-  readonly writePreviews: (paths: ReadonlyArray<string>, onComplete: () => void) => void
+  readonly writePreviews: (segment: TerminalInlineImageOutputSegment, onComplete: () => void) => void
   readonly writeText: (text: string, onComplete: () => void) => void
 }
 
@@ -61,12 +61,11 @@ export const splitTerminalInlineImageOutput = (
  * effects belong to the writer implementation.
  *
  * @pure false - invokes effectful writer callbacks.
- * @effect writer callbacks: writeText, writePreviewLineBreak, writePreviews.
+ * @effect writer callbacks: writeText, writePreviews.
  * @precondition segment is the next queued terminal output segment and
  * onComplete belongs to the caller's active output queue drain.
  * @postcondition writeText is requested exactly once; when previews are enabled
- * and imagePaths is non-empty, the preview line break and preview writes are
- * requested in order before onComplete.
+ * and imagePaths is non-empty, the preview write is requested before onComplete.
  * @invariant segment.text is emitted before any preview callback, and preview
  * callbacks never run when imagePaths is empty or previews are disabled.
  * @complexity O(1) plus writer callback complexity; image paths are forwarded
@@ -83,8 +82,92 @@ export const writeTerminalOutputSegment = (
       onComplete()
       return
     }
-    writer.writePreviewLineBreak(segment, () => {
-      writer.writePreviews(segment.imagePaths, onComplete)
-    })
+    writer.writePreviews(segment, onComplete)
   })
+}
+
+export type TerminalInlineImagePreviewWriter = {
+  readonly loadEntry: (path: string, onComplete: (entry: TerminalInlineImageEntry | null) => void) => void
+  readonly renderPreview: (entry: TerminalInlineImageEntry, onComplete: () => void) => void
+  readonly writeLineBreak: (onComplete: () => void) => void
+}
+
+export type TerminalInlineImagePreviewWriteArgs = {
+  readonly needsLeadingLineBreak: boolean
+  readonly paths: ReadonlyArray<string>
+  readonly renderedPaths: Set<string>
+  readonly writer: TerminalInlineImagePreviewWriter
+}
+
+/**
+ * Sequences inline image preview writes for the image paths of one segment.
+ *
+ * Skips paths whose preview was already rendered in this terminal session and
+ * paths whose entry loads as `null` (unavailable image), so unavailable links
+ * never produce a placeholder and the same image is rendered at most once.
+ * The leading line break is written lazily before the first rendered preview
+ * only, so segments whose previews are all skipped leave the output untouched.
+ *
+ * @param args - Preview paths, session-rendered path set, and effectful writer callbacks.
+ * @param onComplete - Invoked exactly once after every path is processed.
+ * @returns Nothing; results are delivered through the writer callbacks.
+ * @pure false - invokes effectful writer callbacks and mutates renderedPaths.
+ * @effect writer callbacks: loadEntry, renderPreview, writeLineBreak.
+ * @precondition paths contains no duplicates (segment paths are deduplicated at detection).
+ * @postcondition ∀ path ∈ paths: rendered(path) → path ∈ renderedPaths, and
+ * renderPreview runs only for freshly loaded, previously unrendered entries.
+ * @invariant renderPreview is never invoked for a null entry or a path already
+ * in renderedPaths; writeLineBreak runs at most once and only before the first render.
+ * @complexity O(n) where n = |paths|.
+ * @throws Through writer callbacks or onComplete only.
+ */
+// CHANGE: skip unavailable inline images and deduplicate previews per terminal session
+// WHY: rendering placeholders for unresolvable paths and repeating previews for the
+//      same image adds noise to terminal output without conveying information
+// QUOTE(ТЗ): "не пытаться рендерить unavailable ссылки + сделать что бы одна и таже
+//      картинка не рендерилась несколько раз"
+// REF: issue-445
+// SOURCE: n/a
+// FORMAT THEOREM: ∀ path: renders(path) ≤ 1 ∧ (entry(path) = null → renders(path) = 0)
+// PURITY: CORE sequencing over injected SHELL callbacks
+// EFFECT: mutates renderedPaths and drives writer callbacks
+// INVARIANT: onComplete fires exactly once after all paths are processed in input order
+// COMPLEXITY: O(n) where n = |paths|
+export const writeTerminalInlineImagePreviews = (
+  { needsLeadingLineBreak, paths, renderedPaths, writer }: TerminalInlineImagePreviewWriteArgs,
+  onComplete: () => void
+): void => {
+  let lineBreakPending = needsLeadingLineBreak
+  let index = 0
+  const renderNext = (entry: TerminalInlineImageEntry, onRendered: () => void): void => {
+    if (!lineBreakPending) {
+      writer.renderPreview(entry, onRendered)
+      return
+    }
+    lineBreakPending = false
+    writer.writeLineBreak(() => {
+      writer.renderPreview(entry, onRendered)
+    })
+  }
+  const writeNext = (): void => {
+    const path = paths[index]
+    if (path === undefined) {
+      onComplete()
+      return
+    }
+    index += 1
+    if (renderedPaths.has(path)) {
+      writeNext()
+      return
+    }
+    writer.loadEntry(path, (entry) => {
+      if (entry === null) {
+        writeNext()
+        return
+      }
+      renderedPaths.add(path)
+      renderNext(entry, writeNext)
+    })
+  }
+  writeNext()
 }

--- a/packages/terminal/src/web/terminal-inline-images.ts
+++ b/packages/terminal/src/web/terminal-inline-images.ts
@@ -14,18 +14,12 @@ const terminalInlineImagePreviewColumns = 16
 const terminalInlineImagePreviewHeightPx = 56
 const terminalInlineImagePreviewWidthPx = 96
 
-export type TerminalInlineImageEntry =
-  | {
-    readonly _tag: "AvailableTerminalInlineImage"
-    readonly displayUrl: string
-    readonly fetchUrl: string
-    readonly path: string
-  }
-  | {
-    readonly _tag: "UnavailableTerminalInlineImage"
-    readonly fetchUrl: string
-    readonly path: string
-  }
+export type TerminalInlineImageEntry = {
+  readonly _tag: "AvailableTerminalInlineImage"
+  readonly displayUrl: string
+  readonly fetchUrl: string
+  readonly path: string
+}
 
 type TerminalInlineImageObjectUrlCache = Map<string, string>
 
@@ -36,15 +30,6 @@ const availableTerminalInlineImageEntry = (
 ): TerminalInlineImageEntry => ({
   _tag: "AvailableTerminalInlineImage",
   displayUrl,
-  fetchUrl,
-  path
-})
-
-export const unavailableTerminalInlineImageEntry = (
-  path: string,
-  fetchUrl: string
-): TerminalInlineImageEntry => ({
-  _tag: "UnavailableTerminalInlineImage",
   fetchUrl,
   path
 })
@@ -101,18 +86,12 @@ export const revokeTerminalInlineImageObjectUrlCache = (
   cache.clear()
 }
 
-const terminalInlineImageLinkUrl = (entry: TerminalInlineImageEntry): string =>
-  entry._tag === "AvailableTerminalInlineImage" ? entry.displayUrl : entry.fetchUrl
-
-const terminalInlineImageTitle = (entry: TerminalInlineImageEntry): string =>
-  entry._tag === "AvailableTerminalInlineImage" ? entry.path : `${entry.path} unavailable`
-
 const createTerminalInlineImageLink = (entry: TerminalInlineImageEntry): HTMLAnchorElement => {
   const link = document.createElement("a")
-  link.href = terminalInlineImageLinkUrl(entry)
+  link.href = entry.displayUrl
   link.rel = "noreferrer"
   link.target = "_blank"
-  link.title = terminalInlineImageTitle(entry)
+  link.title = entry.path
   link.style.alignItems = "center"
   link.style.background = "#0d1218"
   link.style.border = "1px solid #3a4652"
@@ -129,9 +108,9 @@ const createTerminalInlineImageLink = (entry: TerminalInlineImageEntry): HTMLAnc
   return link
 }
 
-const appendAvailableTerminalInlineImage = (
+const appendTerminalInlineImageContent = (
   link: HTMLAnchorElement,
-  entry: Extract<TerminalInlineImageEntry, { readonly _tag: "AvailableTerminalInlineImage" }>
+  entry: TerminalInlineImageEntry
 ): void => {
   const image = document.createElement("img")
   image.alt = entry.path
@@ -142,30 +121,6 @@ const appendAvailableTerminalInlineImage = (
   image.style.objectFit = "contain"
   image.style.width = "100%"
   link.append(image)
-}
-
-const appendUnavailableTerminalInlineImage = (link: HTMLAnchorElement): void => {
-  const label = document.createElement("span")
-  label.textContent = "unavailable"
-  label.style.color = "#9aa8b6"
-  label.style.fontFamily = "'IBM Plex Mono', ui-monospace, monospace"
-  label.style.fontSize = "11px"
-  label.style.lineHeight = "1"
-  label.style.overflow = "hidden"
-  label.style.textOverflow = "ellipsis"
-  label.style.whiteSpace = "nowrap"
-  link.append(label)
-}
-
-const appendTerminalInlineImageContent = (
-  link: HTMLAnchorElement,
-  entry: TerminalInlineImageEntry
-): void => {
-  if (entry._tag === "AvailableTerminalInlineImage") {
-    appendAvailableTerminalInlineImage(link, entry)
-    return
-  }
-  appendUnavailableTerminalInlineImage(link)
 }
 
 const openImage = (fetchUrl: string): void => {
@@ -191,7 +146,7 @@ const renderInlineImageElement = (
   element: HTMLElement,
   entry: TerminalInlineImageEntry
 ): void => {
-  if (element.dataset["path"] === entry.path && element.dataset["tag"] === entry._tag) {
+  if (element.dataset["path"] === entry.path) {
     return
   }
 
@@ -199,7 +154,6 @@ const renderInlineImageElement = (
   appendTerminalInlineImageContent(link, entry)
 
   element.dataset["path"] = entry.path
-  element.dataset["tag"] = entry._tag
   element.style.pointerEvents = "none"
   element.replaceChildren(link)
 }

--- a/packages/terminal/src/web/terminal-panel-cleanup-runtime.ts
+++ b/packages/terminal/src/web/terminal-panel-cleanup-runtime.ts
@@ -32,6 +32,7 @@ export const cleanupTerminalResources = (
   }
   args.lifecycle.inlineImageDisposables = []
   revokeTerminalInlineImageObjectUrlCache(args.lifecycle.inlineImageObjectUrls)
+  args.lifecycle.inlineImageRenderedPaths.clear()
   args.lifecycle.outputQueue = []
   args.lifecycle.outputWriting = false
   args.removeImageLinks()

--- a/packages/terminal/src/web/terminal-panel-inline-images-runtime.ts
+++ b/packages/terminal/src/web/terminal-panel-inline-images-runtime.ts
@@ -6,14 +6,14 @@ import { resolveTerminalImageFetchUrl } from "./terminal-image-url.js"
 import {
   splitTerminalInlineImageOutput,
   type TerminalInlineImageOutputSegment,
+  writeTerminalInlineImagePreviews,
   writeTerminalOutputSegment
 } from "./terminal-inline-images-core.js"
 import {
   cachedTerminalInlineImageEntry,
   cacheTerminalInlineImageBlob,
   didAppendTerminalInlineImagePreview,
-  terminalInlineImageSpacer,
-  unavailableTerminalInlineImageEntry
+  terminalInlineImageSpacer
 } from "./terminal-inline-images.js"
 import type { TerminalInlineImageEntry } from "./terminal-inline-images.js"
 import type { TerminalMessageHandlers } from "./terminal-panel-runtime-types.js"
@@ -34,14 +34,6 @@ const terminalInlineImageMaxBytes = 10 * 1024 * 1024
 const emptyTerminalInlineImageBufferState: TerminalInlineImageBufferState = {
   chunks: [],
   size: 0
-}
-
-const terminalImageEntry = (
-  handlers: TerminalMessageHandlers,
-  path: string
-): TerminalInlineImageEntry | null => {
-  const fetchUrl = resolveTerminalImageFetchUrl(handlers.session.websocketPath, path)
-  return cachedTerminalInlineImageEntry(handlers.lifecycle.inlineImageObjectUrls, path, fetchUrl)
 }
 
 const terminalInlineImageFetchError = (message: string): TerminalInlineImageFetchError => ({
@@ -136,7 +128,7 @@ const fetchTerminalInlineImageBlob = (
 const loadTerminalImageEntry = (
   handlers: TerminalMessageHandlers,
   path: string,
-  onComplete: (entry: TerminalInlineImageEntry) => void
+  onComplete: (entry: TerminalInlineImageEntry | null) => void
 ): void => {
   const fetchUrl = resolveTerminalImageFetchUrl(handlers.session.websocketPath, path)
   const cached = cachedTerminalInlineImageEntry(handlers.lifecycle.inlineImageObjectUrls, path, fetchUrl)
@@ -147,7 +139,7 @@ const loadTerminalImageEntry = (
   Effect.runFork(
     fetchTerminalInlineImageBlob(fetchUrl).pipe(
       Effect.match({
-        onFailure: () => unavailableTerminalInlineImageEntry(path, fetchUrl),
+        onFailure: () => null,
         onSuccess: (blob) =>
           handlers.lifecycle.disposed
             ? null
@@ -155,7 +147,7 @@ const loadTerminalImageEntry = (
       }),
       Effect.flatMap((entry) =>
         Effect.sync(() => {
-          if (entry === null || handlers.lifecycle.disposed) {
+          if (handlers.lifecycle.disposed) {
             return
           }
           onComplete(entry)
@@ -170,21 +162,6 @@ const writePreviewSpacer = (
   onComplete: () => void
 ): void => {
   handlers.terminal.write(terminalInlineImageSpacer, onComplete)
-}
-
-const writeInlineImagePreview = (
-  handlers: TerminalMessageHandlers,
-  path: string,
-  onComplete: () => void
-): void => {
-  const cached = terminalImageEntry(handlers, path)
-  if (cached !== null) {
-    writeInlineImagePreviewEntry(handlers, cached, onComplete)
-    return
-  }
-  loadTerminalImageEntry(handlers, path, (entry) => {
-    writeInlineImagePreviewEntry(handlers, entry, onComplete)
-  })
 }
 
 const writeInlineImagePreviewEntry = (
@@ -206,32 +183,25 @@ const writeInlineImagePreviewEntry = (
 
 const writeInlineImagePreviews = (
   handlers: TerminalMessageHandlers,
-  paths: ReadonlyArray<string>,
-  onComplete: () => void
-): void => {
-  let index = 0
-  const writeNext = (): void => {
-    const path = paths[index]
-    if (path === undefined) {
-      onComplete()
-      return
-    }
-    index += 1
-    writeInlineImagePreview(handlers, path, writeNext)
-  }
-  writeNext()
-}
-
-const writeLineBreakBeforePreview = (
-  handlers: TerminalMessageHandlers,
   segment: TerminalInlineImageOutputSegment,
   onComplete: () => void
 ): void => {
-  if (segment.endedWithLineBreak) {
-    onComplete()
-    return
-  }
-  handlers.terminal.write("\r\n", onComplete)
+  writeTerminalInlineImagePreviews({
+    needsLeadingLineBreak: !segment.endedWithLineBreak,
+    paths: segment.imagePaths,
+    renderedPaths: handlers.lifecycle.inlineImageRenderedPaths,
+    writer: {
+      loadEntry: (path, onEntry) => {
+        loadTerminalImageEntry(handlers, path, onEntry)
+      },
+      renderPreview: (entry, onRendered) => {
+        writeInlineImagePreviewEntry(handlers, entry, onRendered)
+      },
+      writeLineBreak: (onWritten) => {
+        handlers.terminal.write("\r\n", onWritten)
+      }
+    }
+  }, onComplete)
 }
 
 const flushTerminalOutputQueue = (handlers: TerminalMessageHandlers): void => {
@@ -248,11 +218,8 @@ const flushTerminalOutputQueue = (handlers: TerminalMessageHandlers): void => {
     inlineImagePreviewsEnabledRef: handlers.inlineImagePreviewsEnabledRef,
     segment,
     writer: {
-      writePreviewLineBreak: (outputSegment, onComplete) => {
-        writeLineBreakBeforePreview(handlers, outputSegment, onComplete)
-      },
-      writePreviews: (paths, onComplete) => {
-        writeInlineImagePreviews(handlers, paths, onComplete)
+      writePreviews: (outputSegment, onComplete) => {
+        writeInlineImagePreviews(handlers, outputSegment, onComplete)
       },
       writeText: (text, onComplete) => {
         handlers.terminal.write(text, onComplete)

--- a/packages/terminal/src/web/terminal-panel-runtime-core.ts
+++ b/packages/terminal/src/web/terminal-panel-runtime-core.ts
@@ -31,6 +31,7 @@ export const createLifecycleState = (): TerminalLifecycleState => ({
   disposed: false,
   inlineImageDisposables: [],
   inlineImageObjectUrls: new Map<string, string>(),
+  inlineImageRenderedPaths: new Set<string>(),
   outputQueue: [],
   outputWriting: false,
   readyNotified: false,

--- a/packages/terminal/src/web/terminal-panel-runtime-types.ts
+++ b/packages/terminal/src/web/terminal-panel-runtime-types.ts
@@ -28,6 +28,7 @@ export type TerminalLifecycleState = {
   disposed: boolean
   inlineImageDisposables: Array<IDisposable>
   inlineImageObjectUrls: Map<string, string>
+  inlineImageRenderedPaths: Set<string>
   outputQueue: Array<TerminalInlineImageOutputSegment>
   outputWriting: boolean
   readyNotified: boolean

--- a/packages/terminal/tests/web/terminal-inline-images-core.test.ts
+++ b/packages/terminal/tests/web/terminal-inline-images-core.test.ts
@@ -3,15 +3,17 @@ import { vi } from "vitest"
 
 import {
   splitTerminalInlineImageOutput,
+  type TerminalInlineImageOutputSegment,
+  writeTerminalInlineImagePreviews,
   writeTerminalOutputSegment
 } from "../../src/web/terminal-inline-images-core.js"
+import type { TerminalInlineImageEntry } from "../../src/web/terminal-inline-images.js"
 import {
   cachedTerminalInlineImageEntry,
   cacheTerminalInlineImageBlob,
   revokeTerminalInlineImageObjectUrlCache,
   terminalInlineImagePreviewRows,
-  terminalInlineImageSpacer,
-  unavailableTerminalInlineImageEntry
+  terminalInlineImageSpacer
 } from "../../src/web/terminal-inline-images.js"
 
 const issue250ImagePath = `/${["t", "mp"].join("")}/phantom-e2e.tuhl98/wallet-step-after-password.png`
@@ -71,8 +73,7 @@ describe("terminal inline image output", () => {
 
   it("writes detected image paths as plain terminal text when automatic previews are disabled", () => {
     const textWrites: Array<string> = []
-    const previewWrites: Array<ReadonlyArray<string>> = []
-    const previewLineBreaks = { count: 0 }
+    const previewWrites: Array<TerminalInlineImageOutputSegment> = []
     const completions = { count: 0 }
 
     writeTerminalOutputSegment({
@@ -83,12 +84,8 @@ describe("terminal inline image output", () => {
         text: issue250DeleteCommand
       },
       writer: {
-        writePreviewLineBreak: (_segment, onComplete) => {
-          previewLineBreaks.count += 1
-          onComplete()
-        },
-        writePreviews: (paths, onComplete) => {
-          previewWrites.push(paths)
+        writePreviews: (segment, onComplete) => {
+          previewWrites.push(segment)
           onComplete()
         },
         writeText: (text, onComplete) => {
@@ -101,9 +98,40 @@ describe("terminal inline image output", () => {
     })
 
     expect(textWrites).toEqual([issue250DeleteCommand])
-    expect(previewLineBreaks.count).toBe(0)
     expect(previewWrites).toEqual([])
     expect(completions.count).toBe(1)
+  })
+
+  it("forwards the segment to the preview writer after text when previews are enabled", () => {
+    const writes: Array<string> = []
+    const segment: TerminalInlineImageOutputSegment = {
+      endedWithLineBreak: true,
+      imagePaths: [issue250ImagePath],
+      text: `${issue250ImagePath}\r\n`
+    }
+
+    writeTerminalOutputSegment({
+      inlineImagePreviewsEnabledRef: { current: true },
+      segment,
+      writer: {
+        writePreviews: (previewSegment, onComplete) => {
+          writes.push(`previews:${previewSegment.imagePaths.join(",")}`)
+          onComplete()
+        },
+        writeText: (text, onComplete) => {
+          writes.push(`text:${text}`)
+          onComplete()
+        }
+      }
+    }, () => {
+      writes.push("complete")
+    })
+
+    expect(writes).toEqual([
+      `text:${issue250ImagePath}\r\n`,
+      `previews:${issue250ImagePath}`,
+      "complete"
+    ])
   })
 
   it("caches successful image fetch blobs as reusable object urls", () => {
@@ -130,11 +158,132 @@ describe("terminal inline image output", () => {
     expect(cache.size).toBe(0)
   })
 
-  it("represents failed image fetches without using a broken image url", () => {
-    expect(unavailableTerminalInlineImageEntry("/var/data/missing.png", "https://api/image")).toEqual({
-      _tag: "UnavailableTerminalInlineImage",
-      fetchUrl: "https://api/image",
-      path: "/var/data/missing.png"
+})
+
+const availableEntry = (path: string): TerminalInlineImageEntry => ({
+  _tag: "AvailableTerminalInlineImage",
+  displayUrl: `blob:${path}`,
+  fetchUrl: `https://api${path}`,
+  path
+})
+
+type PreviewWriterLog = {
+  readonly events: Array<string>
+  readonly loadedEntries: Map<string, TerminalInlineImageEntry | null>
+}
+
+const previewWriter = ({ events, loadedEntries }: PreviewWriterLog) => ({
+  loadEntry: (path: string, onComplete: (entry: TerminalInlineImageEntry | null) => void) => {
+    events.push(`load:${path}`)
+    onComplete(loadedEntries.get(path) ?? null)
+  },
+  renderPreview: (entry: TerminalInlineImageEntry, onComplete: () => void) => {
+    events.push(`render:${entry.path}`)
+    onComplete()
+  },
+  writeLineBreak: (onComplete: () => void) => {
+    events.push("line-break")
+    onComplete()
+  }
+})
+
+describe("terminal inline image previews (issue 445)", () => {
+  const missingPath = "/var/data/missing.png"
+  const presentPath = "/var/data/present.png"
+
+  it("does not render a preview for unavailable images", () => {
+    const events: Array<string> = []
+    const renderedPaths = new Set<string>()
+    const completions = { count: 0 }
+
+    writeTerminalInlineImagePreviews({
+      needsLeadingLineBreak: true,
+      paths: [missingPath],
+      renderedPaths,
+      writer: previewWriter({ events, loadedEntries: new Map([[missingPath, null]]) })
+    }, () => {
+      completions.count += 1
     })
+
+    expect(events).toEqual([`load:${missingPath}`])
+    expect(renderedPaths.size).toBe(0)
+    expect(completions.count).toBe(1)
+  })
+
+  it("renders the same image path only once across segments", () => {
+    const events: Array<string> = []
+    const renderedPaths = new Set<string>()
+    const loadedEntries = new Map([[presentPath, availableEntry(presentPath)]])
+
+    writeTerminalInlineImagePreviews({
+      needsLeadingLineBreak: false,
+      paths: [presentPath],
+      renderedPaths,
+      writer: previewWriter({ events, loadedEntries })
+    }, () => {
+      events.push("complete:first")
+    })
+    writeTerminalInlineImagePreviews({
+      needsLeadingLineBreak: false,
+      paths: [presentPath],
+      renderedPaths,
+      writer: previewWriter({ events, loadedEntries })
+    }, () => {
+      events.push("complete:second")
+    })
+
+    expect(events).toEqual([
+      `load:${presentPath}`,
+      `render:${presentPath}`,
+      "complete:first",
+      "complete:second"
+    ])
+    expect(renderedPaths).toEqual(new Set([presentPath]))
+  })
+
+  it("writes the leading line break lazily and only before the first rendered preview", () => {
+    const events: Array<string> = []
+    const renderedPaths = new Set<string>()
+    const otherPath = "/var/data/other.png"
+    const loadedEntries = new Map<string, TerminalInlineImageEntry | null>([
+      [missingPath, null],
+      [otherPath, availableEntry(otherPath)],
+      [presentPath, availableEntry(presentPath)]
+    ])
+
+    writeTerminalInlineImagePreviews({
+      needsLeadingLineBreak: true,
+      paths: [missingPath, presentPath, otherPath],
+      renderedPaths,
+      writer: previewWriter({ events, loadedEntries })
+    }, () => {
+      events.push("complete")
+    })
+
+    expect(events).toEqual([
+      `load:${missingPath}`,
+      `load:${presentPath}`,
+      "line-break",
+      `render:${presentPath}`,
+      `load:${otherPath}`,
+      `render:${otherPath}`,
+      "complete"
+    ])
+  })
+
+  it("leaves output untouched when every preview is skipped", () => {
+    const events: Array<string> = []
+    const renderedPaths = new Set([presentPath])
+
+    writeTerminalInlineImagePreviews({
+      needsLeadingLineBreak: true,
+      paths: [presentPath],
+      renderedPaths,
+      writer: previewWriter({ events, loadedEntries: new Map() })
+    }, () => {
+      events.push("complete")
+    })
+
+    expect(events).toEqual(["complete"])
   })
 })


### PR DESCRIPTION
# Source TZ / Issues

- Fixes #445
- Related discussion: issue screenshot shows repeated "unavailable" boxes for `/home/dev/.docker-git/pasted-images/*.png` paths in the web terminal

## Summary

- stop rendering the "unavailable" placeholder box (plus 4 spacer rows) when an inline image path cannot be fetched — the clickable path link is unaffected
- render each image preview at most once per terminal session via a session-level `inlineImageRenderedPaths` set (previously only per-segment dedup existed, so every re-mention/redraw duplicated the preview)
- write the leading line break before previews lazily, only before the first preview that actually renders, so fully skipped segments leave terminal output untouched
- extract the preview sequencing into a pure core function `writeTerminalInlineImagePreviews` (Functional Core) driven by injected writer callbacks (Imperative Shell)

## Proof of fix

- Причина: при неудачной загрузке картинки создавался `UnavailableTerminalInlineImage` и рендерился бокс "unavailable" + 4 строки-спейсера; дедупликация путей была только внутри одного сегмента, поэтому каждое повторное упоминание/перерисовка пути рендерила превью заново.
- Решение: неудачная загрузка теперь возвращает `null`, и цикл превью полностью пропускает такой путь (неудачи не кэшируются — путь, напечатанный снова после появления файла, всё ещё может получить превью); успешно отрендеренные пути записываются в `lifecycle.inlineImageRenderedPaths` и повторно не рендерятся; ведущий `\r\n` пишется лениво только перед первым реально отрендеренным превью.
- Доказательство: новые регрессионные тесты в `packages/terminal/tests/web/terminal-inline-images-core.test.ts` (`describe("terminal inline image previews (issue 445)")`): unavailable-путь не рендерится, один и тот же путь рендерится один раз через несколько сегментов, ведущий перенос строки пишется лениво и ровно один раз, полностью пропущенный сегмент не трогает вывод. Полный набор terminal-тестов: 20 файлов / 154 теста — зелёные.

## Requirements Alignment

- Implemented: both issue requirements — (1) unavailable ссылки больше не рендерятся как превью-плейсхолдеры, (2) одна и та же картинка рендерится не более одного раза за сессию терминала.
- Out of scope: image path detection, clickable path links (`registerLinkProvider`), fetch timeout/size limits — unchanged.
- Security-sensitive changes: none.

## Verification

- `bun x vitest run tests/web/terminal-inline-images-core.test.ts` (12 tests) in `packages/terminal`
- `bun x vitest run` in `packages/terminal` — 20 files / 154 tests passed
- `bun run typecheck` + `bun run build` in `packages/terminal`
- `bun run typecheck` in `packages/app` (re-exports compile against rebuilt dist)
- `bun x biome check src/ tests/` in `packages/terminal` — clean
- Note: `bun run lint` (eslint via vibecode-linter) crashes at config load time on this environment's Node 20 (`eslint-plugin-unicorn` requires Node ≥ 22 Iterator helpers); verified pre-existing by running it on an unmodified checkout.
